### PR TITLE
fix(build/patches): add patch for parse_domain_for_nodes in apisix/utils/upstream.lua

### DIFF
--- a/src/build/patches/002_upstream_parse_domain_for_nodes.patch
+++ b/src/build/patches/002_upstream_parse_domain_for_nodes.patch
@@ -1,0 +1,19 @@
+diff --git a/apisix/utils/upstream.lua b/apisix/utils/upstream.lua
+index c39d4cce..5d23ce49 100644
+--- a/apisix/utils/upstream.lua
++++ b/apisix/utils/upstream.lua
+@@ -82,6 +82,14 @@ local function parse_domain_for_nodes(nodes)
+             core.table.insert(new_nodes, node)
+         end
+     end
++
++    -- patch for: https://github.com/apache/apisix/issues/10093#issuecomment-1738381865
++    if #new_nodes == 0 then
++        local err = "no valid ip found"
++        core.log.error("parse domain for nodes: ", core.json.delay_encode(nodes), " error: ", err)
++        return nil, err
++    end
++
+     return new_nodes
+ end
+ _M.parse_domain_for_nodes = parse_domain_for_nodes


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

修复: dns 偶发解析失败导致apisix worker dns解析持续失败

https://github.com/apache/apisix/issues/10093#issuecomment-1738381865

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [x] 本地开发联调环境验证通过 (local development environment verification passed)
