### PR TITLE
feat(bk-cache/jwt-key.lua): ha refactor to make the dp robust

### DIFF
--- a/src/apisix/editions/ee/plugins/bk-cache/access-token.lua
+++ b/src/apisix/editions/ee/plugins/bk-cache/access-token.lua
@@ -19,6 +19,7 @@ local core = require("apisix.core")
 local access_token_define = require("apisix.plugins.bk-define.access-token")
 -- local bkauth_component = require("apisix.plugins.bk-components.bkauth")
 local ssm_component = require("apisix.plugins.bk-components.ssm")
+local lru_new = require("resty.lrucache").new
 
 local ACCESS_TOKEN_CACHE_TTL = 600
 local ACCESS_TOKEN_CACHE_COUNT = 2000
@@ -31,11 +32,14 @@ local access_token_lrucache = core.lrucache.new(
     }
 )
 
+local ACCESS_TOKEN_FALLBACK_CACHE_TTL = 60 * 60 * 24
+local ACCESS_TOKEN_FALLBACK_CACHE_COUNT = 2000
+local access_token_fallback_lrucache = lru_new(ACCESS_TOKEN_FALLBACK_CACHE_COUNT)
+
 local _M = {}
 
 local function get_access_token(access_token)
     local err
-    err = "authentication based on access_token is not supported"
 
     -- local bkauth_token, err = bkauth_component.verify_access_token(access_token)
     -- if bkauth_token ~= nil then
@@ -50,26 +54,53 @@ local function get_access_token(access_token)
         if ssm_token ~= nil then
             return {
                 token = access_token_define.new(ssm_token.bk_app_code, ssm_token.username, ssm_token.expires_in),
-            }
+            }, nil
         end
+
+        return nil, err
     end
 
-    return {
-        err = err,
-    }
+    err = "authentication based on access_token is not supported"
+    return nil, err
 end
 
 function _M.get_access_token(access_token)
     local key = access_token
     local result, err = access_token_lrucache(key, nil, get_access_token, access_token)
     if result == nil then
+        -- if the service is down(100% down), we can use the fallback cache, make the dp robust
+        if err == "connection refused" then
+            -- try to use the fallback cache
+            result = access_token_fallback_lrucache:get(key)
+            if result ~= nil then
+                core.log.error("the ssm down, error: ", err, " use the fallback cache. ",
+                               "key=", key, " result=", core.json.delay_encode(result))
+                return result.token, nil
+            end
+        end
+
         return nil, err
     end
-    return result.token, result.err
+
+    -- if the service is ok, update the fallback cache, keep it the newest
+    -- currently, the access_token(ee) is 24 hours, so the expires_in < 24 hours, and maybe the expires_in < 0
+    local expires_in = result.token:get_expires_in()
+    if expires_in > 0 and expires_in <= ACCESS_TOKEN_FALLBACK_CACHE_TTL then
+        -- if the access_token will expire in 24 hours, set the ttl shorter,
+        -- otherwise, when ssm down, some access_token will valid even it's already expired
+        access_token_fallback_lrucache:set(key, result, expires_in)
+    else
+        -- if expires_in < 0, also set 24 hours ttl
+        access_token_fallback_lrucache:set(key, result, ACCESS_TOKEN_FALLBACK_CACHE_TTL)
+    end
+
+
+    return result.token, nil
 end
 
 if _TEST then -- luacheck: ignore
     _M._get_access_token = get_access_token
+    _M._access_token_fallback_lrucache = access_token_fallback_lrucache
 end
 
 return _M

--- a/src/apisix/editions/ee/plugins/bk-cache/access-token.lua
+++ b/src/apisix/editions/ee/plugins/bk-cache/access-token.lua
@@ -77,6 +77,8 @@ function _M.get_access_token(access_token)
                                "key=", key, " result=", core.json.delay_encode(result))
                 return result.token, nil
             end
+
+            err = "get_access_token failed, error: " .. err
         end
 
         return nil, err

--- a/src/apisix/editions/ee/plugins/bk-cache/bk-token.lua
+++ b/src/apisix/editions/ee/plugins/bk-cache/bk-token.lua
@@ -17,6 +17,7 @@
 --
 local core = require("apisix.core")
 local bklogin_component = require("apisix.plugins.bk-components.bklogin")
+local lru_new = require("resty.lrucache").new
 
 local BK_TOKEN_CACHE_TTL = 300
 local BK_TOKEN_CACHE_COUNT = 2000
@@ -29,15 +30,39 @@ local bk_token_lrucache = core.lrucache.new(
     }
 )
 
+local BK_TOKEN_FALLBACK_CACHE_TTL = 60 * 60 * 24
+local BK_TOKEN_FALLBACK_CACHE_COUNT = 2000
+local bk_token_fallback_lrucache = lru_new(BK_TOKEN_FALLBACK_CACHE_COUNT)
+
 local _M = {}
 
 function _M.get_username_by_bk_token(bk_token)
     local key = bk_token
     local result, err = bk_token_lrucache(key, nil, bklogin_component.get_username_by_bk_token, bk_token)
     if result == nil then
+        -- if the service is down(100% down), we can use the fallback cache, make the dp robust
+        -- if the bklogin down, no new bk_token will be generated; but the old bk_token maybe expired
+        if err == "connection refused" then
+            -- try to use the fallback cache
+            result = bk_token_fallback_lrucache:get(key)
+            if result ~= nil then
+                core.log.error("the bklogin down, error: ", err, " use the fallback cache. ",
+                               "key=", key, " result=", core.json.delay_encode(result))
+                return result.username, result.error_message
+            end
+        end
+
         return nil, err
     end
+
+    -- if the service is ok, update the fallback cache, keep it the newest
+    bk_token_fallback_lrucache:set(key, result, BK_TOKEN_FALLBACK_CACHE_TTL)
+
     return result.username, result.error_message
+end
+
+if _TEST then -- luacheck: ignore
+    _M._bk_token_fallback_lrucache = bk_token_fallback_lrucache
 end
 
 return _M

--- a/src/apisix/editions/ee/plugins/bk-cache/bk-token.lua
+++ b/src/apisix/editions/ee/plugins/bk-cache/bk-token.lua
@@ -50,6 +50,8 @@ function _M.get_username_by_bk_token(bk_token)
                                "key=", key, " result=", core.json.delay_encode(result))
                 return result.username, result.error_message
             end
+
+            err = "get_username_by_bk_token failed, error: " .. err
         end
 
         return nil, err

--- a/src/apisix/editions/ee/plugins/bk-components/bklogin.lua
+++ b/src/apisix/editions/ee/plugins/bk-components/bklogin.lua
@@ -56,6 +56,24 @@ function _M.get_username_by_bk_token(bk_token)
         }
     )
 
+    -- retry if some connection error, while the bklogin in bk-user 2.x
+    if err == "closed" or err == "connection reset by peer" then
+        res, err = http_client:request_uri(
+            url, {
+                method = "GET",
+                query = core.string.encode_args(
+                    {
+                        bk_token = bk_token,
+                    }
+                ),
+                ssl_verify = false,
+                headers = {
+                    ["Content-Type"] = "application/x-www-form-urlencoded",
+                },
+            }
+        )
+    end
+
     local result, _err = bk_components_utils.parse_response(res, err, true)
     if result == nil then
         core.log.error(

--- a/src/apisix/editions/ee/plugins/bk-components/bklogin.lua
+++ b/src/apisix/editions/ee/plugins/bk-components/bklogin.lua
@@ -74,6 +74,12 @@ function _M.get_username_by_bk_token(bk_token)
         )
     end
 
+    -- if the ssm is down, return the raw error
+    if err == "connection refused" then
+        core.log.error("failed to request url: %s, err: %s, response: nil", url, err)
+        return nil, err
+    end
+
     local result, _err = bk_components_utils.parse_response(res, err, true)
     if result == nil then
         core.log.error(

--- a/src/apisix/editions/ee/plugins/bk-components/ssm.lua
+++ b/src/apisix/editions/ee/plugins/bk-components/ssm.lua
@@ -65,6 +65,12 @@ function _M.verify_access_token(access_token)
         }
     )
 
+    -- if the ssm is down, return the raw error
+    if err == "connection refused" then
+        core.log.error("failed to request url: %s, err: %s, response: nil", url, err)
+        return nil, err
+    end
+
     local result, _err = bk_components_utils.parse_response(res, err, true)
     if result == nil then
         core.log.error(

--- a/src/apisix/editions/ee/tests/bk-cache/test-access-token.lua
+++ b/src/apisix/editions/ee/tests/bk-cache/test-access-token.lua
@@ -185,7 +185,7 @@ describe(
                         local access_token = uuid.generate_v4()
                         local result, err = access_token_cache.get_access_token(access_token)
                         assert.is_nil(result)
-                        assert.is_equal(err, "connection refused")
+                        assert.is_equal(err, "get_access_token failed, error: connection refused")
                         assert.stub(ssm_component.verify_access_token).was_called_with(access_token)
                     end
                 )

--- a/src/apisix/editions/ee/tests/bk-cache/test-bk-token.lua
+++ b/src/apisix/editions/ee/tests/bk-cache/test-bk-token.lua
@@ -98,7 +98,7 @@ describe(
                         local bk_token = uuid.generate_v4()
                         local result, err = bk_token_cache.get_username_by_bk_token(bk_token)
                         assert.is_nil(result)
-                        assert.is_equal(err, "connection refused")
+                        assert.is_equal(err, "get_username_by_bk_token failed, error: connection refused")
                         assert.stub(bklogin_component.get_username_by_bk_token).was_called_with(bk_token)
                     end
                 )

--- a/src/apisix/editions/ee/tests/bk-cache/test-bk-token.lua
+++ b/src/apisix/editions/ee/tests/bk-cache/test-bk-token.lua
@@ -89,6 +89,38 @@ describe(
                         assert.stub(bklogin_component.get_username_by_bk_token).was_called(3)
                     end
                 )
+
+                it(
+                    "connection refused, miss in fallback cache", function()
+                        get_username_by_bk_token_result = nil
+                        get_username_by_bk_token_err = "connection refused"
+
+                        local bk_token = uuid.generate_v4()
+                        local result, err = bk_token_cache.get_username_by_bk_token(bk_token)
+                        assert.is_nil(result)
+                        assert.is_equal(err, "connection refused")
+                        assert.stub(bklogin_component.get_username_by_bk_token).was_called_with(bk_token)
+                    end
+                )
+
+                it(
+                    "connection refused, hit in fallback cache", function()
+                        local cached_get_username_by_bk_token_result = {
+                            username = "admin",
+                        }
+                        get_username_by_bk_token_result = nil
+                        get_username_by_bk_token_err = "connection refused"
+
+                        local bk_token = uuid.generate_v4()
+                        bk_token_cache._bk_token_fallback_lrucache:set(bk_token, cached_get_username_by_bk_token_result, 60 * 60 * 24)
+
+                        local result, err = bk_token_cache.get_username_by_bk_token(bk_token)
+                        assert.is_equal(result, "admin")
+                        assert.is_nil(err)
+                        assert.stub(bklogin_component.get_username_by_bk_token).was_called_with(bk_token)
+                    end
+                )
+
             end
         )
     end

--- a/src/apisix/editions/ee/tests/bk-components/test-bklogin.lua
+++ b/src/apisix/editions/ee/tests/bk-components/test-bklogin.lua
@@ -63,6 +63,17 @@ describe(
                 )
 
                 it(
+                    "connection refused", function()
+                        response = nil
+                        response_err = "connection refused"
+
+                        local result, err = bklogin.get_username_by_bk_token("fake-bk-token")
+                        assert.is_nil(result)
+                        assert.equals(err, "connection refused")
+                    end
+                )
+
+                it(
                     "bk_error_code is not 0", function()
                         response = {
                             status = 200,

--- a/src/apisix/editions/ee/tests/bk-components/test-ssm.lua
+++ b/src/apisix/editions/ee/tests/bk-components/test-ssm.lua
@@ -63,6 +63,17 @@ describe(
                 )
 
                 it(
+                    "connection refused", function()
+                        response = nil
+                        response_err = "connection refused"
+
+                        local result, err = ssm.verify_access_token("fake-access-token")
+                        assert.is_nil(result)
+                        assert.equals(err, "connection refused")
+                    end
+                )
+
+                it(
                     "code is not 0", function()
                         response = {
                             status = 200,

--- a/src/apisix/plugins/bk-cache/app-account.lua
+++ b/src/apisix/plugins/bk-cache/app-account.lua
@@ -67,6 +67,8 @@ function _M.verify_app_secret(app_code, app_secret)
             -- else
             --     core.log.error("the bkauth down, but also miss in fallback cache, error: ", err, " key=", key)
             end
+
+            err = "verify_app_secret failed, error: " .. err
         end
 
         return nil, err

--- a/src/apisix/plugins/bk-cache/app-account.lua
+++ b/src/apisix/plugins/bk-cache/app-account.lua
@@ -65,7 +65,7 @@ function _M.verify_app_secret(app_code, app_secret)
                                "key=", key, " result=", core.json.delay_encode(result))
                 return result, nil
             -- else
-            --     core.log.error("the bkauth down, but also miss in fallback cache, error: ", err, " fallback cache is empty. key=", key)
+            --     core.log.error("the bkauth down, but also miss in fallback cache, error: ", err, " key=", key)
             end
         end
 

--- a/src/apisix/plugins/bk-cache/app-account.lua
+++ b/src/apisix/plugins/bk-cache/app-account.lua
@@ -18,6 +18,7 @@
 local core = require("apisix.core")
 local bkauth_component = require("apisix.plugins.bk-components.bkauth")
 local table_concat = table.concat
+local lru_new = require("resty.lrucache").new
 
 local VERIFY_APP_SECRET_CACHE_TTL = 600
 local VERIFY_APP_SECRET_CACHE_COUNT = 1000
@@ -29,6 +30,9 @@ local verify_app_secret_lrucache = core.lrucache.new(
         invalid_stale = true,
     }
 )
+local VERIFY_APP_SECRET_FALLBACK_CACHE_TTL = 60 * 60 * 24
+local VERIFY_APP_SECRET_FALLBACK_CACHE_COUNT = 2000
+local verify_app_secret_fallback_lrucache = lru_new(VERIFY_APP_SECRET_FALLBACK_CACHE_COUNT)
 
 local APP_CODE_APP_SECRETS_CACHE_TTL = 600
 local APP_CODE_APP_SECRETS_CACHE_COUNT = 1000
@@ -50,7 +54,32 @@ function _M.verify_app_secret(app_code, app_secret)
             app_secret,
         }, ":"
     )
-    return verify_app_secret_lrucache(key, nil, bkauth_component.verify_app_secret, app_code, app_secret)
+    local result, err = verify_app_secret_lrucache(key, nil, bkauth_component.verify_app_secret, app_code, app_secret)
+    if result == nil then
+        -- if the service is down(100% down), we can use the fallback cache, make the dp robust
+        if err == "connection refused" then
+            -- try to use the fallback cache
+            result = verify_app_secret_fallback_lrucache:get(key)
+            if result ~= nil then
+                core.log.error("the bkauth down, error: ", err, " use the fallback cache. ",
+                               "key=", key, " result=", core.json.delay_encode(result))
+                return result, nil
+            -- else
+            --     core.log.error("the bkauth down, but also miss in fallback cache, error: ", err, " fallback cache is empty. key=", key)
+            end
+        end
+
+        return nil, err
+    end
+
+    -- if the service is ok, update the fallback cache, keep it the newest
+    -- if the app_code/app_secret been updated, the service is ok, then the data in the fallback cache would be updated
+
+    -- NOTE: here we don't know if the result is from the cache or the real request,
+    --       so we update the fallback cache every time, which may not so efficient?
+    verify_app_secret_fallback_lrucache:set(key, result, VERIFY_APP_SECRET_FALLBACK_CACHE_TTL)
+
+    return result, err
 end
 
 function _M.list_app_secrets(app_code)
@@ -58,4 +87,9 @@ function _M.list_app_secrets(app_code)
     return app_code_app_secrets_lrucache(key, nil, bkauth_component.list_app_secrets, app_code)
 end
 
+if _TEST then -- luacheck: ignore
+    _M._verify_app_secret_fallback_lrucache = verify_app_secret_fallback_lrucache
+end
+
 return _M
+

--- a/src/apisix/plugins/bk-cache/jwt-key.lua
+++ b/src/apisix/plugins/bk-cache/jwt-key.lua
@@ -18,7 +18,8 @@
 local core = require("apisix.core")
 local bk_apigateway_core_component = require("apisix.plugins.bk-components.bk-apigateway-core")
 
-local JWT_PUBLIC_KEY_CACHE_TTL = 600
+-- NOTE: the jwt would never changed? so we can cache it forever
+local JWT_PUBLIC_KEY_CACHE_TTL = 60 * 60 * 24
 local JWT_PUBLIC_KEY_CACHE_COUNT = 1000
 local jwt_public_key_lrucache = core.lrucache.new(
     {

--- a/src/apisix/plugins/bk-cache/jwt-key.lua
+++ b/src/apisix/plugins/bk-cache/jwt-key.lua
@@ -18,7 +18,7 @@
 local core = require("apisix.core")
 local bk_apigateway_core_component = require("apisix.plugins.bk-components.bk-apigateway-core")
 
--- NOTE: the jwt would never changed? so we can cache it forever
+-- NOTE: the jwt would never changed? so we can cache it for a long time
 local JWT_PUBLIC_KEY_CACHE_TTL = 60 * 60 * 24
 local JWT_PUBLIC_KEY_CACHE_COUNT = 1000
 local jwt_public_key_lrucache = core.lrucache.new(

--- a/src/apisix/plugins/bk-components/bkauth.lua
+++ b/src/apisix/plugins/bk-components/bkauth.lua
@@ -71,10 +71,15 @@ function _M.verify_app_secret(app_code, app_secret)
     )
 
     if not (res and res.body) then
-        err = string_format("failed to request third-party api, url: %s, request_id: %s, err: %s, response: nil", url,
-            request_id, err)
-        core.log.error(err)
-        return nil, err
+        local wrapped_err = string_format(
+            "failed to request third-party api, url: %s, request_id: %s, err: %s, response: nil",
+            url, request_id, err
+        )
+        core.log.error(wrapped_err)
+        if err == "connection refused" then
+            return nil, err
+        end
+        return nil, wrapped_err
     end
 
     -- 响应格式正常，错误码 404，表示应用不存在

--- a/src/apisix/plugins/bk-define/access-token.lua
+++ b/src/apisix/plugins/bk-define/access-token.lua
@@ -48,6 +48,11 @@ function _M.has_expired(self)
     return self.expires_in <= 0
 end
 
+-- AccessToken 将会在多久过期
+function _M.get_expires_in(self)
+    return self.expires_in
+end
+
 -- 是否为用户类型的 AccessToken
 function _M.is_user_token(self)
     return not pl_types.is_empty(self.user_id)

--- a/src/apisix/tests/bk-cache/test-app-account.lua
+++ b/src/apisix/tests/bk-cache/test-app-account.lua
@@ -114,7 +114,7 @@ describe(
                         local app_code = uuid.generate_v4()
                         local result, err = app_account_cache.verify_app_secret(app_code, 'fake-app-secret')
                         assert.is_nil(result)
-                        assert.is_equal(err, 'connection refused')
+                        assert.is_equal(err, 'verify_app_secret failed, error: connection refused')
                         assert.stub(bkauth_component.verify_app_secret).was_called_with(app_code, 'fake-app-secret')
                     end
                 )

--- a/src/apisix/tests/bk-components/test-bkauth.lua
+++ b/src/apisix/tests/bk-components/test-bkauth.lua
@@ -63,6 +63,17 @@ describe(
                 )
 
                 it(
+                    "connection refused", function()
+                        response = nil
+                        response_err = "connection refused"
+
+                        local result, err = bkauth.verify_app_secret("fake-app-code", "fake-app-secret")
+                        assert.is_nil(result)
+                        assert.equals(err, "connection refused")
+                    end
+                )
+
+                it(
                     "status 404", function()
                         response = {
                             status = 404,


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

> 目标：即使依赖的第三方服务挂了，也能持续运行一段时间，确保大部分访问过的请求还能继续访问，直到服务恢复

- 鉴于 jwt 不会改变（且查询不到 404 不会缓存）， 将 lrucache的 ttl 改成 24 小时（如果改变，需要reload）




### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
