### PR TITLE
fix(apisix/prometheus): patch to support custom default_buckets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ RUN luarocks install multipart --tree=/usr/local/apisix/deps && \
 
 ADD ./build/config-watcher ./src/build/bin/apisix-start.sh ./src/build/bin/config-watcher-start.sh /data/bkgateway/bin/
 ADD ./src/apisix/plugins/ /usr/local/apisix/apisix/plugins/
+# FIXME: remove the patch if upgrade to >=3.4.x, while the patch is only for 3.2.x ---
+ADD ./src/build/patches /usr/local/apisix/patches
+RUN ls /usr/local/apisix/patches | sort | xargs -L1 -I __patch_file__ sh -c 'cat ./patches/__patch_file__ | patch -t -p1'
+# FIXME: remove the patch if upgrade to >=3.4.x, while the patch is only for 3.2.x ---
 
 RUN chmod 755 /data/bkgateway/bin/* && chmod 777 /usr/local/apisix/logs
 

--- a/src/build/patches/001_change_prometheus_default_buckets.patch
+++ b/src/build/patches/001_change_prometheus_default_buckets.patch
@@ -1,14 +1,5 @@
-From 7ae3981c0e1793129e4e551c1583b2a3db22682d Mon Sep 17 00:00:00 2001
-From: jiangfucheng <jiangfucheng0914@foxmail.com>
-Date: Thu, 15 Jun 2023 22:57:25 +0800
-Subject: [PATCH 1/4] feat(prometheus): allow user configure DEFAULT_BUCKETS
-
----
- apisix/plugins/prometheus/exporter.lua |  7 ++-
- 1 files changed, 7 insertions(+), 1 deletion(-)
-
 diff --git a/apisix/plugins/prometheus/exporter.lua b/apisix/plugins/prometheus/exporter.lua
-index 1cb4a534cb9f..8e90326409bc 100644
+index 45ff94c3..5434ce56 100644
 --- a/apisix/plugins/prometheus/exporter.lua
 +++ b/apisix/plugins/prometheus/exporter.lua
 @@ -168,10 +168,15 @@ function _M.http_init(prometheus_enabled_in_stream)
@@ -28,3 +19,15 @@ index 1cb4a534cb9f..8e90326409bc 100644
  
      metrics.bandwidth = prometheus:counter("bandwidth",
              "Total bandwidth in bytes consumed per service in APISIX",
+@@ -208,6 +213,11 @@ end
+ 
+ 
+ function _M.http_log(conf, ctx)
++    local attr = plugin.plugin_attr("prometheus")
++    if attr and not attr.enable_official then
++        return
++    end
++
+     local vars = ctx.var
+ 
+     local route_id = ""

--- a/src/build/patches/001_change_prometheus_default_buckets.patch
+++ b/src/build/patches/001_change_prometheus_default_buckets.patch
@@ -1,0 +1,30 @@
+From 7ae3981c0e1793129e4e551c1583b2a3db22682d Mon Sep 17 00:00:00 2001
+From: jiangfucheng <jiangfucheng0914@foxmail.com>
+Date: Thu, 15 Jun 2023 22:57:25 +0800
+Subject: [PATCH 1/4] feat(prometheus): allow user configure DEFAULT_BUCKETS
+
+---
+ apisix/plugins/prometheus/exporter.lua |  7 ++-
+ 1 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/apisix/plugins/prometheus/exporter.lua b/apisix/plugins/prometheus/exporter.lua
+index 1cb4a534cb9f..8e90326409bc 100644
+--- a/apisix/plugins/prometheus/exporter.lua
++++ b/apisix/plugins/prometheus/exporter.lua
+@@ -168,10 +168,15 @@ function _M.http_init(prometheus_enabled_in_stream)
+             {"code", "route", "matched_uri", "matched_host", "service", "consumer", "node",
+             unpack(extra_labels("http_status"))})
+ 
++    local buckets = DEFAULT_BUCKETS
++    if attr and attr.default_buckets then
++        buckets = attr.default_buckets
++    end
++
+     metrics.latency = prometheus:histogram("http_latency",
+         "HTTP request latency in milliseconds per service in APISIX",
+         {"type", "route", "service", "consumer", "node", unpack(extra_labels("http_latency"))},
+-        DEFAULT_BUCKETS)
++        buckets)
+ 
+     metrics.bandwidth = prometheus:counter("bandwidth",
+             "Total bandwidth in bytes consumed per service in APISIX",


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

- patch 到 3.2.1 以支持自定义设置 `default_buckets`
- 增加`enable_official` 以便在某些环境关闭官方metrics

相关pr: https://github.com/apache/apisix/pull/9673/files

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
