### PR TITLE
fix(bk-components): add retry for timeout of core-api and bkauth

### DIFF
--- a/src/apisix/plugins/bk-components/bk-apigateway-core.lua
+++ b/src/apisix/plugins/bk-components/bk-apigateway-core.lua
@@ -27,7 +27,7 @@ local string_format = string.format
 local QUERY_PERMISSION_URL = "/api/v1/micro-gateway/%s/permissions/"
 local QUERY_PUBLIC_KEY_URL = "/api/v1/micro-gateway/%s/public_keys/"
 -- NOTE: important, if you change the timeout here, you should reset the timeout/exptime in bk-cache-fallback lock
-local BKCORE_TIMEOUT_MS = 5 * 1000
+local BKCORE_TIMEOUT_MS = 2400
 
 local _M = {
     host = bk_core.config.get_bk_apigateway_core_addr(),
@@ -57,6 +57,19 @@ local function bk_apigateway_core_do_get(instance_id, instance_secret, host, pat
             query = query
         }
     )
+
+    if err == "timeout" then
+        res, err = client:request_uri(url,
+            {
+                method = "GET",
+                headers = {
+                    ["X-Bk-Micro-Gateway-Instance-Id"] = instance_id,
+                    ["X-Bk-Micro-Gateway-Instance-Secret"] = instance_secret,
+                },
+                query = query
+            }
+        )
+    end
 
     if not res then
         err = "request failed, err: " .. err

--- a/src/apisix/plugins/bk-components/bkauth.lua
+++ b/src/apisix/plugins/bk-components/bkauth.lua
@@ -29,7 +29,7 @@ local VERIFY_APP_SECRET_URL = "/api/v1/apps/%s/access-keys/verify"
 local LIST_APP_SECRETS_URL = "/api/v1/apps/%s/access-keys"
 local VERIFY_ACCESS_TOKEN_URL = "/api/v1/oauth/tokens/verify"
 
-local BKAUTH_TIMEOUT_MS = 5 * 1000
+local BKAUTH_TIMEOUT_MS = 3 * 1000
 
 local bkapp = bk_core.config.get_bkapp() or {}
 
@@ -70,6 +70,28 @@ function _M.verify_app_secret(app_code, app_secret)
         }
     )
 
+    -- if got timeout, retry here
+    if err == "timeout" then
+        res, err = http_client:request_uri(
+            url, {
+                method = "POST",
+                body = core.json.encode(
+                    {
+                        bk_app_secret = app_secret,
+                    }
+                ),
+                ssl_verify = false,
+
+                headers = {
+                    ["X-Bk-App-Code"] = _M.app_code,
+                    ["X-Bk-App-Secret"] = _M.app_secret,
+                    ["X-Request-Id"] = request_id,
+                    ["Content-Type"] = "application/json",
+                },
+            }
+        )
+    end
+
     if not (res and res.body) then
         err = string_format("failed to request third-party api, url: %s, request_id: %s, err: %s, response: nil", url,
             request_id, err)
@@ -89,22 +111,21 @@ function _M.verify_app_secret(app_code, app_secret)
     if result == nil then
         core.log.error(
             string_format(
-                "failed to request %s, request_id: %s, response is not valid json, status: %s, response: %s", url,
-                request_id, res.status, res.body
+                "failed to request %s, request_id: %s, response is not valid json, status: %s, response: %s",
+                url, request_id, res.status, res.body
             )
         )
         return nil, string_format(
-            "failed to request third-party api, response is not valid json, url: %s, request_id: %s, status: %s", url,
-            request_id, res.status
+            "failed to request third-party api, response is not valid json, url: %s, request_id: %s, status: %s",
+            url, request_id, res.status
         )
     end
 
     if result.code ~= 0 or res.status ~= 200 then
         core.log.error(
             string_format(
-                "failed to request %s, request_id: %s, result.code!=0 or status!=200, status: %s, response: %s", url,
-                request_id, res.status,
-                res.body
+                "failed to request %s, request_id: %s, result.code!=0 or status!=200, status: %s, response: %s",
+                url, request_id, res.status, res.body
             )
         )
         return nil, string_format(


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

bkauth和core-api的性能都非常好，一般10ms以内；但是由于网络问题/db 偶发查询慢，会导致偶发的 timeout；

1. 将默认超时时间减半
2. 增加一次重试, 解决偶发网络问题


### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
