### PR TITLE
feat(bk-components/bk-apigateway-core): change timeout to 5s

### DIFF
--- a/src/apisix/plugins/bk-components/bk-apigateway-core.lua
+++ b/src/apisix/plugins/bk-components/bk-apigateway-core.lua
@@ -26,7 +26,7 @@ local string_format = string.format
 
 local QUERY_PERMISSION_URL = "/api/v1/micro-gateway/%s/permissions/"
 local QUERY_PUBLIC_KEY_URL = "/api/v1/micro-gateway/%s/public_keys/"
-local BKCORE_TIMEOUT_MS = 2 * 1000
+local BKCORE_TIMEOUT_MS = 5 * 1000
 
 local _M = {
     host = bk_core.config.get_bk_apigateway_core_addr(),


### PR DESCRIPTION
解决线上偶发timeout问题

后续 `apigateway-core-api` 接入 APM 后重点优化掉这类问题 