### PR TITLE
[1.23] feat(plugins): add bk-tenant-validate-exempt plugin

### DIFF
--- a/src/apisix/plugins/README.md
+++ b/src/apisix/plugins/README.md
@@ -52,6 +52,7 @@
 - bk-auth-validate                          # priority: 17680
 - bk-user-restriction                       # priority: 17679
 - bk-oauth2-audience-validate               # priority: 17678  # OAuth2 audience 验证：验证 MCP 服务器和网关 API 的 audience 声明
+- bk-tenant-validate-exempt                 # priority: 17676  # 如果资源配置了此插件, 则跳过 bk-tenant-validate 校验
 - bk-tenant-verify                          # priority: 17675
 - bk-tenant-validate                        # priority: 17674
 - bk-jwt                                    # priority: 17670

--- a/src/apisix/plugins/bk-tenant-validate-exempt.lua
+++ b/src/apisix/plugins/bk-tenant-validate-exempt.lua
@@ -1,0 +1,49 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) 2025 Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+
+-- # bk-tenant-validate-exempt
+--
+-- When this plugin is attached to a resource, it exempts the resource from
+-- bk-tenant-validate checks by setting a skip flag in the request context.
+
+local core = require("apisix.core")
+
+local plugin_name = "bk-tenant-validate-exempt"
+local schema = {
+    type = "object",
+    properties = {},
+}
+
+local _M = {
+    version = 0.1,
+    priority = 17676,
+    name = plugin_name,
+    schema = schema,
+}
+
+
+function _M.check_schema(conf)
+    return core.schema.check(schema, conf)
+end
+
+
+function _M.rewrite(conf, ctx) -- luacheck: ignore
+    ctx.var.bk_skip_tenant_validate = true
+end
+
+return _M

--- a/src/apisix/plugins/bk-tenant-validate.lua
+++ b/src/apisix/plugins/bk-tenant-validate.lua
@@ -155,6 +155,10 @@ local function validate_header_tenant_id(ctx, gateway_tenant_mode, gateway_tenan
 end
 
 function _M.rewrite(conf, ctx) -- luacheck: ignore
+    if ctx.var.bk_skip_tenant_validate then
+        return
+    end
+
     local gateway_tenant_mode = conf.tenant_mode
     local gateway_tenant_id = conf.tenant_id
 

--- a/src/apisix/t/bk-tenant-validate-exempt.t
+++ b/src/apisix/t/bk-tenant-validate-exempt.t
@@ -1,0 +1,120 @@
+
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) 2025 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+}
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_shuffle();
+no_root_location();
+run_tests;
+
+__DATA__
+
+=== TEST 1: sanity
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-tenant-validate-exempt")
+            local ok, err = plugin.check_schema({})
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+
+=== TEST 2: set bk_skip_tenant_validate in ctx
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-tenant-validate-exempt")
+            local ctx = {
+                var = {},
+            }
+            plugin.rewrite({}, ctx)
+            if ctx.var.bk_skip_tenant_validate then
+                ngx.say("skip_tenant_validate: true")
+            else
+                ngx.say("skip_tenant_validate: false")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+skip_tenant_validate: true
+
+=== TEST 3: add route with both exempt and validate plugins
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "bk-tenant-validate-exempt": {},
+                        "bk-tenant-validate": {
+                            "tenant_mode": "single",
+                            "tenant_id": "tenant_a"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+=== TEST 4: request should pass tenant validate when exempt is present
+Cross-tenant header would normally be rejected, but exempt skips the validate check.
+--- request
+GET /hello HTTP/1.1
+--- more_headers
+X-Bk-Tenant-Id: different_tenant
+--- response_status: 200

--- a/src/apisix/tests/test-bk-tenant-validate-exempt.lua
+++ b/src/apisix/tests/test-bk-tenant-validate-exempt.lua
@@ -1,0 +1,40 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) 2025 Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+local plugin = require("apisix.plugins.bk-tenant-validate-exempt")
+
+describe("bk-tenant-validate-exempt", function()
+
+    context("check_schema", function()
+        it("should accept empty config", function()
+            local ok, err = plugin.check_schema({})
+            assert.is_truthy(ok)
+            assert.is_nil(err)
+        end)
+    end)
+
+    context("rewrite", function()
+        it("should set bk_skip_tenant_validate to true", function()
+            local ctx = {
+                var = {},
+            }
+            plugin.rewrite({}, ctx)
+            assert.is_true(ctx.var.bk_skip_tenant_validate)
+        end)
+    end)
+
+end)

--- a/src/apisix/tests/test-bk-tenant-validate.lua
+++ b/src/apisix/tests/test-bk-tenant-validate.lua
@@ -286,6 +286,12 @@ describe("bk-tenant-validate", function()
 
         end)
 
+        it("should skip when bk_skip_tenant_validate is true", function()
+            ctx.var.bk_skip_tenant_validate = true
+            local err = validate.rewrite(conf, ctx)
+            assert.is_nil(err)
+        end)
+
         after_each(function()
         end)
 

--- a/src/apisix/typing.lua
+++ b/src/apisix/typing.lua
@@ -145,6 +145,7 @@
 ---@field bk_backend_id integer|nil 网关后端 ID
 ---@field bk_backend_name string|nil 网关后端名称
 ---@field bk_skip_error_wrapper boolean|nil 是否跳过错误拦截器
+---@field bk_skip_tenant_validate boolean|nil 是否跳过租户校验
 ---@field bk_status_rewrite_200 boolean|nil 是否重写 200 状态码
 ---@field bk_api_auth bk_gateway.ApiAuth|nil 应用认证配置
 ---@field bk_resource_auth bk_gateway.ResourceAuth|nil 资源权限配置


### PR DESCRIPTION
## Summary

- Add new `bk-tenant-validate-exempt` plugin (priority: 17676) that allows specific resources to opt out of tenant validation
- When attached to a resource, it sets `ctx.var.bk_skip_tenant_validate = true`, causing `bk-tenant-validate` to skip its cross-tenant checks
- Follows the existing `bk_skip_error_wrapper` pattern used by `bk-mock` and `bk-error-wrapper`

## Changes

| File | Change |
|---|---|
| `plugins/bk-tenant-validate-exempt.lua` | New plugin |
| `plugins/bk-tenant-validate.lua` | Check `bk_skip_tenant_validate` flag at start of `rewrite()` |
| `plugins/README.md` | Register new plugin at priority 17676 |
| `typing.lua` | Add `bk_skip_tenant_validate` context variable type |
| `tests/test-bk-tenant-validate-exempt.lua` | Busted unit tests |
| `tests/test-bk-tenant-validate.lua` | Added skip behavior test case |
| `t/bk-tenant-validate-exempt.t` | test-nginx functional tests |

## Test plan

- [x] Busted unit tests pass (711/711)
- [x] test-nginx functional tests pass (27 files, 593 tests)
- [x] `make test` all green


Made with [Cursor](https://cursor.com)