### PR TITLE
fix(oauth2): strip rewritten subpath prefix in oauth2 resource URL

### DIFF
--- a/src/apisix/plugins/bk-core/config.lua
+++ b/src/apisix/plugins/bk-core/config.lua
@@ -132,6 +132,23 @@ function _M.get_enable_multi_tenant_mode()
     return enable_multi_tenant_mode
 end
 
+function _M.should_strip_subpath_prefix()
+    local conf = core.config.local_conf()
+    local strip_subpath_prefix = core.table.try_read_attr(conf, "bk_gateway", "strip_subpath_prefix")
+    if strip_subpath_prefix == nil then
+        return false
+    end
+
+    if type(strip_subpath_prefix) == "boolean" then
+        return strip_subpath_prefix
+    end
+
+    if type(strip_subpath_prefix) == "string" then
+        return string_lower(strip_subpath_prefix) == "true"
+    end
+
+    return false
+end
 
 function _M.is_cache_disabled()
     local conf = core.config.local_conf()

--- a/src/apisix/plugins/bk-core/oauth2.lua
+++ b/src/apisix/plugins/bk-core/oauth2.lua
@@ -22,8 +22,30 @@ local ngx_escape_uri = ngx.escape_uri
 local string_match = string.match
 local string_gsub = string.gsub
 local string_format = string.format
+local string_sub = string.sub
+local string_len = string.len
 
 local _M = {}
+
+
+local function strip_subpath_prefix(path, gateway_name)
+    local prefix = "/api/" .. gateway_name
+    local prefix_len = string_len(prefix)
+    if string_sub(path, 1, prefix_len) ~= prefix then
+        return path
+    end
+
+    local next_char = string_sub(path, prefix_len + 1, prefix_len + 1)
+    if next_char ~= "" and next_char ~= "/" then
+        return path
+    end
+
+    path = string_sub(path, prefix_len + 1)
+    if path == "" then
+        path = "/"
+    end
+    return path
+end
 
 
 local function escape_auth_header_value(value)
@@ -69,6 +91,12 @@ function _M.build_www_authenticate_header(ctx, error_code, error_description)
 
     -- Step 3: Build the resource path and encode it
     local path = (ctx and ctx.var and ctx.var.uri) or "/"
+
+    -- In some envs, nginx rewrites subdomain to subpath, so the path has an extra /api/{gateway_name} prefix
+    -- e.g. /api/bk-apigateway/prod/api/v2/... should be /prod/api/v2/...
+    if config.should_strip_subpath_prefix() then
+        path = strip_subpath_prefix(path, gateway_name)
+    end
     local resource_url = rendered_origin .. path
     local encoded_resource_url = ngx_escape_uri(resource_url)
 
@@ -94,6 +122,7 @@ end
 
 if _TEST then -- luacheck: ignore
     _M._escape_auth_header_value = escape_auth_header_value
+    _M._strip_subpath_prefix = strip_subpath_prefix
 end
 
 return _M

--- a/src/apisix/t/bk-oauth2-protected-resource.t
+++ b/src/apisix/t/bk-oauth2-protected-resource.t
@@ -128,3 +128,105 @@ Authorization: Basic dXNlcjpwYXNz
 --- error_code: 401
 --- response_headers_like
 WWW-Authenticate: Bearer .*
+
+=== TEST 8: should strip /api/{gateway_name} prefix when enabled
+--- config
+    location /t {
+        content_by_lua_block {
+            local bk_core = require("apisix.plugins.bk-core.init")
+            local oauth2 = require("apisix.plugins.bk-core.oauth2")
+            local old_get_tmpl = bk_core.config.get_bk_apigateway_api_tmpl
+            local old_should_strip = bk_core.config.should_strip_subpath_prefix
+
+            bk_core.config.get_bk_apigateway_api_tmpl = function()
+                return "http://{api_name}.bkapi.example.com"
+            end
+            bk_core.config.should_strip_subpath_prefix = function()
+                return true
+            end
+
+            local header = oauth2.build_www_authenticate_header({
+                var = {
+                    bk_gateway_name = "bk-apigateway",
+                    uri = "/api/bk-apigateway/prod/api/v2/mcp-servers/bk-apigateway-prod-debugger/mcp/",
+                },
+            }, "invalid_request", "no valid authentication header found")
+
+            bk_core.config.get_bk_apigateway_api_tmpl = old_get_tmpl
+            bk_core.config.should_strip_subpath_prefix = old_should_strip
+
+            ngx.say(header)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+resource=http%3A%2F%2Fbk-apigateway.bkapi.example.com%2Fprod%2Fapi%2Fv2%2Fmcp-servers%2Fbk-apigateway-prod-debugger%2Fmcp%2F.*
+
+=== TEST 9: should not strip prefix when disabled
+--- config
+    location /t {
+        content_by_lua_block {
+            local bk_core = require("apisix.plugins.bk-core.init")
+            local oauth2 = require("apisix.plugins.bk-core.oauth2")
+            local old_get_tmpl = bk_core.config.get_bk_apigateway_api_tmpl
+            local old_should_strip = bk_core.config.should_strip_subpath_prefix
+
+            bk_core.config.get_bk_apigateway_api_tmpl = function()
+                return "http://{api_name}.bkapi.example.com"
+            end
+            bk_core.config.should_strip_subpath_prefix = function()
+                return false
+            end
+
+            local header = oauth2.build_www_authenticate_header({
+                var = {
+                    bk_gateway_name = "bk-apigateway",
+                    uri = "/api/bk-apigateway/prod/api/v2/mcp-servers/bk-apigateway-prod-debugger/mcp/",
+                },
+            }, "invalid_request", "no valid authentication header found")
+
+            bk_core.config.get_bk_apigateway_api_tmpl = old_get_tmpl
+            bk_core.config.should_strip_subpath_prefix = old_should_strip
+
+            ngx.say(header)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+resource=http%3A%2F%2Fbk-apigateway.bkapi.example.com%2Fapi%2Fbk-apigateway%2Fprod%2Fapi%2Fv2%2Fmcp-servers%2Fbk-apigateway-prod-debugger%2Fmcp%2F.*
+
+=== TEST 10: should not strip partial gateway name prefix
+--- config
+    location /t {
+        content_by_lua_block {
+            local bk_core = require("apisix.plugins.bk-core.init")
+            local oauth2 = require("apisix.plugins.bk-core.oauth2")
+            local old_get_tmpl = bk_core.config.get_bk_apigateway_api_tmpl
+            local old_should_strip = bk_core.config.should_strip_subpath_prefix
+
+            bk_core.config.get_bk_apigateway_api_tmpl = function()
+                return "http://{api_name}.bkapi.example.com"
+            end
+            bk_core.config.should_strip_subpath_prefix = function()
+                return true
+            end
+
+            local header = oauth2.build_www_authenticate_header({
+                var = {
+                    bk_gateway_name = "bk-apigateway",
+                    uri = "/api/bk-apigateway-extra/prod/api/v2/mcp-servers",
+                },
+            }, "invalid_request", "no valid authentication header found")
+
+            bk_core.config.get_bk_apigateway_api_tmpl = old_get_tmpl
+            bk_core.config.should_strip_subpath_prefix = old_should_strip
+
+            ngx.say(header)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+resource=http%3A%2F%2Fbk-apigateway.bkapi.example.com%2Fapi%2Fbk-apigateway-extra%2Fprod%2Fapi%2Fv2%2Fmcp-servers.*

--- a/src/apisix/tests/test-bk-core-config.lua
+++ b/src/apisix/tests/test-bk-core-config.lua
@@ -1,0 +1,112 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) 2025 Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+local core = require("apisix.core")
+local bk_core = require("apisix.plugins.bk-core.init")
+
+describe(
+    "bk-core.config", function()
+        after_each(
+            function()
+                if core.config.local_conf.revert then
+                    core.config.local_conf:revert()
+                end
+            end
+        )
+
+        context(
+            "should_strip_subpath_prefix", function()
+                it(
+                    "should return false when value is nil", function()
+                        stub(
+                            core.config, "local_conf", function()
+                                return { bk_gateway = {} }
+                            end
+                        )
+                        assert.is_false(bk_core.config.should_strip_subpath_prefix())
+                    end
+                )
+
+                it(
+                    "should return boolean true as-is", function()
+                        stub(
+                            core.config, "local_conf", function()
+                                return { bk_gateway = { strip_subpath_prefix = true } }
+                            end
+                        )
+                        assert.is_true(bk_core.config.should_strip_subpath_prefix())
+                    end
+                )
+
+                it(
+                    "should return boolean false as-is", function()
+                        stub(
+                            core.config, "local_conf", function()
+                                return { bk_gateway = { strip_subpath_prefix = false } }
+                            end
+                        )
+                        assert.is_false(bk_core.config.should_strip_subpath_prefix())
+                    end
+                )
+
+                it(
+                    "should parse lowercase true string", function()
+                        stub(
+                            core.config, "local_conf", function()
+                                return { bk_gateway = { strip_subpath_prefix = "true" } }
+                            end
+                        )
+                        assert.is_true(bk_core.config.should_strip_subpath_prefix())
+                    end
+                )
+
+                it(
+                    "should parse uppercase true string", function()
+                        stub(
+                            core.config, "local_conf", function()
+                                return { bk_gateway = { strip_subpath_prefix = "TRUE" } }
+                            end
+                        )
+                        assert.is_true(bk_core.config.should_strip_subpath_prefix())
+                    end
+                )
+
+                it(
+                    "should parse false string as false", function()
+                        stub(
+                            core.config, "local_conf", function()
+                                return { bk_gateway = { strip_subpath_prefix = "false" } }
+                            end
+                        )
+                        assert.is_false(bk_core.config.should_strip_subpath_prefix())
+                    end
+                )
+
+                it(
+                    "should return false for unexpected value types", function()
+                        stub(
+                            core.config, "local_conf", function()
+                                return { bk_gateway = { strip_subpath_prefix = 1 } }
+                            end
+                        )
+                        assert.is_false(bk_core.config.should_strip_subpath_prefix())
+                    end
+                )
+            end
+        )
+    end
+)

--- a/src/apisix/tests/test-bk-core-oauth2.lua
+++ b/src/apisix/tests/test-bk-core-oauth2.lua
@@ -36,12 +36,19 @@ describe(
                         return "http://bkapi.example.com/api/{api_name}"
                     end
                 )
+
+                stub(
+                    bk_core.config, "should_strip_subpath_prefix", function()
+                        return false
+                    end
+                )
             end
         )
 
         after_each(
             function()
                 bk_core.config.get_bk_apigateway_api_tmpl:revert()
+                bk_core.config.should_strip_subpath_prefix:revert()
             end
         )
 
@@ -86,6 +93,61 @@ describe(
                     "should escape both backslashes and double quotes", function()
                         local result = oauth2._escape_auth_header_value('a\\"b')
                         assert.is_equal('a\\\\\\"b', result)
+                    end
+                )
+            end
+        )
+
+        context(
+            "strip_subpath_prefix", function()
+                it(
+                    "should strip /api/{gateway_name} prefix from path", function()
+                        local result = oauth2._strip_subpath_prefix("/api/demo/prod/api/v2/users", "demo")
+                        assert.is_equal("/prod/api/v2/users", result)
+                    end
+                )
+
+                it(
+                    "should return / when path equals the prefix exactly", function()
+                        local result = oauth2._strip_subpath_prefix("/api/demo", "demo")
+                        assert.is_equal("/", result)
+                    end
+                )
+
+                it(
+                    "should not strip when path does not start with prefix", function()
+                        local result = oauth2._strip_subpath_prefix("/prod/api/v2/users", "demo")
+                        assert.is_equal("/prod/api/v2/users", result)
+                    end
+                )
+
+                it(
+                    "should not strip partial gateway name match", function()
+                        local result = oauth2._strip_subpath_prefix("/api/demo-extra/prod", "demo")
+                        assert.is_equal("/api/demo-extra/prod", result)
+                    end
+                )
+
+                it(
+                    "should handle path with only slash after prefix", function()
+                        local result = oauth2._strip_subpath_prefix("/api/demo/", "demo")
+                        assert.is_equal("/", result)
+                    end
+                )
+
+                it(
+                    "should handle gateway name with hyphens", function()
+                        local result = oauth2._strip_subpath_prefix(
+                            "/api/bk-apigateway/prod/api/v2/mcp-servers", "bk-apigateway"
+                        )
+                        assert.is_equal("/prod/api/v2/mcp-servers", result)
+                    end
+                )
+
+                it(
+                    "should return path unchanged when prefix is for different gateway", function()
+                        local result = oauth2._strip_subpath_prefix("/api/other-gw/prod", "demo")
+                        assert.is_equal("/api/other-gw/prod", result)
                     end
                 )
             end
@@ -346,6 +408,82 @@ describe(
                         -- The resource URL should end with just the origin + "/"
                         assert.is_truthy(
                             string.find(header, "resource_metadata=", 1, true)
+                        )
+                    end
+                )
+            end
+        )
+
+        context(
+            "build_www_authenticate_header - subpath prefix stripping", function()
+                it(
+                    "should strip /api/{gateway_name} from path when enabled", function()
+                        bk_core.config.should_strip_subpath_prefix:revert()
+                        stub(
+                            bk_core.config, "should_strip_subpath_prefix", function()
+                                return true
+                            end
+                        )
+                        bk_core.config.get_bk_apigateway_api_tmpl:revert()
+                        stub(
+                            bk_core.config, "get_bk_apigateway_api_tmpl", function()
+                                return "http://{api_name}.bkapi.example.com"
+                            end
+                        )
+                        ctx.var.bk_gateway_name = "bk-apigateway"
+                        ctx.var.uri = "/api/bk-apigateway/prod/api/v2/mcp-servers"
+
+                        local header = oauth2.build_www_authenticate_header(ctx)
+
+                        -- The resource URL should NOT contain /api/bk-apigateway prefix
+                        assert.is_truthy(
+                            string.find(
+                                header,
+                                "bk-apigateway.bkapi.example.com%2Fprod%2Fapi%2Fv2%2Fmcp-servers",
+                                1, true
+                            )
+                        )
+                    end
+                )
+
+                it(
+                    "should not strip when config is disabled", function()
+                        ctx.var.bk_gateway_name = "demo"
+                        ctx.var.uri = "/api/demo/prod/api/v2/users"
+
+                        local header = oauth2.build_www_authenticate_header(ctx)
+
+                        -- The resource URL should still contain /api/demo
+                        assert.is_truthy(
+                            string.find(
+                                header,
+                                "%2Fapi%2Fdemo%2Fprod%2Fapi%2Fv2%2Fusers",
+                                1, true
+                            )
+                        )
+                    end
+                )
+
+                it(
+                    "should not strip when path does not match gateway prefix", function()
+                        bk_core.config.should_strip_subpath_prefix:revert()
+                        stub(
+                            bk_core.config, "should_strip_subpath_prefix", function()
+                                return true
+                            end
+                        )
+                        ctx.var.bk_gateway_name = "demo"
+                        ctx.var.uri = "/other/path/prod"
+
+                        local header = oauth2.build_www_authenticate_header(ctx)
+
+                        -- Path should remain unchanged
+                        assert.is_truthy(
+                            string.find(
+                                header,
+                                "%2Fother%2Fpath%2Fprod",
+                                1, true
+                            )
                         )
                     end
                 )


### PR DESCRIPTION
## Summary
- Add `bk_core.config.should_strip_subpath_prefix()` and normalize bool/string values safely.
- Strip rewritten `/api/{gateway_name}` prefix from OAuth2 `resource` URL when enabled.
- Add unit tests and test-nginx cases for enabled/disabled and partial-match boundary behavior.

## Test plan
- [x] `RUN_WITH_IT= make test-busted`
- [x] `RUN_WITH_IT= make test-nginx CASE_FILE=bk-oauth2-protected-resource.t`

Made with [Cursor](https://cursor.com)