### PR TITLE
feat(build/patches): patch radixtree_uri_with_parameter rebuild with interval

### DIFF
--- a/src/build/patches/004_radixtree_uri_with_parameter_rebuild_with_interval.patch
+++ b/src/build/patches/004_radixtree_uri_with_parameter_rebuild_with_interval.patch
@@ -1,0 +1,40 @@
+diff --git a/apisix/http/router/radixtree_uri_with_parameter.lua b/apisix/http/router/radixtree_uri_with_parameter.lua
+index 4bf7f3eb..cd9da089 100644
+--- a/apisix/http/router/radixtree_uri_with_parameter.lua
++++ b/apisix/http/router/radixtree_uri_with_parameter.lua
+@@ -18,8 +18,12 @@ local require = require
+ local core = require("apisix.core")
+ local base_router = require("apisix.http.route")
+ local get_services = require("apisix.http.service").services
++local ngx_time     = ngx.time
++local random = math.random
+ local cached_router_version
+ local cached_service_version
++local cached_timestamp = 0
++local random_interval = 0
+ 
+ 
+ local _M = {}
+@@ -34,10 +38,22 @@ function _M.match(api_ctx)
+     if not cached_router_version or cached_router_version ~= user_routes.conf_version
+         or not cached_service_version or cached_service_version ~= service_version
+     then
++        if ngx_time() - cached_timestamp >= random_interval
++        then
++
+         uri_router = base_router.create_radixtree_uri_router(user_routes.values,
+                                                              uri_routes, true)
+         cached_router_version = user_routes.conf_version
+         cached_service_version = service_version
++
++                cached_timestamp = ngx_time()
++                -- rebuild the tree every {random_interval} seconds, at least 5 seconds
++                -- we do this to avoid:
++                -- 1. all the workers rebuild the tree at the same time
++                -- 2. the workers keep rebuilding if the `/routes` is updating frequently
++                random_interval = random(5, 15)
++                core.log.info("rebuild the tree")
++        end
+     end
+ 
+     if not uri_router then


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

当前问题: 如果`/routes`一直有更新并且一直有请求进来, 每个worker会一直重建radixtree cache

修复:
1. 实时判断重建改成周期判断重建
2. 增加随机时间段, 避免所有worker在同一个时间执行rebuild


### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [x] 本地开发联调环境验证通过 (local development environment verification passed)
