### PR TITLE
fix(bk-rate-limit): update the key to use new limits if the config changed

### DIFF
--- a/src/apisix/plugins/bk-rate-limit/init.lua
+++ b/src/apisix/plugins/bk-rate-limit/init.lua
@@ -155,4 +155,8 @@ function _M.rate_limit(conf, ctx, plugin_name, key, count, time_window)
     end
 end
 
+if _TEST then
+    _M.gen_limit_key = gen_limit_key
+end
+
 return _M

--- a/src/apisix/plugins/bk-rate-limit/init.lua
+++ b/src/apisix/plugins/bk-rate-limit/init.lua
@@ -35,6 +35,7 @@
 --     redis_database: 0
 --     redis_timeout: 1001
 --
+local apisix_plugin = require("apisix.plugin")
 local core = require("apisix.core")
 local rate_limit_redis = require("apisix.plugins.bk-rate-limit.rate-limit-redis")
 local lrucache = core.lrucache.new(
@@ -77,6 +78,14 @@ local _M = {
     },
 }
 
+local function gen_limit_key(conf, key)
+    -- Here we use plugin-level conf version to prevent the counter from being resetting
+    -- because of the change elsewhere.
+    -- e.g. conf_version = 1969078430
+    local new_key = key .. ':' .. apisix_plugin.conf_version(conf)
+    return new_key
+end
+
 ---Create rate-limit-redis object
 ---@param plugin_name string @apisix plugin name
 ---@return table @rate-limit-redis object
@@ -108,6 +117,7 @@ function _M.rate_limit(conf, ctx, plugin_name, key, count, time_window)
         return 500
     end
 
+    key = gen_limit_key(conf, key)
     core.log.info("limit key: ", key)
 
     local delay, remaining, reset = lim:incoming(key, count, time_window)

--- a/src/apisix/plugins/bk-resource-rate-limit.lua
+++ b/src/apisix/plugins/bk-resource-rate-limit.lua
@@ -62,6 +62,8 @@ function _M.access(conf, ctx)
     end
 
     -- TODO: make it lazy, share the key with other plugins
+    -- FIXME: should change the bk_reosurce_name to bk_resource_id if you need more accurate rate limit
+    --        while the developer may change the bk_resource_name from the frontend page.
     local key = table_concat(
         {
             bk_app_code,

--- a/src/apisix/plugins/bk-stage-rate-limit.lua
+++ b/src/apisix/plugins/bk-stage-rate-limit.lua
@@ -85,7 +85,6 @@ function _M.access(conf, ctx)
     else
         for i, rate in ipairs(rates) do
             -- here we should add the rate index into key, otherwise the rate limit will be shared(will be wrong)
-            -- FIXME: if the rate changes, will wait for the period to effect
             local limit_key = key .. ":" .. tostring(i)
             local code = ratelimit.rate_limit(conf, ctx, plugin_name, limit_key, rate.tokens, rate.period)
             if code then

--- a/src/apisix/tests/bk-rate-limit/test-init.lua
+++ b/src/apisix/tests/bk-rate-limit/test-init.lua
@@ -55,6 +55,12 @@ describe(
                     local key = ratelimit.gen_limit_key(conf, "key")
                     assert.equal(key, "key:223132457")
                     assert.equal(conf._version, "223132457")
+
+                    -- mock the conf change
+                    conf._version = nil
+                    conf["hello"] = "world"
+                    key = ratelimit.gen_limit_key(conf, "key")
+                    assert.equal(key, "key:3624485329")
                 end
             )
             end

--- a/src/apisix/tests/bk-rate-limit/test-init.lua
+++ b/src/apisix/tests/bk-rate-limit/test-init.lua
@@ -49,6 +49,19 @@ describe(
         )
 
         context(
+            "gen_limit_key", function()
+                it("ok", function()
+                    local conf = {}
+                    local key = ratelimit.gen_limit_key(conf, "key")
+                    assert.equal(key, "key:223132457")
+                    assert.equal(conf._version, "223132457")
+                end
+            )
+            end
+        )
+
+
+        context(
             "rate_limit", function()
                 local conf
                 local ctx


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

- 修复: 当前更新频率限制阈值需要等待原先的限制从redis中失效(ttl=period)

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [x] 本地开发联调环境验证通过 (local development environment verification passed)
