### PR TITLE
refactor(bk-delete-sensitive): remove useless core.log.warn

### DIFF
--- a/src/apisix/plugins/bk-delete-sensitive.lua
+++ b/src/apisix/plugins/bk-delete-sensitive.lua
@@ -34,7 +34,6 @@ local core = require("apisix.core")
 local bk_core = require("apisix.plugins.bk-core.init")
 local ngx = ngx -- luacheck: ignore
 local ipairs = ipairs
-local tostring = tostring
 
 local plugin_name = "bk-delete-sensitive"
 
@@ -104,10 +103,6 @@ local function delete_sensitive_params(ctx, sensitive_keys, unfiltered_sensitive
     end
 
     if ctx.var.auth_params_location == "header" and (query_changed or form_changed or body_changed) then
-        core.log.warn(
-            "auth params are present in both header and request parameters, request_id: " ..
-                tostring(ctx.var.bk_request_id)
-        )
         -- 记录认证参数位置，便于统计哪些请求将认证参数放到请求参数，推动优化
         ctx.var.auth_params_location = "header_and_params"
     end


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

- bk-delete-sensitive: 去掉log.warn auth params are present in both header and request
- 

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
