### PR TITLE
feat(plugins/bk-default-tenant.lua): add plugin bk-default-tenant

### DIFF
--- a/src/apisix/plugins/README.md
+++ b/src/apisix/plugins/README.md
@@ -61,6 +61,7 @@ proxy 预处理：17000 ~ 17500
 - bk-delete-sensitive                       # priority: 17450
 - bk-delete-cookie                          # priority: 17440
 - bk-proxy-rewrite                          # priority: 17430 # 该插件供 operator 进行后端地址转换使用
+- bk-default-tenant                         # priority: 17425
 - bk-stage-header-rewrite                   # priority: 17421
 - bk-resource-header-rewrite                # priority: 17420
 - bk-mock                                   # priority: 17150

--- a/src/apisix/plugins/bk-default-tenant.lua
+++ b/src/apisix/plugins/bk-default-tenant.lua
@@ -1,0 +1,44 @@
+
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+
+local core = require("apisix.core")
+
+local plugin_name = "bk-default-tenant"
+
+local schema = {
+    type = "object",
+    properties = {},
+}
+
+local _M = {
+    version  = 0.1,
+    priority = 17425,
+    name     = plugin_name,
+    schema   = schema,
+}
+
+function _M.check_schema(conf)
+    return core.schema.check(schema, conf)
+end
+
+function _M.rewrite(conf, ctx)
+    core.request.set_header(ctx, "X-Bk-Tenant-Id", "default")
+end
+
+return _M

--- a/src/apisix/plugins/bk-default-tenant.lua
+++ b/src/apisix/plugins/bk-default-tenant.lua
@@ -39,6 +39,7 @@ end
 
 function _M.rewrite(conf, ctx)
     core.request.set_header(ctx, "X-Bk-Tenant-Id", "default")
+    ctx.var.bk_tenant_id = "default"
 end
 
 return _M

--- a/src/apisix/plugins/bk-log-context.lua
+++ b/src/apisix/plugins/bk-log-context.lua
@@ -185,4 +185,10 @@ core.ctx.register_var(
     end
 )
 
+core.ctx.register_var(
+    "bk_tenant_id", function(ctx)
+        return core.request.header(ctx, "X-Bk-Tenant-Id") or ""
+    end
+)
+
 return _M

--- a/src/apisix/t/bk-default-tenant.t
+++ b/src/apisix/t/bk-default-tenant.t
@@ -1,0 +1,110 @@
+
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+}
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_shuffle();
+no_root_location();
+run_tests;
+
+__DATA__
+
+=== TEST 1: sanity
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-default-tenant")
+            local ok, err = plugin.check_schema({})
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+
+=== TEST 2: add plugin
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "plugins": {
+                        "bk-proxy-rewrite": {
+                            "uri": "/uri/plugin_proxy_rewrite"
+                        },
+                        "bk-default-tenant": {}
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+=== TEST 3: rewrite tenant header
+--- request
+GET /hello HTTP/1.1
+--- more_headers
+X-Bk-Tenant-Id: other
+--- response_body
+uri: /uri/plugin_proxy_rewrite
+host: localhost
+x-bk-tenant-id: default
+x-real-ip: 127.0.0.1
+
+=== TEST 4: set tenant header
+--- request
+GET /hello HTTP/1.1
+--- response_body
+uri: /uri/plugin_proxy_rewrite
+host: localhost
+x-bk-tenant-id: default
+x-real-ip: 127.0.0.1

--- a/src/apisix/tests/test-bk-default-tenant.lua
+++ b/src/apisix/tests/test-bk-default-tenant.lua
@@ -55,6 +55,7 @@ describe(
                         assert.is_equal(ctx.headers["X-Bk-Tenant-Id"], nil)
                         plugin.rewrite(conf, ctx)
                         assert.is_equal(ctx.headers["X-Bk-Tenant-Id"], "default")
+                        assert.is_equal(ctx.var.bk_tenant_id, "default")
                     end
                 )
 
@@ -64,6 +65,7 @@ describe(
                         assert.is_equal(ctx.headers["X-Bk-Tenant-Id"], "other")
                         plugin.rewrite(conf, ctx)
                         assert.is_equal(ctx.headers["X-Bk-Tenant-Id"], "default")
+                        assert.is_equal(ctx.var.bk_tenant_id, "default")
                     end
                 )
             end

--- a/src/apisix/tests/test-bk-default-tenant.lua
+++ b/src/apisix/tests/test-bk-default-tenant.lua
@@ -1,0 +1,72 @@
+
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+
+local core = require("apisix.core")
+local plugin = require("apisix.plugins.bk-default-tenant")
+
+describe(
+    "bk-default-tenant", function()
+
+        local ctx
+        local conf
+
+        before_each(
+            function()
+                ctx = {
+                    var = {
+                        uri = "/path/value1/value2?hello=hello",
+                    },
+                    headers = {
+                        ["X-Bk-Tenant-Id"] = nil,
+                    },
+                    conf_id = "conf_id",
+                    conf_type = "conf_type"
+                }
+            end
+        )
+
+        context(
+            "header rewrite", function()
+
+                before_each(
+                    function()
+                        conf = {}
+                    end
+                )
+
+                it(
+                    "header set to default", function()
+                        assert.is_equal(ctx.headers["X-Bk-Tenant-Id"], nil)
+                        plugin.rewrite(conf, ctx)
+                        assert.is_equal(ctx.headers["X-Bk-Tenant-Id"], "default")
+                    end
+                )
+
+                it(
+                    "header overwritten to default", function()
+                        ctx.headers["X-Bk-Tenant-Id"] = "other"
+                        assert.is_equal(ctx.headers["X-Bk-Tenant-Id"], "other")
+                        plugin.rewrite(conf, ctx)
+                        assert.is_equal(ctx.headers["X-Bk-Tenant-Id"], "default")
+                    end
+                )
+            end
+        )
+    end
+)

--- a/src/apisix/tests/test-bk-log-context.lua
+++ b/src/apisix/tests/test-bk-log-context.lua
@@ -31,6 +31,7 @@ describe(
                         should_log_response_body = true,
                     }
                 )
+                ctx.headers = {}
             end
         )
 
@@ -118,6 +119,20 @@ describe(
                         assert.is_equal(ctx.var.bk_log_request_body, "")
                     end
                 )
+
+                it(
+                    "should log bk_tenant_id when present", function()
+                        ctx.headers["X-Bk-Tenant-Id"] = "tenant123"
+                        assert.is_equal(ctx.var.bk_tenant_id, "tenant123")
+                    end
+                )
+
+                it(
+                    "should log empty bk_tenant_id when missing", function()
+                        assert.is_equal(ctx.var.bk_tenant_id, "")
+                    end
+                )
+
             end
         )
 


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

多租户需求：
- 多租户代码，但是没有开启多租户，处于单租户模式，此时需要默认给所有流量注入 `X-Bk-Tenant-Id: default`
- 增加 ctx.var.bk_tenant_id， 默认从 header中获取， 并且 default tenant中将之设置为`default`

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
