### PR TITLE
feat(bk-permission): update cache settings

### DIFF
--- a/src/apisix/ci/Dockerfile.apisix-test-busted
+++ b/src/apisix/ci/Dockerfile.apisix-test-busted
@@ -9,6 +9,7 @@ FROM apache/apisix:$APISIX_VERSION-centos
 
 RUN sed -i 's#mirrorlist.centos.org#vault.centos.org#g' /etc/yum.repos.d/CentOS-Base.repo
 RUN sed -i 's#mirror.centos.org#vault.centos.org#g' /etc/yum.repos.d/CentOS-Base.repo
+RUN sed -i 's/gpgcheck = 1/gpgcheck = 0/' /etc/yum.repos.d/*
 RUN cat /etc/yum.repos.d/CentOS-Base.repo
 RUN yum clean all && yum update -y
 

--- a/src/apisix/ci/Dockerfile.apisix-test-busted
+++ b/src/apisix/ci/Dockerfile.apisix-test-busted
@@ -9,7 +9,7 @@ FROM apache/apisix:$APISIX_VERSION-centos
 
 RUN sed -i 's#mirrorlist.centos.org#vault.centos.org#g' /etc/yum.repos.d/CentOS-Base.repo
 RUN sed -i 's#mirror.centos.org#vault.centos.org#g' /etc/yum.repos.d/CentOS-Base.repo
-RUN sed -i 's/gpgcheck = 1/gpgcheck = 0/' /etc/yum.repos.d/*
+RUN sed -i 's/gpgcheck=1/gpgcheck=0/' /etc/yum.repos.d/*
 RUN cat /etc/yum.repos.d/CentOS-Base.repo
 RUN yum clean all && yum update -y
 

--- a/src/apisix/ci/Dockerfile.apisix-test-busted
+++ b/src/apisix/ci/Dockerfile.apisix-test-busted
@@ -11,8 +11,6 @@ RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 RUN cat /etc/yum.repos.d/CentOS-Base.repo
 
-RUN yum clean all && yum update -y
-
 RUN yum install -y sudo make gcc curl wget unzip git valgrind
 
 ARG APISIX_VERSION

--- a/src/apisix/ci/Dockerfile.apisix-test-busted
+++ b/src/apisix/ci/Dockerfile.apisix-test-busted
@@ -7,10 +7,10 @@ FROM apache/apisix:$APISIX_VERSION-centos
 #     curl -o /etc/yum.repos.d/CentOS-Base.repo http://mirrors.cloud.tencent.com/repo/centos7_base.repo && \
 #     yum clean all
 
-RUN sed -i 's#mirrorlist.centos.org#vault.centos.org#g' /etc/yum.repos.d/CentOS-Base.repo
-RUN sed -i 's#mirror.centos.org#vault.centos.org#g' /etc/yum.repos.d/CentOS-Base.repo
-RUN sed -i 's/gpgcheck=1/gpgcheck=0/' /etc/yum.repos.d/*
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 RUN cat /etc/yum.repos.d/CentOS-Base.repo
+
 RUN yum clean all && yum update -y
 
 RUN yum install -y sudo make gcc curl wget unzip git valgrind

--- a/src/apisix/ci/Dockerfile.apisix-test-busted
+++ b/src/apisix/ci/Dockerfile.apisix-test-busted
@@ -9,6 +9,8 @@ FROM apache/apisix:$APISIX_VERSION-centos
 
 RUN sed -i 's#mirrorlist.centos.org#vault.centos.org#g' /etc/yum.repos.d/CentOS-Base.repo
 RUN sed -i 's#mirror.centos.org#vault.centos.org#g' /etc/yum.repos.d/CentOS-Base.repo
+RUN cat /etc/yum.repos.d/CentOS-Base.repo
+RUN yum clean all && yum update -y
 
 RUN yum install -y sudo make gcc curl wget unzip git valgrind
 

--- a/src/apisix/ci/Dockerfile.apisix-test-busted
+++ b/src/apisix/ci/Dockerfile.apisix-test-busted
@@ -9,7 +9,6 @@ FROM apache/apisix:$APISIX_VERSION-centos
 
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-RUN cat /etc/yum.repos.d/CentOS-Base.repo
 
 RUN yum install -y sudo make gcc curl wget unzip git valgrind
 

--- a/src/apisix/ci/Dockerfile.apisix-test-busted
+++ b/src/apisix/ci/Dockerfile.apisix-test-busted
@@ -7,6 +7,9 @@ FROM apache/apisix:$APISIX_VERSION-centos
 #     curl -o /etc/yum.repos.d/CentOS-Base.repo http://mirrors.cloud.tencent.com/repo/centos7_base.repo && \
 #     yum clean all
 
+RUN sed -i 's#mirrorlist.centos.org#vault.centos.org#g' /etc/yum.repos.d/CentOS-Base.repo
+RUN sed -i 's#mirror.centos.org#vault.centos.org#g' /etc/yum.repos.d/CentOS-Base.repo
+
 RUN yum install -y sudo make gcc curl wget unzip git valgrind
 
 ARG APISIX_VERSION

--- a/src/apisix/ci/Dockerfile.apisix-test-nginx
+++ b/src/apisix/ci/Dockerfile.apisix-test-nginx
@@ -6,6 +6,9 @@ FROM apache/apisix:$APISIX_VERSION-centos
 #     curl -o /etc/yum.repos.d/CentOS-Base.repo http://mirrors.cloud.tencent.com/repo/centos7_base.repo && \
 #     yum clean all
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum install -y sudo make gcc curl wget unzip git valgrind vim cpanminus perl
 RUN cpanm --notest Test::Nginx IPC::Run > build.log 2>&1 || (cat build.log && exit 1)
 

--- a/src/apisix/editions/ee/plugins/bk-cache/bk-token.lua
+++ b/src/apisix/editions/ee/plugins/bk-cache/bk-token.lua
@@ -19,7 +19,7 @@ local core = require("apisix.core")
 local bklogin_component = require("apisix.plugins.bk-components.bklogin")
 
 local BK_TOKEN_CACHE_TTL = 300
-local BK_TOKEN_CACHE_COUNT = 500
+local BK_TOKEN_CACHE_COUNT = 2000
 local bk_token_lrucache = core.lrucache.new(
     {
         ttl = BK_TOKEN_CACHE_TTL,

--- a/src/apisix/plugins/bk-permission.lua
+++ b/src/apisix/plugins/bk-permission.lua
@@ -77,10 +77,10 @@ local cache
 function _M.init()
     cache = cache_fallback.new(
         {
-            lrucache_max_items = 5120,
+            lrucache_max_items = 10240, -- key is gateway+resource+app_code, so maybe a lot of keys
             lrucache_ttl = 60,
-            lrucache_short_ttl = 30,
-            fallback_cache_ttl = 60 * 60,
+            lrucache_short_ttl = 2, -- cache failed response for 2 seconds
+            fallback_cache_ttl = 60 * 60 * 12, -- if core-api is down, use the fallback cache data generated in 12 hours
         }, plugin_name
     )
 end

--- a/src/apisix/tests/test-bk-permission.lua
+++ b/src/apisix/tests/test-bk-permission.lua
@@ -72,10 +72,10 @@ describe(
                 local cache = plugin._get_cache()
                 assert.is_not_nil(cache)
 
-                assert.equal(5120, cache.lrucache_max_items)
+                assert.equal(10240, cache.lrucache_max_items)
                 assert.equal(60, cache.lrucache_ttl)
-                assert.equal(30, cache.lrucache_short_ttl)
-                assert.equal(3600, cache.fallback_cache_ttl)
+                assert.equal(2, cache.lrucache_short_ttl)
+                assert.equal(43200, cache.fallback_cache_ttl)
 
             end
         )


### PR DESCRIPTION
### Description

调整bk-permission cache 配置
1. 调大max_items
2. 降低某次请求core-api失败导致 30s 内请求都失败的影响
3. 兜底的 cache数据从 1 小时改成 12 小时，最小化避免core-api宕机导致的影响

Fixes # (issue)

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
