### PR TITLE
feat(plugin/bk-response-check): change prometheus label path to matched_uri, decrease the metrics

### DIFF
--- a/src/apisix/plugins/bk-response-check.lua
+++ b/src/apisix/plugins/bk-response-check.lua
@@ -52,7 +52,7 @@ function _M.init()
             "resource_name",
             "service_name",
             "method",
-            "path",
+            "matched_uri",
             "status",
             "proxy_phase",
             "proxy_error",
@@ -68,7 +68,7 @@ function _M.init()
             "resource_name",
             "service_name",
             "method",
-            "path",
+            "matched_uri",
         }, {
             100,
             300,
@@ -103,10 +103,17 @@ function _M.log(conf, ctx)
     local service_name = ctx.var.bk_service_name or ""
     local instance = ctx.var.instance_id or ""
     local method = ctx.var.method
-    local path = ctx.var.uri
+    --        it's route.uri/uris, how to get it from apisix?
     local proxy_phase = ctx.var.proxy_phase or ""
     local status = ctx.var.status
     local proxy_error = ctx.var.proxy_error or "0"
+
+    -- NOTE: change from path to matched_uri, to decrease the metrics(use /a/{id} instead of /a/123)
+    -- local path = ctx.var.uri
+    local matched_uri = ""
+    if ctx.curr_req_matched then
+        matched_uri = ctx.curr_req_matched._path or ""
+    end
 
     local status_label = ""
     if status then
@@ -121,7 +128,7 @@ function _M.log(conf, ctx)
             resource_name,
             service_name,
             method,
-            path,
+            matched_uri,
             status_label,
             proxy_phase,
             proxy_error,
@@ -137,7 +144,7 @@ function _M.log(conf, ctx)
                 resource_name,
                 service_name,
                 method,
-                path,
+                matched_uri,
             }
         )
     end

--- a/src/apisix/plugins/bk-response-check.lua
+++ b/src/apisix/plugins/bk-response-check.lua
@@ -103,7 +103,6 @@ function _M.log(conf, ctx)
     local service_name = ctx.var.bk_service_name or ""
     local instance = ctx.var.instance_id or ""
     local method = ctx.var.method
-    --        it's route.uri/uris, how to get it from apisix?
     local proxy_phase = ctx.var.proxy_phase or ""
     local status = ctx.var.status
     local proxy_error = ctx.var.proxy_error or "0"

--- a/src/apisix/tests/test-bk-response-check.lua
+++ b/src/apisix/tests/test-bk-response-check.lua
@@ -56,5 +56,60 @@ describe(
             end
         )
 
+        context(
+            "log", function()
+                it(
+                    "should log the metrics", function()
+                        ctx = {
+                            var = {
+                                gateway = "gateway",
+                                api_name = "api_name",
+                                stage_name = "stage_name",
+                                resource_name = "resource_name",
+                                service_name = "service_name",
+                                method = "method",
+                                matched_uri = "matched_uri",
+                                status = 200,
+                                proxy_phase = "proxy_phase",
+                                proxy_error = "proxy_error",
+                            },
+                            curr_req_matched = {
+                                _path = "matched_uri"
+                            },
+                        }
+                        plugin.init()
+                        plugin.log(nil, ctx)
+
+                        assert.is_not_nil(prometheus.registry["apigateway_api_requests_total"])
+                        assert.is_not_nil(prometheus.registry["apigateway_api_request_duration_milliseconds"])
+                        assert.is_not_nil(prometheus.registry["apigateway_app_requests_total"])
+
+                        local api_requests_total = prometheus.registry["apigateway_api_requests_total"]
+                        local expected_label_names = {
+                            'gateway',
+                            'api_name',
+                            'stage_name',
+                            'resource_name',
+                            'service_name',
+                            'method',
+                            'matched_uri',
+                            'status',
+                            'proxy_phase',
+                            'proxy_error' ,
+                        }
+                        local expected_key = 'apigateway_api_requests_total{gateway="",api_name="",stage_name="",' ..
+                        'resource_name="",service_name="",method="method",matched_uri="matched_uri",status="200",' ..
+                        'proxy_phase="proxy_phase",proxy_error="proxy_error"}'
+
+                        assert.is_same(expected_label_names, api_requests_total["label_names"])
+                        assert.equal(expected_key, api_requests_total["_key_index"]["keys"][2])
+
+                    end
+                )
+            end
+        )
+
+
+
     end
 )


### PR DESCRIPTION
将 path 换成 matched_uri, 减少metrics数量(统计视图中只用到了route_id/route_name, 不会用到path)

- 原来 `path="/api/httpbin/prod/status/200/"`  (500/404等等)
- 改为 `matched_uri="/api/httpbin/prod/status/:codes/?"`