### PR TITLE
fix(bin/apisix-start.sh): change the order of apisix start command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,6 @@ RUN ls /usr/local/apisix/patches | sort | xargs -L1 -I __patch_file__ sh -c 'cat
 
 RUN chmod 755 /data/bkgateway/bin/* && chmod 777 /usr/local/apisix/logs
 
-
 CMD ["sh", "-c", "/usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]
+
+STOPSIGNAL SIGQUIT

--- a/src/build/bin/apisix-start.sh
+++ b/src/build/bin/apisix-start.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 echo "starting......"
 
-
 # if standaloneConfigPath not empty, watch the path
 if [ x"${standaloneConfigPath}" != x"" ]
 then
@@ -17,11 +16,6 @@ then
     echo "config-watcher for ${standaloneConfigPath} started"
 fi
 
-# start
-echo "start apisix"
-apisix start
-echo "apisix started"
-
 # start nginx error to sentry
 if [ x"${BK_APIGW_NGINX_ERROR_LOG_SENTRY_DSN}" != x"" ]
 then
@@ -34,8 +28,9 @@ fi
 
 echo "start config-watcher for ${apisixDebugConfigPath}(note: will wait until the container quit)"
 # note the shell will wait here, so, YOU SHOULD NOT PUT ANY COMMANDS AFTER HERE
-sh /data/bkgateway/bin/config-watcher-start.sh "-sourcePath ${apisixDebugConfigPath} -destPath /usr/local/apisix/conf -files debug.yaml -isConfigMap"
+sh /data/bkgateway/bin/config-watcher-start.sh "-sourcePath ${apisixDebugConfigPath} -destPath /usr/local/apisix/conf -files debug.yaml -isConfigMap" &
 
+echo "start apisix"
+/usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'
 
-echo "done"
-
+echo "quit"


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes apisix-start.sh 中进程启动顺序, apisix退出时脚本必须随之退出

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [x] 本地开发联调环境验证通过 (local development environment verification passed)
