### PR TITLE
fix(plugins/bk-mock): set_header should override same key

### DIFF
--- a/src/apisix/ci/Dockerfile.apisix-test-nginx
+++ b/src/apisix/ci/Dockerfile.apisix-test-nginx
@@ -20,7 +20,7 @@ RUN wget https://github.com/apache/apisix/archive/refs/tags/${APISIX_VERSION}.ta
 
 # install dependencies
 ARG CODE_DIR=/codes/apisix-${APISIX_VERSION}
-RUN sed -i 's#yum install -y openresty openresty-debug openresty-openssl111-debug-devel pcre pcre-devel#yum install -y openresty openresty-debug openresty-openssl111-debug-devel pcre pcre-devel --skip-broken#g' ${CODE_DIR}/ci/centos7-ci.sh
+RUN sed -i 's#yum install -y openresty openresty-debug openresty-openssl111-debug-devel pcre pcre-devel#yum install -y openresty openresty-debug-1.25.3.2-1.el7.x86_64 openresty-openssl111-debug-devel pcre pcre-devel --skip-broken#g' ${CODE_DIR}/ci/centos7-ci.sh
 RUN sed -i 's|https://registry.npm.taobao.org|https://registry.npmmirror.com|g' ${CODE_DIR}/t/plugin/grpc-web/package-lock.json
 RUN cd ${CODE_DIR} &&  bash ./ci/centos7-ci.sh install_dependencies
 RUN cp -r ${CODE_DIR}/t /usr/local/apisix/

--- a/src/apisix/plugins/bk-mock.lua
+++ b/src/apisix/plugins/bk-mock.lua
@@ -75,11 +75,11 @@ function _M.header_filter(conf)
     end
 
     for key, value in pairs(conf.response_headers) do
-        -- set the header if it is not set by other plugins(they have higher priority)
-        if not ngx.header[key] then
-            core.response.set_header(key, value)
-        end
+        core.response.set_header(key, value)
     end
+
+    -- fixme: add a config with_mock_header to control whether to add the header
+    core.response.set_header("x-mock-by", "bk-apigateway")
 end
 
 return _M

--- a/src/apisix/plugins/bk-mock.lua
+++ b/src/apisix/plugins/bk-mock.lua
@@ -27,7 +27,6 @@
 
 local pl_types = require("pl.types")
 local core = require("apisix.core")
-local ngx = ngx
 local pairs = pairs
 
 local plugin_name = "bk-mock"

--- a/src/apisix/t/bk-mock.t
+++ b/src/apisix/t/bk-mock.t
@@ -68,7 +68,7 @@ done
                         "plugins": {
                             "bk-mock": {
                                 "response_status": 400,
-                                "response_example": "abc",
+                                "response_example": "abc\n",
                                 "response_headers" : {
                                     "foo": "bar",
                                     "Content-Type": "application/json2"
@@ -95,9 +95,10 @@ GET /t
 --- response_body
 passed
 
-=== TEST 3: check bk-mock
+=== TEST 3: check
 --- request
 GET /hello HTTP/1.1
+--- error_code: 400
 --- response_body
 abc
 --- response_headers

--- a/src/apisix/t/bk-mock.t
+++ b/src/apisix/t/bk-mock.t
@@ -1,0 +1,106 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_shuffle();
+no_root_location();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: sanity
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-mock")
+            local ok, err = plugin.check_schema({
+              response_status =  200,
+              response_example = 'Hello world',
+              response_headers = {
+                    ["Content-Type"] = "application/json"
+               }
+            })
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- response_body
+done
+
+=== TEST 2: add route
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "plugins": {
+                            "bk-mock": {
+                                "response_status": 400,
+                                "response_example": "abc",
+                                "response_headers" : {
+                                    "foo": "bar",
+                                    "Content-Type": "application/json2"
+                                }
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+=== TEST 3: check bk-mock
+--- request
+GET /hello HTTP/1.1
+--- response_body
+abc
+--- response_headers
+Content-Type: application/json2
+foo: bar
+x-mock-by: bk-apigateway

--- a/src/apisix/tests/test-bk-mock.lua
+++ b/src/apisix/tests/test-bk-mock.lua
@@ -123,6 +123,7 @@ describe(
 
                         plugin.header_filter(conf)
                         assert.stub(core.response.set_header).was_called_with("X-Token", "foo")
+                        assert.stub(core.response.set_header).was_called_with("x-mock-by", "bk-apigateway")
                     end
                 )
 
@@ -132,18 +133,6 @@ describe(
 
                         plugin.header_filter(conf)
                         assert.stub(core.response.set_header).was_not_called()
-                    end
-                )
-
-                it(
-                    "header cannot be overwriten", function()
-                        ngx.header["X-Token"] = "bar"
-                        conf.response_headers = {
-                            ["X-Token"] = "foo",
-                        }
-
-                        plugin.header_filter(conf)
-                        assert.is_equal(ngx.header["X-Token"], "bar")
                     end
                 )
             end


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

bk-mock 设置header需要override 同名 key

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [x] 本地开发联调环境验证通过 (local development environment verification passed)
