### PR TITLE
feat(inner-jwt-verifier.lua): make user verified of inner-jwt optional

### DIFF
--- a/src/apisix/ci/Dockerfile.apisix-test-busted
+++ b/src/apisix/ci/Dockerfile.apisix-test-busted
@@ -13,7 +13,7 @@ RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|
 RUN yum install -y sudo make gcc curl wget unzip git valgrind
 
 ARG APISIX_VERSION
-RUN curl https://raw.githubusercontent.com/apache/apisix/${APISIX_VERSION}/utils/linux-install-luarocks.sh | bash
+RUN wget https://raw.githubusercontent.com/apache/apisix/${APISIX_VERSION}/utils/linux-install-luarocks.sh && sed -i 's/3.8.0/3.12.0/g' linux-install-luarocks.sh &&  bash linux-install-luarocks.sh
 # lock the version of luasystem, otherwise the busted won't be installed success
 RUN luarocks install https://luarocks.org/manifests/lunarmodules/luasystem-0.2.1-0.rockspec
 RUN luarocks install https://github.com/lunarmodules/busted/releases/download/v2.1.1/busted-2.1.1-1.rockspec

--- a/src/apisix/ci/Dockerfile.apisix-test-nginx
+++ b/src/apisix/ci/Dockerfile.apisix-test-nginx
@@ -24,7 +24,7 @@ RUN sed -i 's#yum install -y openresty openresty-debug openresty-openssl111-debu
 RUN sed -i 's|https://registry.npm.taobao.org|https://registry.npmmirror.com|g' ${CODE_DIR}/t/plugin/grpc-web/package-lock.json
 # fix archived libs in luarocks
 RUN sed -i 's|lualdap = 1.2.6-1|lualdap = 1.4.0-1|g' ${CODE_DIR}/rockspec/apisix-master-0.rockspec
-RUN cd ${CODE_DIR} &&  bash ./ci/centos7-ci.sh install_dependencies
+RUN cd ${CODE_DIR} && sed -i 's/3.8.0/3.12.0/g' utils/linux-install-luarocks.sh && bash ./ci/centos7-ci.sh install_dependencies
 RUN cp -r ${CODE_DIR}/t /usr/local/apisix/
 
 # the t/APISIX.pm:add_cleanup_handler will call it if the FLUSH_ETCD=1

--- a/src/apisix/plugins/bk-auth-verify/inner-jwt-verifier.lua
+++ b/src/apisix/plugins/bk-auth-verify/inner-jwt-verifier.lua
@@ -88,11 +88,15 @@ function _M.verify_user(self)
 
     local user_info = jwt_obj.payload.user
     if user_info == nil then
-        return nil, "parameter jwt does not indicate user information"
+        return bk_user_define.new_anonymous_user(
+        "auth parameter does not indicate user information, verified by inner-jwt-verifier"
+        )
     end
 
     if user_info.verified ~= true then
-        return nil, "the user indicated by jwt is not verified"
+        return bk_user_define.new_anonymous_user(
+        "the user indicated by auth parameter is not verified, verified by inner-jwt-verifier"
+        )
     end
 
     return bk_user_define.new_user(

--- a/src/apisix/tests/bk-auth-verify/test-inner-jwt-verifier.lua
+++ b/src/apisix/tests/bk-auth-verify/test-inner-jwt-verifier.lua
@@ -179,7 +179,7 @@ describe(
                 )
 
                 it(
-                    "user is nil", function()
+                    "user is nil, use anonymous user", function()
                         parse_jwt_token_result = {
                             header = {
                                 kid = "bk-apigateway"
@@ -189,8 +189,10 @@ describe(
                         parse_jwt_token_err = nil
 
                         local user, err = inner_jwt_verifier.new("fake-jwt-token"):verify_user()
-                        assert.is_equal(err, "parameter jwt does not indicate user information")
-                        assert.is_nil(user)
+                        assert.is_nil(err)
+                        assert.is_equal(user.username, "")
+                        assert.is_false(user.verified)
+                        assert.is_equal(user.valid_error_message, "auth parameter does not indicate user information, verified by inner-jwt-verifier")
                     end
                 )
 
@@ -210,8 +212,10 @@ describe(
                         parse_jwt_token_err = nil
 
                         local user, err = inner_jwt_verifier.new("fake-jwt-token"):verify_user()
-                        assert.is_equal(err, "the user indicated by jwt is not verified")
-                        assert.is_nil(user)
+                        assert.is_nil(err)
+                        assert.is_equal(user.username, "")
+                        assert.is_false(user.verified)
+                        assert.is_equal(user.valid_error_message, "the user indicated by auth parameter is not verified, verified by inner-jwt-verifier")
                     end
                 )
 


### PR DESCRIPTION
### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

inner-jwt 不强制要求 user.verified=true， 如果没有提供或者false，创建匿名用户，往后走； 如果接口开启用户认证才会报错

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
