### PR TITLE
fix(oauth2): fix bkauth verify logic and update MCP audience prefix

### DIFF
--- a/src/apisix/plugins/bk-components/bkauth.lua
+++ b/src/apisix/plugins/bk-components/bkauth.lua
@@ -44,7 +44,11 @@ local _M = {
     -- bkauth_access_token = bkapp.bkauth_access_token,
 }
 
-local function bkauth_do_request(host, path, params, request_id)
+local function bkauth_do_request(host, path, params, request_id, check_code)
+    if check_code == nil then
+        check_code = true
+    end
+
     if pl_types.is_empty(host) then
         return nil, "server error: bkauth host is not configured."
     end
@@ -92,7 +96,7 @@ local function bkauth_do_request(host, path, params, request_id)
         return nil, new_err
     end
 
-    if result.code ~= 0 then
+    if check_code and result.code ~= 0 then
         local new_err = string_format(
                 "failed to request third-party api, url: %s, request_id: %s, result.code!=0, status: %s, response: %s",
                 url, request_id, res.status, res.body
@@ -230,7 +234,7 @@ function _M.verify_oauth2_access_token(access_token)
             ["Content-Type"] = "application/json",
         },
     }
-    local result, err = bkauth_do_request(_M.host, path, params, request_id)
+    local result, err = bkauth_do_request(_M.host, path, params, request_id, false)
     if err ~= nil then
         return nil, err
     end

--- a/src/apisix/plugins/bk-core/init.lua
+++ b/src/apisix/plugins/bk-core/init.lua
@@ -23,4 +23,5 @@ return {
     url = require("apisix.plugins.bk-core.url"),
     hmac = require("apisix.plugins.bk-core.hmac"),
     cookie = require("apisix.plugins.bk-core.cookie"),
+    oauth2 = require("apisix.plugins.bk-core.oauth2"),
 }

--- a/src/apisix/plugins/bk-core/oauth2.lua
+++ b/src/apisix/plugins/bk-core/oauth2.lua
@@ -38,8 +38,10 @@ end
 
 ---Build the WWW-Authenticate header value for OAuth2 discovery
 ---@param ctx table The current context object
+---@param error_code string|nil The OAuth2 error code (e.g., "invalid_token", "invalid_request")
+---@param error_description string|nil The human-readable error description
 ---@return string The WWW-Authenticate header value
-function _M.build_www_authenticate_header(ctx, error, error_description)
+function _M.build_www_authenticate_header(ctx, error_code, error_description)
     local tmpl = config.get_bk_apigateway_api_tmpl()
 
     -- If tmpl is not configured (nil or empty), return minimal header
@@ -70,14 +72,14 @@ function _M.build_www_authenticate_header(ctx, error, error_description)
     local resource_url = rendered_origin .. path
     local encoded_resource_url = ngx_escape_uri(resource_url)
 
-    if error and error_description then
+    if error_code and error_description then
         local tmpl_str = 'Bearer resource_metadata="%s/prod/api/v2/open/.well-known/' ..
             'oauth-protected-resource?resource=%s", error="%s", error_description="%s"'
         return string_format(
             tmpl_str,
             base_url,
             encoded_resource_url,
-            escape_auth_header_value(error),
+            escape_auth_header_value(error_code),
             escape_auth_header_value(error_description)
         )
     end
@@ -89,5 +91,9 @@ function _M.build_www_authenticate_header(ctx, error, error_description)
     )
 end
 
+
+if _TEST then -- luacheck: ignore
+    _M._escape_auth_header_value = escape_auth_header_value
+end
 
 return _M

--- a/src/apisix/plugins/bk-core/oauth2.lua
+++ b/src/apisix/plugins/bk-core/oauth2.lua
@@ -1,0 +1,93 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) 2025 Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+local config = require("apisix.plugins.bk-core.config")
+
+local ngx = ngx
+local ngx_escape_uri = ngx.escape_uri
+local string_match = string.match
+local string_gsub = string.gsub
+local string_format = string.format
+
+local _M = {}
+
+
+local function escape_auth_header_value(value)
+    if value == nil or value == "" then
+        return ""
+    end
+
+    local escaped = string_gsub(value, "\\", "\\\\")
+    escaped = string_gsub(escaped, '"', '\\"')
+    return escaped
+end
+
+---Build the WWW-Authenticate header value for OAuth2 discovery
+---@param ctx table The current context object
+---@return string The WWW-Authenticate header value
+function _M.build_www_authenticate_header(ctx, error, error_description)
+    local tmpl = config.get_bk_apigateway_api_tmpl()
+
+    -- If tmpl is not configured (nil or empty), return minimal header
+    if tmpl == nil or tmpl == "" then
+        return 'Bearer realm="bk-apigateway", error="invalid_request", error_description="api tmpl is not configured"'
+    end
+
+    -- Validate that tmpl is a valid URL format (must start with http:// or https://)
+    if not string_match(tmpl, "^https?://") then
+        return 'Bearer realm="bk-apigateway", error="invalid_request", error_description="invalid api tmpl format"'
+    end
+
+    -- The tmpl can be in two formats:
+    -- - subpath: http://bkapi.example.com/api/{api_name}
+    -- - subdomain: http://{api_name}.bkapi.example.com
+
+    -- Step 1: Replace {api_name} with "bk-apigateway" to get the base URL
+    local base_url = string_gsub(tmpl, "{api_name}", "bk-apigateway")
+
+    -- Step 2: Extract scheme and domain (host) from the rendered URL to get the origin
+    -- Pattern matches: scheme://host (stops at first / after host or end of string)
+    local gateway_name = (ctx and ctx.var and ctx.var.bk_gateway_name) or "unknown"
+    local rendered_url = string_gsub(tmpl, "{api_name}", gateway_name)
+    local rendered_origin = string_match(rendered_url, "^(https?://[^/]+)")
+
+    -- Step 3: Build the resource path and encode it
+    local path = (ctx and ctx.var and ctx.var.uri) or "/"
+    local resource_url = rendered_origin .. path
+    local encoded_resource_url = ngx_escape_uri(resource_url)
+
+    if error and error_description then
+        local tmpl_str = 'Bearer resource_metadata="%s/prod/api/v2/open/.well-known/' ..
+            'oauth-protected-resource?resource=%s", error="%s", error_description="%s"'
+        return string_format(
+            tmpl_str,
+            base_url,
+            encoded_resource_url,
+            escape_auth_header_value(error),
+            escape_auth_header_value(error_description)
+        )
+    end
+
+    return string_format(
+        'Bearer resource_metadata="%s/prod/api/v2/open/.well-known/oauth-protected-resource?resource=%s"',
+        base_url,
+        encoded_resource_url
+    )
+end
+
+
+return _M

--- a/src/apisix/plugins/bk-oauth2-audience-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-audience-validate.lua
@@ -21,7 +21,7 @@
 -- the token is authorized for the specific resource being accessed.
 --
 -- Audience formats supported:
---   - mcp_server:{mcp_server_name} - Access to specific MCP server
+--   - mcp:{mcp_server_name} - Access to specific MCP server
 --   - gateway:{gateway_name}/api:{api_name} - Access to specific gateway API
 --   - gateway:{gateway_name}/api:* - Access to all APIs under a gateway (wildcard)
 --

--- a/src/apisix/plugins/bk-oauth2-audience-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-audience-validate.lua
@@ -70,7 +70,7 @@ local function parse_audience(audience_str)
     end
 
     -- Try mcp_server:{name} format
-    local mcp_name = string_match(audience_str, "^mcp_server:(.+)$")
+    local mcp_name = string_match(audience_str, "^mcp:(.+)$")
     if mcp_name then
         return {
             type = "mcp_server",

--- a/src/apisix/plugins/bk-oauth2-audience-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-audience-validate.lua
@@ -33,6 +33,7 @@
 local pl_types = require("pl.types")
 local core = require("apisix.core")
 local errorx = require("apisix.plugins.bk-core.errorx")
+local oauth2 = require("apisix.plugins.bk-core.oauth2")
 local ngx = ngx
 local ngx_re = ngx.re
 local ipairs = ipairs
@@ -243,6 +244,9 @@ function _M.rewrite(conf, ctx) -- luacheck: no unused
             :with_field("reason", reason)
             :with_field("gateway", ctx.var.bk_gateway_name or "")
             :with_field("resource", ctx.var.bk_resource_name or "")
+
+        local www_auth = oauth2.build_www_authenticate_header(ctx, "invalid_audience", reason)
+        ngx.header["WWW-Authenticate"] = www_auth
         return errorx.exit_with_apigw_err(ctx, err, _M)
     end
 

--- a/src/apisix/plugins/bk-oauth2-protected-resource.lua
+++ b/src/apisix/plugins/bk-oauth2-protected-resource.lua
@@ -28,14 +28,12 @@
 --
 local pl_types = require("pl.types")
 local core = require("apisix.core")
-local bk_core = require("apisix.plugins.bk-core.init")
+local oauth2 = require("apisix.plugins.bk-core.oauth2")
 local errorx = require("apisix.plugins.bk-core.errorx")
 local ngx = ngx
-local ngx_escape_uri = ngx.escape_uri
 local string_sub = string.sub
 local string_lower = string.lower
 local string_match = string.match
-local string_gsub = string.gsub
 
 local plugin_name = "bk-oauth2-protected-resource"
 
@@ -83,48 +81,6 @@ local function parse_bearer_token(authorization)
 end
 
 
----Build the WWW-Authenticate header value for OAuth2 discovery
----@param ctx table The current context object
----@return string The WWW-Authenticate header value
-local function build_www_authenticate_header(ctx)
-    local tmpl = bk_core.config.get_bk_apigateway_api_tmpl()
-
-    -- If tmpl is not configured (nil or empty), return minimal header
-    if tmpl == nil or tmpl == "" then
-        return 'Bearer realm="bk-apigateway", error="invalid_request", error_description="api tmpl is not configured"'
-    end
-
-    -- Validate that tmpl is a valid URL format (must start with http:// or https://)
-    if not string_match(tmpl, "^https?://") then
-        return 'Bearer realm="bk-apigateway", error="invalid_request", error_description="invalid api tmpl format"'
-    end
-
-    -- The tmpl can be in two formats:
-    -- - subpath: http://bkapi.example.com/api/{api_name}
-    -- - subdomain: http://{api_name}.bkapi.example.com
-
-    -- Step 1: Replace {api_name} with "bk-apigateway" to get the base URL
-    local base_url = string_gsub(tmpl, "{api_name}", "bk-apigateway")
-
-    -- Step 2: Extract scheme and domain (host) from the rendered URL to get the origin
-    -- Pattern matches: scheme://host (stops at first / after host or end of string)
-    local gateway_name = ctx.var.bk_gateway_name or "unknown"
-    local rendered_url = string_gsub(tmpl, "{api_name}", gateway_name)
-    local rendered_origin = string_match(rendered_url, "^(https?://[^/]+)")
-
-    -- Step 3: Build the resource path and encode it
-    local path = ctx.var.uri or "/"
-    local resource_url = rendered_origin .. path
-    local encoded_resource_url = ngx_escape_uri(resource_url)
-
-    return string.format(
-        'Bearer resource_metadata="%s/prod/api/v2/open/.well-known/oauth-protected-resource?resource=%s"',
-        base_url,
-        encoded_resource_url
-    )
-end
-
-
 function _M.rewrite(conf, ctx) -- luacheck: no unused
     -- Check for X-Bkapi-Authorization header first (legacy BlueKing auth)
     -- If present, skip OAuth2 flow and allow legacy flow to handle authentication
@@ -149,8 +105,9 @@ function _M.rewrite(conf, ctx) -- luacheck: no unused
     -- No valid auth headers present
     -- Return 401 with WWW-Authenticate header for OAuth2 discovery
     core.log.info("bk-oauth2-protected-resource: no valid auth header, returning 401 with WWW-Authenticate")
-    local www_authenticate = build_www_authenticate_header(ctx)
-    ngx.header["WWW-Authenticate"] = www_authenticate
+    local www_auth = oauth2.build_www_authenticate_header(
+        ctx, "invalid_request", "no valid authentication header found")
+    ngx.header["WWW-Authenticate"] = www_auth
 
     local err = errorx.new_general_unauthorized()
         :with_field("reason", "no valid authentication header found")
@@ -161,7 +118,6 @@ end
 
 if _TEST then -- luacheck: ignore
     _M._parse_bearer_token = parse_bearer_token
-    _M._build_www_authenticate_header = build_www_authenticate_header
 end
 
 return _M

--- a/src/apisix/plugins/bk-oauth2-verify.lua
+++ b/src/apisix/plugins/bk-oauth2-verify.lua
@@ -33,6 +33,7 @@
 local pl_types = require("pl.types")
 local core = require("apisix.core")
 local errorx = require("apisix.plugins.bk-core.errorx")
+local oauth2 = require("apisix.plugins.bk-core.oauth2")
 local oauth2_cache = require("apisix.plugins.bk-cache.oauth2-access-token")
 local bk_app_define = require("apisix.plugins.bk-define.app")
 local bk_user_define = require("apisix.plugins.bk-define.user")
@@ -41,8 +42,6 @@ local ngx_time = ngx.time
 local string_lower = string.lower
 local string_sub = string.sub
 local string_match = string.match
-local string_gsub = string.gsub
-local string_format = string.format
 
 local plugin_name = "bk-oauth2-verify"
 local AUTHORIZATION_HEADER = "Authorization"
@@ -101,39 +100,6 @@ local function mask_token(token)
 end
 
 
-local function escape_auth_header_value(value)
-    if pl_types.is_empty(value) then
-        return ""
-    end
-
-    local escaped = string_gsub(value, "\\", "\\\\")
-    escaped = string_gsub(escaped, '"', '\\"')
-    return escaped
-end
-
-
-local function build_www_authenticate_header(ctx, reason, error)
-    local realm = "bk-apigateway"
-    if ctx and ctx.var and not pl_types.is_empty(ctx.var.bk_gateway_name) then
-        realm = ctx.var.bk_gateway_name
-    end
-
-    local description = reason or "token verification failed"
-    return string_format(
-        'Bearer realm="%s", error="%s", error_description="%s"',
-        escape_auth_header_value(realm),
-        escape_auth_header_value(error),
-        escape_auth_header_value(description)
-    )
-end
-
-
-local function set_www_authenticate_header(ctx, reason, error)
-    local header_value = build_www_authenticate_header(ctx, reason, error or "invalid_token")
-    core.response.set_header("WWW-Authenticate", header_value)
-end
-
-
 ---Verify the OAuth2 access token and return the verification result
 ---@param access_token string The OAuth2 access token
 ---@return table|nil result The verification result
@@ -185,7 +151,9 @@ function _M.rewrite(conf, ctx) -- luacheck: no unused
 
         local err = errorx.new_general_unauthorized()
             :with_field("reason", "Bearer token not found in Authorization header")
-        set_www_authenticate_header(ctx, "Bearer token not found in Authorization header", "invalid_request")
+        local www_auth = oauth2.build_www_authenticate_header(
+            ctx, "invalid_request", "Bearer token not found in Authorization header")
+        core.response.set_header("WWW-Authenticate", www_auth)
         return errorx.exit_with_apigw_err(ctx, err, _M)
     end
 
@@ -200,7 +168,8 @@ function _M.rewrite(conf, ctx) -- luacheck: no unused
         -- wrap it, it's an internal error
         local error_message = "call bkauth api to verify token failed: " .. (err or "unknown error")
         error_obj = error_obj:with_field("reason", error_message)
-        set_www_authenticate_header(ctx, error_message)
+        local www_auth = oauth2.build_www_authenticate_header(ctx, "invalid_token", error_message)
+        core.response.set_header("WWW-Authenticate", www_auth)
         return errorx.exit_with_apigw_err(ctx, error_obj, _M)
     end
 
@@ -210,7 +179,8 @@ function _M.rewrite(conf, ctx) -- luacheck: no unused
 
         local reason = result.error.message or "token verification failed, active=false"
         error_obj = error_obj:with_field("reason", reason)
-        set_www_authenticate_header(ctx, reason, result.error.code)
+        local www_auth = oauth2.build_www_authenticate_header(ctx, result.error.code, reason)
+        core.response.set_header("WWW-Authenticate", www_auth)
         return errorx.exit_with_apigw_err(ctx, error_obj, _M)
     end
 
@@ -218,7 +188,9 @@ function _M.rewrite(conf, ctx) -- luacheck: no unused
     if result.exp < ngx_time() then
         core.log.info("bk-oauth2-verify: token expired, token_hint=", masked_token, ", exp=", result.exp)
         error_obj = error_obj:with_field("reason", "token expired")
-        set_www_authenticate_header(ctx, "token expired")
+        local www_auth = oauth2.build_www_authenticate_header(ctx, "invalid_token", "token expired")
+        core.response.set_header("WWW-Authenticate", www_auth)
+
         return errorx.exit_with_apigw_err(ctx, error_obj, _M)
     end
 

--- a/src/apisix/t/bk-oauth2-audience-validate.t
+++ b/src/apisix/t/bk-oauth2-audience-validate.t
@@ -158,7 +158,7 @@ pass
                     bk_gateway_name = "bk-apigateway",
                     bk_resource_name = "mcp-resource",
                     uri = "/api/v2/mcp-servers/my-server/resources",
-                    audience = {"mcp_server:my-server"}
+                    audience = {"mcp:my-server"}
                 }
             }
 
@@ -314,7 +314,7 @@ status: 403
                     bk_gateway_name = "bk-apigateway",
                     bk_resource_name = "mcp-resource",
                     uri = "/api/v2/mcp-servers/server-a/resources",
-                    audience = {"mcp_server:server-b"}
+                    audience = {"mcp:server-b"}
                 }
             }
 
@@ -337,7 +337,7 @@ status: 403
                     bk_gateway_name = "other-gateway",
                     bk_resource_name = "mcp-resource",
                     uri = "/api/v2/mcp-servers/my-server/resources",
-                    audience = {"mcp_server:my-server"}
+                    audience = {"mcp:my-server"}
                 }
             }
 
@@ -359,7 +359,7 @@ status: 403
                     is_bk_oauth2 = true,
                     bk_gateway_name = "demo",
                     bk_resource_name = "my-api",
-                    audience = {"gateway:other/api:other", "gateway:another/api:another", "mcp_server:some-server"}
+                    audience = {"gateway:other/api:other", "gateway:another/api:another", "mcp:some-server"}
                 }
             }
 

--- a/src/apisix/tests/test-bk-core-oauth2.lua
+++ b/src/apisix/tests/test-bk-core-oauth2.lua
@@ -1,0 +1,355 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) 2025 Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+local bk_core = require("apisix.plugins.bk-core.init")
+local oauth2 = require("apisix.plugins.bk-core.oauth2")
+
+describe(
+    "bk-core.oauth2", function()
+        local ctx
+
+        before_each(
+            function()
+                ctx = {
+                    var = {
+                        bk_gateway_name = "demo",
+                        uri = "/api/v1/users",
+                    },
+                }
+
+                stub(
+                    bk_core.config, "get_bk_apigateway_api_tmpl", function()
+                        return "http://bkapi.example.com/api/{api_name}"
+                    end
+                )
+            end
+        )
+
+        after_each(
+            function()
+                bk_core.config.get_bk_apigateway_api_tmpl:revert()
+            end
+        )
+
+        context(
+            "escape_auth_header_value", function()
+                it(
+                    "should return empty string for nil", function()
+                        local result = oauth2._escape_auth_header_value(nil)
+                        assert.is_equal("", result)
+                    end
+                )
+
+                it(
+                    "should return empty string for empty input", function()
+                        local result = oauth2._escape_auth_header_value("")
+                        assert.is_equal("", result)
+                    end
+                )
+
+                it(
+                    "should return value as-is when no special characters", function()
+                        local result = oauth2._escape_auth_header_value("hello world")
+                        assert.is_equal("hello world", result)
+                    end
+                )
+
+                it(
+                    "should escape double quotes", function()
+                        local result = oauth2._escape_auth_header_value('say "hello"')
+                        assert.is_equal('say \\"hello\\"', result)
+                    end
+                )
+
+                it(
+                    "should escape backslashes", function()
+                        local result = oauth2._escape_auth_header_value("path\\to\\file")
+                        assert.is_equal("path\\\\to\\\\file", result)
+                    end
+                )
+
+                it(
+                    "should escape both backslashes and double quotes", function()
+                        local result = oauth2._escape_auth_header_value('a\\"b')
+                        assert.is_equal('a\\\\\\"b', result)
+                    end
+                )
+            end
+        )
+
+        context(
+            "build_www_authenticate_header - tmpl validation", function()
+                it(
+                    "should return realm error when tmpl is nil", function()
+                        bk_core.config.get_bk_apigateway_api_tmpl:revert()
+                        stub(
+                            bk_core.config, "get_bk_apigateway_api_tmpl", function()
+                                return nil
+                            end
+                        )
+
+                        local header = oauth2.build_www_authenticate_header(ctx)
+
+                        assert.is_equal(
+                            'Bearer realm="bk-apigateway", error="invalid_request",'
+                                .. ' error_description="api tmpl is not configured"',
+                            header
+                        )
+                    end
+                )
+
+                it(
+                    "should return realm error when tmpl is empty", function()
+                        bk_core.config.get_bk_apigateway_api_tmpl:revert()
+                        stub(
+                            bk_core.config, "get_bk_apigateway_api_tmpl", function()
+                                return ""
+                            end
+                        )
+
+                        local header = oauth2.build_www_authenticate_header(ctx)
+
+                        assert.is_equal(
+                            'Bearer realm="bk-apigateway", error="invalid_request",'
+                                .. ' error_description="api tmpl is not configured"',
+                            header
+                        )
+                    end
+                )
+
+                it(
+                    "should return realm error for invalid tmpl format", function()
+                        bk_core.config.get_bk_apigateway_api_tmpl:revert()
+                        stub(
+                            bk_core.config, "get_bk_apigateway_api_tmpl", function()
+                                return "not-a-valid-url"
+                            end
+                        )
+
+                        local header = oauth2.build_www_authenticate_header(ctx)
+
+                        assert.is_equal(
+                            'Bearer realm="bk-apigateway", error="invalid_request",'
+                                .. ' error_description="invalid api tmpl format"',
+                            header
+                        )
+                    end
+                )
+            end
+        )
+
+        context(
+            "build_www_authenticate_header - without error params", function()
+                it(
+                    "should handle subpath template format", function()
+                        local header = oauth2.build_www_authenticate_header(ctx)
+
+                        assert.is_not_nil(header)
+                        assert.is_truthy(
+                            string.find(
+                                header,
+                                'Bearer resource_metadata="http://bkapi.example.com/api/bk-apigateway/prod/',
+                                1, true
+                            )
+                        )
+                        -- Should NOT contain error= fields
+                        assert.is_nil(string.find(header, 'error=', 1, true))
+                    end
+                )
+
+                it(
+                    "should handle subdomain template format", function()
+                        bk_core.config.get_bk_apigateway_api_tmpl:revert()
+                        stub(
+                            bk_core.config, "get_bk_apigateway_api_tmpl", function()
+                                return "http://{api_name}.bkapi.example.com"
+                            end
+                        )
+
+                        local header = oauth2.build_www_authenticate_header(ctx)
+
+                        assert.is_not_nil(header)
+                        assert.is_truthy(
+                            string.find(
+                                header,
+                                'resource_metadata="http://bk-apigateway.bkapi.example.com/prod/',
+                                1, true
+                            )
+                        )
+                    end
+                )
+
+                it(
+                    "should use gateway_name in resource URL for subdomain template", function()
+                        bk_core.config.get_bk_apigateway_api_tmpl:revert()
+                        stub(
+                            bk_core.config, "get_bk_apigateway_api_tmpl", function()
+                                return "http://{api_name}.bkapi.example.com"
+                            end
+                        )
+                        ctx.var.bk_gateway_name = "my-gateway"
+
+                        local header = oauth2.build_www_authenticate_header(ctx)
+
+                        -- The resource URL origin should contain the gateway name
+                        assert.is_truthy(
+                            string.find(header, "my-gateway.bkapi.example.com", 1, true)
+                        )
+                    end
+                )
+
+                it(
+                    "should URL-encode the resource path", function()
+                        ctx.var.uri = "/api/v1/users?query=test&page=1"
+
+                        local header = oauth2.build_www_authenticate_header(ctx)
+
+                        -- The resource URL should be URL encoded
+                        local expected = "resource=http%3A%2F%2Fbkapi.example.com%2Fapi%2Fv1%2Fusers"
+                        assert.is_truthy(string.find(header, expected, 1, true))
+                    end
+                )
+            end
+        )
+
+        context(
+            "build_www_authenticate_header - with error params", function()
+                it(
+                    "should include error and error_description", function()
+                        local header = oauth2.build_www_authenticate_header(
+                            ctx, "invalid_token", "token has expired"
+                        )
+
+                        assert.is_truthy(
+                            string.find(header, 'error="invalid_token"', 1, true)
+                        )
+                        assert.is_truthy(
+                            string.find(header, 'error_description="token has expired"', 1, true)
+                        )
+                        -- Should also include resource_metadata
+                        assert.is_truthy(
+                            string.find(header, "resource_metadata=", 1, true)
+                        )
+                    end
+                )
+
+                it(
+                    "should escape special characters in error_code", function()
+                        local header = oauth2.build_www_authenticate_header(
+                            ctx, 'invalid"token', "some error"
+                        )
+
+                        assert.is_truthy(
+                            string.find(header, 'error="invalid\\"token"', 1, true)
+                        )
+                    end
+                )
+
+                it(
+                    "should escape special characters in error_description", function()
+                        local header = oauth2.build_www_authenticate_header(
+                            ctx, "invalid_token", 'token "abc\\def" expired'
+                        )
+
+                        assert.is_truthy(
+                            string.find(header, 'error_description="token \\"abc\\\\def\\" expired"', 1, true)
+                        )
+                    end
+                )
+
+                it(
+                    "should not include error fields when only error_code is provided", function()
+                        local header = oauth2.build_www_authenticate_header(ctx, "invalid_token", nil)
+
+                        -- Should fall back to no-error path
+                        assert.is_nil(string.find(header, 'error=', 1, true))
+                    end
+                )
+
+                it(
+                    "should not include error fields when only error_description is provided", function()
+                        local header = oauth2.build_www_authenticate_header(ctx, nil, "some description")
+
+                        -- Should fall back to no-error path
+                        assert.is_nil(string.find(header, 'error=', 1, true))
+                    end
+                )
+            end
+        )
+
+        context(
+            "build_www_authenticate_header - defensive nil handling", function()
+                it(
+                    "should handle nil ctx gracefully", function()
+                        local header = oauth2.build_www_authenticate_header(nil)
+
+                        assert.is_not_nil(header)
+                        -- Should use "unknown" as gateway name and "/" as path
+                        assert.is_truthy(
+                            string.find(header, "resource_metadata=", 1, true)
+                        )
+                    end
+                )
+
+                it(
+                    "should handle nil ctx.var gracefully", function()
+                        local header = oauth2.build_www_authenticate_header({ var = nil })
+
+                        assert.is_not_nil(header)
+                        assert.is_truthy(
+                            string.find(header, "resource_metadata=", 1, true)
+                        )
+                    end
+                )
+
+                it(
+                    "should default gateway_name to unknown when missing", function()
+                        bk_core.config.get_bk_apigateway_api_tmpl:revert()
+                        stub(
+                            bk_core.config, "get_bk_apigateway_api_tmpl", function()
+                                return "http://{api_name}.bkapi.example.com"
+                            end
+                        )
+                        ctx.var.bk_gateway_name = nil
+
+                        local header = oauth2.build_www_authenticate_header(ctx)
+
+                        assert.is_not_nil(header)
+                        -- Should use "unknown" as the gateway name in subdomain
+                        assert.is_truthy(
+                            string.find(header, "unknown.bkapi.example.com", 1, true)
+                        )
+                    end
+                )
+
+                it(
+                    "should default uri to / when missing", function()
+                        ctx.var.uri = nil
+
+                        local header = oauth2.build_www_authenticate_header(ctx)
+
+                        assert.is_not_nil(header)
+                        -- The resource URL should end with just the origin + "/"
+                        assert.is_truthy(
+                            string.find(header, "resource_metadata=", 1, true)
+                        )
+                    end
+                )
+            end
+        )
+    end
+)

--- a/src/apisix/tests/test-bk-oauth2-audience-validate.lua
+++ b/src/apisix/tests/test-bk-oauth2-audience-validate.lua
@@ -98,8 +98,8 @@ describe(
         context(
             "audience parsing", function()
                 it(
-                    "should parse mcp_server format correctly", function()
-                        local result = plugin._parse_audience("mcp_server:my-server")
+                    "should parse mcp format correctly", function()
+                        local result = plugin._parse_audience("mcp:my-server")
 
                         assert.is_equal("mcp_server", result.type)
                         assert.is_equal("my-server", result.name)
@@ -179,7 +179,7 @@ describe(
                         ctx.var.is_bk_oauth2 = true
                         ctx.var.bk_gateway_name = "bk-apigateway"
                         ctx.var.uri = "/api/v2/mcp-servers/my-server/resources"
-                        ctx.var.audience = {"mcp_server:my-server"}
+                        ctx.var.audience = {"mcp:my-server"}
 
                         local result = plugin.rewrite({}, ctx)
 
@@ -192,7 +192,7 @@ describe(
                         ctx.var.is_bk_oauth2 = true
                         ctx.var.bk_gateway_name = "bk-apigateway"
                         ctx.var.uri = "/api/v2/mcp-servers/other-server/resources"
-                        ctx.var.audience = {"mcp_server:my-server"}
+                        ctx.var.audience = {"mcp:my-server"}
 
                         local status = plugin.rewrite({}, ctx)
 
@@ -205,7 +205,7 @@ describe(
                         ctx.var.is_bk_oauth2 = true
                         ctx.var.bk_gateway_name = "other-gateway"
                         ctx.var.uri = "/api/v2/mcp-servers/my-server/resources"
-                        ctx.var.audience = {"mcp_server:my-server"}
+                        ctx.var.audience = {"mcp:my-server"}
 
                         local status = plugin.rewrite({}, ctx)
 
@@ -296,7 +296,7 @@ describe(
                         ctx.var.bk_resource_name = "test-api"
                         ctx.var.audience = {
                             "gateway:other/api:other",
-                            "mcp_server:my-server",
+                            "mcp:my-server",
                         }
 
                         local status = plugin.rewrite({}, ctx)

--- a/src/apisix/tests/test-bk-oauth2-protected-resource.lua
+++ b/src/apisix/tests/test-bk-oauth2-protected-resource.lua
@@ -17,6 +17,7 @@
 --
 local core = require("apisix.core")
 local bk_core = require("apisix.plugins.bk-core.init")
+local oauth2 = require("apisix.plugins.bk-core.oauth2")
 local plugin = require("apisix.plugins.bk-oauth2-protected-resource")
 
 describe(
@@ -183,7 +184,7 @@ describe(
         )
 
         context(
-            "_build_www_authenticate_header", function()
+            "build_www_authenticate_header", function()
                 it(
                     "should handle subpath template format", function()
                         bk_core.config.get_bk_apigateway_api_tmpl:revert()
@@ -193,7 +194,7 @@ describe(
                             end
                         )
 
-                        local header = plugin._build_www_authenticate_header(ctx)
+                        local header = oauth2.build_www_authenticate_header(ctx)
 
                         assert.is_not_nil(header)
                         local expected = 'resource_metadata="http://bkapi.example.com/api/bk-apigateway/prod/'
@@ -210,7 +211,7 @@ describe(
                             end
                         )
 
-                        local header = plugin._build_www_authenticate_header(ctx)
+                        local header = oauth2.build_www_authenticate_header(ctx)
 
                         assert.is_not_nil(header)
                         assert.is_truthy(
@@ -230,7 +231,7 @@ describe(
                             end
                         )
 
-                        local header = plugin._build_www_authenticate_header(ctx)
+                        local header = oauth2.build_www_authenticate_header(ctx)
 
                         assert.is_equal(
                             'Bearer realm="bk-apigateway", error="invalid_request", error_description="api tmpl is not configured"',
@@ -248,7 +249,7 @@ describe(
                             end
                         )
 
-                        local header = plugin._build_www_authenticate_header(ctx)
+                        local header = oauth2.build_www_authenticate_header(ctx)
 
                         assert.is_equal(
                             'Bearer realm="bk-apigateway", error="invalid_request", error_description="invalid api tmpl format"',
@@ -267,7 +268,7 @@ describe(
                         )
                         ctx.var.uri = "/api/v1/users?query=test"
 
-                        local header = plugin._build_www_authenticate_header(ctx)
+                        local header = oauth2.build_www_authenticate_header(ctx)
 
                         -- The resource URL should be URL encoded
                         -- Use plain text matching to avoid pattern issues with %2F

--- a/src/apisix/tests/test-bk-oauth2-verify.lua
+++ b/src/apisix/tests/test-bk-oauth2-verify.lua
@@ -48,16 +48,15 @@ describe(
                     end
                 )
 
-                stub(
-                    core.response, "set_header", function(...)
-                        local args = {...}
-                        local name = args[1]
-                        local value = args[2]
-                        if name == "WWW-Authenticate" then
+                ngx.header = {}
+                setmetatable(ngx.header, {
+                    __newindex = function(tbl, key, value)
+                        rawset(tbl, key, value)
+                        if key == "WWW-Authenticate" then
                             www_authenticate_header = value
                         end
-                    end
-                )
+                    end,
+                })
 
                 stub(
                     oauth2_cache, "get_oauth2_access_token", function(token)
@@ -79,7 +78,6 @@ describe(
         after_each(
             function()
                 core.request.header:revert()
-                core.response.set_header:revert()
                 oauth2_cache.get_oauth2_access_token:revert()
                 bk_core.config.get_bk_apigateway_api_tmpl:revert()
             end


### PR DESCRIPTION
## Summary
- Skip `result.code` check in `verify_oauth2_access_token` by adding a `check_code` parameter to `bkauth_do_request`, allowing the caller to handle non-zero response codes properly
- Update MCP audience prefix from `mcp_server:` to `mcp:` in `bk-oauth2-audience-validate` plugin
- Update all related unit tests and functional tests

## Test plan
- [ ] Run `make test-busted` to verify unit tests pass
- [ ] Run `make test-nginx CASE_FILE=bk-oauth2-audience-validate.t` to verify functional tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)