### PR TITLE
[1.23] feat(plugins): add bk-query-string-rewrite plugin

### DIFF
--- a/src/apisix/AGENTS.md
+++ b/src/apisix/AGENTS.md
@@ -1,6 +1,5 @@
 # AGENTS.md
 
-
 ### Plugin Architecture
 
 All BlueKing plugins follow the `bk-*` naming convention and execute in a specific priority order (17000-19000):
@@ -119,6 +118,13 @@ Notes:
 - In non-TTY environments, use `RUN_WITH_IT= make test`.
 
 ## Plugin Development Guidelines
+
+- You can read the other plugins source code and test code to help you write the new plugin and test code.
+
+### Plugin Isolation
+
+- New plugins MUST define their own schema and `check_schema` function inline. Do NOT import or depend on another plugin's schema, functions, or module.
+- Each plugin should be as self-contained as possible. Shared utilities from `bk-core/` are acceptable, but cross-plugin dependencies are not.
 
 ### Naming Conventions
 

--- a/src/apisix/plugins/README.md
+++ b/src/apisix/plugins/README.md
@@ -73,6 +73,7 @@ proxy 预处理：17000 ~ 17500
 - bk-default-tenant                         # priority: 17425
 - bk-stage-header-rewrite                   # priority: 17421
 - bk-resource-header-rewrite                # priority: 17420
+- bk-query-string-rewrite                   # priority: 17410
 - bk-mock                                   # priority: 17150
 
 官方插件：

--- a/src/apisix/plugins/bk-query-string-rewrite.lua
+++ b/src/apisix/plugins/bk-query-string-rewrite.lua
@@ -1,0 +1,121 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) 2025 Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+
+-- bk-query-string-rewrite
+--
+-- Rewrite the query string parameters of a request using the plugin configuration.
+-- - add:    add param only if it does NOT already exist
+-- - set:    always set the param value (add or replace)
+-- - remove: remove the param if it exists
+
+local core = require("apisix.core")
+local pairs = pairs
+local ipairs = ipairs
+local tostring = tostring
+
+local plugin_name = "bk-query-string-rewrite"
+
+local schema = {
+    type = "object",
+    description = "rewrite query string parameters",
+    minProperties = 1,
+    additionalProperties = false,
+    properties = {
+        add = {
+            type = "object",
+            patternProperties = {
+                ["^[^=&#?]+$"] = {
+                    oneOf = {
+                        {type = "string"},
+                        {type = "number"},
+                    },
+                },
+            },
+        },
+        set = {
+            type = "object",
+            patternProperties = {
+                ["^[^=&#?]+$"] = {
+                    oneOf = {
+                        {type = "string"},
+                        {type = "number"},
+                    },
+                },
+            },
+        },
+        remove = {
+            type = "array",
+            items = {
+                type = "string",
+                pattern = "^[^=&#?]+$",
+            },
+        },
+    },
+}
+
+local _M = {
+    version = 0.1,
+    priority = 17410,
+    name = plugin_name,
+    schema = schema,
+}
+
+
+function _M.check_schema(conf)
+    return core.schema.check(schema, conf)
+end
+
+
+function _M.rewrite(conf, ctx)
+    local uri_args = core.request.get_uri_args(ctx)
+    local changed = false
+
+    if conf.add then
+        for param, value in pairs(conf.add) do
+            -- if the param is not in the uri_args, then add it
+            -- otherwise, skip it
+            if uri_args[param] == nil then
+                uri_args[param] = core.utils.resolve_var(tostring(value), ctx.var)
+                changed = true
+            end
+        end
+    end
+
+    if conf.set then
+        for param, value in pairs(conf.set) do
+            uri_args[param] = core.utils.resolve_var(tostring(value), ctx.var)
+            changed = true
+        end
+    end
+
+    if conf.remove then
+        for _, param in ipairs(conf.remove) do
+            if uri_args[param] ~= nil then
+                uri_args[param] = nil
+                changed = true
+            end
+        end
+    end
+
+    if changed then
+        core.request.set_uri_args(ctx, uri_args)
+    end
+end
+
+
+return _M

--- a/src/apisix/t/bk-query-string-rewrite.t
+++ b/src/apisix/t/bk-query-string-rewrite.t
@@ -1,0 +1,314 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+}
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_shuffle();
+no_root_location();
+run_tests;
+
+__DATA__
+
+=== TEST 1: sanity - schema validation
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-query-string-rewrite")
+            local ok, err = plugin.check_schema({
+                set = {version = "v2"},
+                remove = {"debug"}
+            })
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+
+=== TEST 2: set route with set operation
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "bk-query-string-rewrite": {
+                            "set": {
+                                "version": "v2"
+                            }
+                        },
+                        "mocking": {
+                            "content_type": "text/plain",
+                            "response_status": 200,
+                            "response_example": "args:$args\n"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1982": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+=== TEST 3: set - adds new query param
+--- request
+GET /hello
+--- response_body
+args:version=v2
+
+=== TEST 4: set - replaces existing query param
+--- request
+GET /hello?version=v1
+--- response_body
+args:version=v2
+
+=== TEST 5: set - preserves other query params
+--- request
+GET /hello?existing=keep
+--- response_body_like
+args:(?=.*version=v2)(?=.*existing=keep).*
+
+=== TEST 6: set route with add operation
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "bk-query-string-rewrite": {
+                            "add": {
+                                "version": "v2"
+                            }
+                        },
+                        "mocking": {
+                            "content_type": "text/plain",
+                            "response_status": 200,
+                            "response_example": "args:$args\n"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1982": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+=== TEST 7: add - adds param when not present
+--- request
+GET /hello
+--- response_body
+args:version=v2
+
+=== TEST 8: add - skips param when already present
+--- request
+GET /hello?version=v1
+--- response_body
+args:version=v1
+
+=== TEST 9: set route with remove operation
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "bk-query-string-rewrite": {
+                            "remove": ["debug", "trace"]
+                        },
+                        "mocking": {
+                            "content_type": "text/plain",
+                            "response_status": 200,
+                            "response_example": "args:$args\n"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1982": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+=== TEST 10: remove - removes existing param
+--- request
+GET /hello?debug=1&keep=value
+--- response_body
+args:keep=value
+
+=== TEST 11: remove - removes multiple params
+--- request
+GET /hello?debug=1&trace=on&keep=value
+--- response_body
+args:keep=value
+
+=== TEST 12: remove - no-op when param not present
+--- request
+GET /hello?keep=value
+--- response_body
+args:keep=value
+
+=== TEST 13: set route with combined operations
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "bk-query-string-rewrite": {
+                            "add": {
+                                "added": "new"
+                            },
+                            "set": {
+                                "forced": "value"
+                            },
+                            "remove": ["unwanted"]
+                        },
+                        "mocking": {
+                            "content_type": "text/plain",
+                            "response_status": 200,
+                            "response_example": "args:$args\n"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1982": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+=== TEST 14: combined - add, set, and remove
+--- request
+GET /hello?unwanted=bye&existing=keep
+--- response_body_like
+args:(?=.*added=new)(?=.*forced=value)(?=.*existing=keep)(?!.*unwanted=).*
+
+=== TEST 15: combined - add skips existing, set replaces
+--- request
+GET /hello?added=original&forced=old&unwanted=bye
+--- response_body_like
+args:(?=.*added=original)(?=.*forced=value)(?!.*unwanted=).*
+
+=== TEST 16: disable plugin
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed

--- a/src/apisix/tests/test-bk-query-string-rewrite.lua
+++ b/src/apisix/tests/test-bk-query-string-rewrite.lua
@@ -1,0 +1,307 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) 2025 Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+
+local core = require("apisix.core")
+local plugin = require("apisix.plugins.bk-query-string-rewrite")
+
+describe(
+    "bk-query-string-rewrite", function()
+
+        local ctx
+        local uri_args
+
+        before_each(
+            function()
+                uri_args = {}
+                ctx = {
+                    var = {
+                        uri = "/path/value1/value2",
+                    },
+                    conf_id = "conf_id",
+                    conf_type = "conf_type",
+                }
+                stub(
+                    core.request, "get_uri_args", function()
+                        return uri_args
+                    end
+                )
+                stub(core.request, "set_uri_args")
+            end
+        )
+
+        after_each(
+            function()
+                core.request.get_uri_args:revert()
+                core.request.set_uri_args:revert()
+            end
+        )
+
+        context(
+            "add", function()
+
+                it(
+                    "adds param when not present", function()
+                        uri_args = {}
+                        local conf = {
+                            add = {
+                                version = "v2",
+                            },
+                        }
+                        plugin.rewrite(conf, ctx)
+                        assert.stub(core.request.set_uri_args).was_called_with(
+                            ctx, {
+                                version = "v2",
+                            }
+                        )
+                    end
+                )
+
+                it(
+                    "skips param when already present", function()
+                        uri_args = {
+                            version = "v1",
+                        }
+                        local conf = {
+                            add = {
+                                version = "v2",
+                            },
+                        }
+                        plugin.rewrite(conf, ctx)
+                        assert.stub(core.request.set_uri_args).was_not_called()
+                    end
+                )
+
+                it(
+                    "adds multiple params, skips existing ones", function()
+                        uri_args = {
+                            existing = "old",
+                        }
+                        local conf = {
+                            add = {
+                                existing = "new",
+                                added = "value",
+                            },
+                        }
+                        plugin.rewrite(conf, ctx)
+                        assert.stub(core.request.set_uri_args).was_called_with(
+                            ctx, {
+                                existing = "old",
+                                added = "value",
+                            }
+                        )
+                    end
+                )
+            end
+        )
+
+        context(
+            "set", function()
+
+                it(
+                    "sets new param", function()
+                        uri_args = {}
+                        local conf = {
+                            set = {
+                                version = "v2",
+                            },
+                        }
+                        plugin.rewrite(conf, ctx)
+                        assert.stub(core.request.set_uri_args).was_called_with(
+                            ctx, {
+                                version = "v2",
+                            }
+                        )
+                    end
+                )
+
+                it(
+                    "replaces existing param", function()
+                        uri_args = {
+                            version = "v1",
+                            other = "keep",
+                        }
+                        local conf = {
+                            set = {
+                                version = "v2",
+                            },
+                        }
+                        plugin.rewrite(conf, ctx)
+                        assert.stub(core.request.set_uri_args).was_called_with(
+                            ctx, {
+                                version = "v2",
+                                other = "keep",
+                            }
+                        )
+                    end
+                )
+            end
+        )
+
+        context(
+            "remove", function()
+
+                it(
+                    "removes existing param", function()
+                        uri_args = {
+                            toremove = "value",
+                            keep = "value",
+                        }
+                        local conf = {
+                            remove = {"toremove"},
+                        }
+                        plugin.rewrite(conf, ctx)
+                        assert.stub(core.request.set_uri_args).was_called_with(
+                            ctx, {
+                                keep = "value",
+                            }
+                        )
+                    end
+                )
+
+                it(
+                    "no-op when param does not exist", function()
+                        uri_args = {
+                            keep = "value",
+                        }
+                        local conf = {
+                            remove = {"nonexistent"},
+                        }
+                        plugin.rewrite(conf, ctx)
+                        assert.stub(core.request.set_uri_args).was_not_called()
+                    end
+                )
+            end
+        )
+
+        context(
+            "combined operations", function()
+
+                it(
+                    "add, set, and remove together", function()
+                        uri_args = {
+                            existing = "old",
+                            toremove = "bye",
+                        }
+                        local conf = {
+                            add = {
+                                existing = "should-skip",
+                                added = "new",
+                            },
+                            set = {
+                                forced = "value",
+                            },
+                            remove = {"toremove"},
+                        }
+                        plugin.rewrite(conf, ctx)
+                        assert.stub(core.request.set_uri_args).was_called_with(
+                            ctx, {
+                                existing = "old",
+                                added = "new",
+                                forced = "value",
+                            }
+                        )
+                    end
+                )
+            end
+        )
+
+        context(
+            "no changes", function()
+
+                it(
+                    "does not call set_uri_args when nothing changes", function()
+                        uri_args = {
+                            existing = "value",
+                        }
+                        local conf = {
+                            add = {
+                                existing = "skip",
+                            },
+                            remove = {"nonexistent"},
+                        }
+                        plugin.rewrite(conf, ctx)
+                        assert.stub(core.request.set_uri_args).was_not_called()
+                    end
+                )
+            end
+        )
+
+        context(
+            "variable resolution", function()
+
+                it(
+                    "resolves variables in set values", function()
+                        uri_args = {}
+                        ctx.var.uri = "/test/path"
+                        local conf = {
+                            set = {
+                                current_uri = "$uri",
+                            },
+                        }
+                        plugin.rewrite(conf, ctx)
+                        assert.stub(core.request.set_uri_args).was_called_with(
+                            ctx, {
+                                current_uri = "/test/path",
+                            }
+                        )
+                    end
+                )
+
+                it(
+                    "resolves variables in add values", function()
+                        uri_args = {}
+                        ctx.var.uri = "/test/path"
+                        local conf = {
+                            add = {
+                                current_uri = "$uri",
+                            },
+                        }
+                        plugin.rewrite(conf, ctx)
+                        assert.stub(core.request.set_uri_args).was_called_with(
+                            ctx, {
+                                current_uri = "/test/path",
+                            }
+                        )
+                    end
+                )
+            end
+        )
+
+        context(
+            "number values", function()
+
+                it(
+                    "converts number values to string", function()
+                        uri_args = {}
+                        local conf = {
+                            set = {
+                                count = 42,
+                            },
+                        }
+                        plugin.rewrite(conf, ctx)
+                        assert.stub(core.request.set_uri_args).was_called_with(
+                            ctx, {
+                                count = "42",
+                            }
+                        )
+                    end
+                )
+            end
+        )
+    end
+)


### PR DESCRIPTION
## Summary

- Add new `bk-query-string-rewrite` plugin (priority 17410) that rewrites request query string parameters with three operations:
  - **add**: adds param only if it does NOT already exist
  - **set**: always sets the param value (add or replace)
  - **remove**: removes the param if it exists
- Add plugin isolation guideline to AGENTS.md: new plugins must define their own schema inline, no cross-plugin dependencies

## Test plan

- [x] Busted unit tests: 720/720 pass (test-bk-query-string-rewrite.lua covers add/set/remove, combined ops, variable resolution, number conversion, no-op detection)
- [x] Test-nginx functional tests: 51/51 pass (bk-query-string-rewrite.t covers schema validation, each operation via HTTP requests, combined operations)
- [x] Luacheck lint: 0 warnings / 0 errors


Made with [Cursor](https://cursor.com)