### PR TITLE
[1.22.x] fix(error-wrapper): refine upstream error phase detection

### DIFF
--- a/.code.yml
+++ b/.code.yml
@@ -1,0 +1,9 @@
+source:
+  test_source:
+    # the busted and nginx tests
+    filepath_regex: [".*/src/apisix/t/.*", ".*/src/apisix/tests/.*", ".*/src/apisix/editions/ee/tests/.*"]
+  auto_generate_source:
+    filepath_regex:
+  third_party_source:
+    # this is the submodule of official apache/apisix repo
+    filepath_regex: [".*/src/apisix-core/.*"]

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ src/apisix/edition-metadata.json
 build.yml
 .lua_modules
 
+# agent
+.claude
+.cursor
+.specify

--- a/src/apisix/plugins/bk-core/config.lua
+++ b/src/apisix/plugins/bk-core/config.lua
@@ -132,6 +132,23 @@ function _M.get_enable_multi_tenant_mode()
     return enable_multi_tenant_mode
 end
 
+function _M.should_strip_subpath_prefix()
+    local conf = core.config.local_conf()
+    local strip_subpath_prefix = core.table.try_read_attr(conf, "bk_gateway", "strip_subpath_prefix")
+    if strip_subpath_prefix == nil then
+        return false
+    end
+
+    if type(strip_subpath_prefix) == "boolean" then
+        return strip_subpath_prefix
+    end
+
+    if type(strip_subpath_prefix) == "string" then
+        return string_lower(strip_subpath_prefix) == "true"
+    end
+
+    return false
+end
 
 function _M.is_cache_disabled()
     local conf = core.config.local_conf()

--- a/src/apisix/plugins/bk-core/oauth2.lua
+++ b/src/apisix/plugins/bk-core/oauth2.lua
@@ -22,8 +22,30 @@ local ngx_escape_uri = ngx.escape_uri
 local string_match = string.match
 local string_gsub = string.gsub
 local string_format = string.format
+local string_sub = string.sub
+local string_len = string.len
 
 local _M = {}
+
+
+local function strip_subpath_prefix(path, gateway_name)
+    local prefix = "/api/" .. gateway_name
+    local prefix_len = string_len(prefix)
+    if string_sub(path, 1, prefix_len) ~= prefix then
+        return path
+    end
+
+    local next_char = string_sub(path, prefix_len + 1, prefix_len + 1)
+    if next_char ~= "" and next_char ~= "/" then
+        return path
+    end
+
+    path = string_sub(path, prefix_len + 1)
+    if path == "" then
+        path = "/"
+    end
+    return path
+end
 
 
 local function escape_auth_header_value(value)
@@ -69,6 +91,12 @@ function _M.build_www_authenticate_header(ctx, error_code, error_description)
 
     -- Step 3: Build the resource path and encode it
     local path = (ctx and ctx.var and ctx.var.uri) or "/"
+
+    -- In some envs, nginx rewrites subdomain to subpath, so the path has an extra /api/{gateway_name} prefix
+    -- e.g. /api/bk-apigateway/prod/api/v2/... should be /prod/api/v2/...
+    if config.should_strip_subpath_prefix() then
+        path = strip_subpath_prefix(path, gateway_name)
+    end
     local resource_url = rendered_origin .. path
     local encoded_resource_url = ngx_escape_uri(resource_url)
 
@@ -94,6 +122,7 @@ end
 
 if _TEST then -- luacheck: ignore
     _M._escape_auth_header_value = escape_auth_header_value
+    _M._strip_subpath_prefix = strip_subpath_prefix
 end
 
 return _M

--- a/src/apisix/plugins/bk-core/proxy_phases.lua
+++ b/src/apisix/plugins/bk-core/proxy_phases.lua
@@ -21,6 +21,6 @@ return {
     PROXYING = "proxing",
     CONNECTING = "connecting",
     HEADER_WAITING = "header-waiting",
-    HEAEDER_RECEIVING = "header-receiving",
+    HEADER_RECEIVING = "header-receiving",
     FINISH = "finish",
 }

--- a/src/apisix/plugins/bk-error-wrapper.lua
+++ b/src/apisix/plugins/bk-error-wrapper.lua
@@ -80,21 +80,30 @@ local function _get_upstream_error_msg(ctx)
     local ngx_status = ngx.status
 
     if ngx_status >= 500 and ngx_status <= 599 then
+        -- keeps time spent on establishing a connection with the upstream server
+        -- 0 if keep-alive is used
         local upstream_connect_time = ctx.var.upstream_connect_time or 0
+        -- keeps time spent on receiving the response header from the upstream server
         local upstream_header_time = ctx.var.upstream_header_time or 0
+        -- keeps time spent on receiving the response from the upstream server
         local upstream_response_time = ctx.var.upstream_response_time or 0
+        -- number of bytes sent to an upstream server
         local upstream_bytes_sent = bk_upstream.get_last_upstream_bytes_sent(ctx)
+        -- number of bytes received from an upstream server
         local upstream_bytes_received = bk_upstream.get_last_upstream_bytes_received(ctx)
 
         if ngx_status == 502 then
             if upstream_connect_time == 0 then
-                if upstream_bytes_sent == 0 then
+                -- 连接建立耗时为0，且什么都没发， 什么也没收到 → 连接直接被拒绝
+                if upstream_bytes_sent == 0 and upstream_bytes_received == 0 then
                     -- connect() failed (111: Connection refused) while connecting to upstream
                     return proxy_phases.CONNECTING, "connection refused"
                 end
             else
                 -- upstream_connect_time is ok, connected
                 if upstream_bytes_sent > 0 and upstream_bytes_received == 0 then
+                    -- 成功建立连接并发送了请求，但收到 0 字节响应
+                    -- → upstream 在响应前就 RST 或关闭了连接
                     -- readv() failed (104: Connection reset by peer) while reading upstream
                     -- recv() failed (104: Connection reset by peer) while reading response header from upstream
                     -- upstream prematurely closed connection while reading upstream
@@ -103,14 +112,32 @@ local function _get_upstream_error_msg(ctx)
                         "connection reset by peer OR upstream prematurely closed connection"
                 end
 
+                -- legacy logical moved here:
+                -- upstream_connect_time > 0 and upstream_bytes_received == 0 => "cannot read header from upstream"
+                if upstream_bytes_received == 0 then
+                    return proxy_phases.HEADER_WAITING, "cannot read header from upstream"
+                end
+
+                if upstream_bytes_received > 0 and upstream_header_time == 0 then
+                    -- 收到了一些字节，但 header 始终没有完整解析出来
+                    -- 可能是：upstream 发了一半就断了，或者响应不是合法 HTTP
+                    return proxy_phases.HEADER_RECEIVING,
+                        "cannot read header from upstream OR upstream prematurely closed connection"
+                end
+
             end
         end
 
         if ngx_status == 504 then
             if upstream_bytes_sent == 0 then
+                -- 什么都没发出去 → 连接阶段就超时了
+                -- nginx error: upstream timed out (110: Connection timed out) while connecting to upstream
                 return proxy_phases.CONNECTING, "connection timed out while connecting to upstream"
             end
             if upstream_bytes_sent > 0 and upstream_bytes_received == 0 then
+                -- 连上了、发了请求，但一个字节响应都没收到 → 等 header 超时
+                -- nginx error: upstream timed out (110: Connection timed out)
+                --              while reading response header from upstream
                 return proxy_phases.HEADER_WAITING,
                     "connection timed out while reading response header from upstream OR reading upstream"
             end
@@ -130,6 +157,7 @@ local function _get_upstream_error_msg(ctx)
 
     -- the legacy logical
     if not ctx.var.upstream_connect_time then -- 握手失败
+        -- NOTE: 线上没有命中这个的记录
         return proxy_phases.CONNECTING, "failed to connect to upstream"
     -- note: 此处删掉对$upstream_bytes_sent判断的原因是
     -- 在header_filter阶段，upstream_bytes_sent只生效与响应头读取失败的情况响应头成功读取时,
@@ -137,9 +165,13 @@ local function _get_upstream_error_msg(ctx)
     -- elseif not pl_types.to_bool(bk_upstream.get_last_upstream_bytes_sent()) then -- 握手成功，发送请求失败
     --     upstream_error_msg = "cannot send request to upstream"
     elseif not pl_types.to_bool(bk_upstream.get_last_upstream_bytes_received(ctx)) then -- 读取头失败
-        return proxy_phases.HEADER_WAITING, "cannot read header from upstream"
+        -- TODO: 线上有, 带优化后，去掉 legacy logical
+        -- upstream_connect_time > 0 and upstream_bytes_received == 0
+        -- move to the line 115
+        return proxy_phases.HEADER_WAITING, "cannot read header from upstream."
     elseif not ctx.var.upstream_header_time then -- 读到了头，但未读完，可能是读头超时，可能是头格式不对
-        return proxy_phases.HEAEDER_RECEIVING, "failed to read header from upstream"
+        -- NOTE: 线上没有命中这个的记录
+        return proxy_phases.HEADER_RECEIVING, "failed to read header from upstream"
     end
 
     return proxy_phases.FINISH

--- a/src/apisix/plugins/bk-error-wrapper.lua
+++ b/src/apisix/plugins/bk-error-wrapper.lua
@@ -118,12 +118,22 @@ local function _get_upstream_error_msg(ctx)
                     return proxy_phases.HEADER_WAITING, "cannot read header from upstream"
                 end
 
-                if upstream_bytes_received > 0 and upstream_header_time == 0 then
-                    -- 收到了一些字节，但 header 始终没有完整解析出来
-                    -- 可能是：upstream 发了一半就断了，或者响应不是合法 HTTP
-                    return proxy_phases.HEADER_RECEIVING,
-                        "cannot read header from upstream OR upstream prematurely closed connection"
-                end
+                -- TODO(refactor): keep this branch in this PR, but it is broader
+                -- than the connection-refused fix above. In header_filter, any
+                -- non-FINISH phase sets proxy_error=1 and may rewrite the client
+                -- response with upstream_error, so this is not only a log label.
+                -- The intended signal is: upstream sent some bytes, but NGINX did
+                -- not receive a complete response header. This can describe a
+                -- malformed/partial upstream header, but it can also match a very
+                -- fast real upstream 502 when bytes were received and header_time
+                -- is recorded as 0. Refactor this after collecting production or
+                -- test-nginx evidence for the exact malformed-header shape.
+                -- if upstream_bytes_received > 0 and upstream_header_time == 0 then
+                --     -- 收到了一些字节，但 header 始终没有完整解析出来
+                --     -- 可能是：upstream 发了一半就断了，或者响应不是合法 HTTP
+                --     return proxy_phases.HEADER_RECEIVING,
+                --         "cannot read header from upstream OR upstream prematurely closed connection"
+                -- end
 
             end
         end

--- a/src/apisix/plugins/bk-oauth2-audience-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-audience-validate.lua
@@ -70,7 +70,7 @@ local function parse_audience(audience_str)
         return nil
     end
 
-    -- Try mcp_server:{name} format
+    -- Try mcp:{name} format
     local mcp_name = string_match(audience_str, "^mcp:(.+)$")
     if mcp_name then
         return {

--- a/src/apisix/t/bk-oauth2-protected-resource.t
+++ b/src/apisix/t/bk-oauth2-protected-resource.t
@@ -128,3 +128,105 @@ Authorization: Basic dXNlcjpwYXNz
 --- error_code: 401
 --- response_headers_like
 WWW-Authenticate: Bearer .*
+
+=== TEST 8: should strip /api/{gateway_name} prefix when enabled
+--- config
+    location /t {
+        content_by_lua_block {
+            local bk_core = require("apisix.plugins.bk-core.init")
+            local oauth2 = require("apisix.plugins.bk-core.oauth2")
+            local old_get_tmpl = bk_core.config.get_bk_apigateway_api_tmpl
+            local old_should_strip = bk_core.config.should_strip_subpath_prefix
+
+            bk_core.config.get_bk_apigateway_api_tmpl = function()
+                return "http://{api_name}.bkapi.example.com"
+            end
+            bk_core.config.should_strip_subpath_prefix = function()
+                return true
+            end
+
+            local header = oauth2.build_www_authenticate_header({
+                var = {
+                    bk_gateway_name = "bk-apigateway",
+                    uri = "/api/bk-apigateway/prod/api/v2/mcp-servers/bk-apigateway-prod-debugger/mcp/",
+                },
+            }, "invalid_request", "no valid authentication header found")
+
+            bk_core.config.get_bk_apigateway_api_tmpl = old_get_tmpl
+            bk_core.config.should_strip_subpath_prefix = old_should_strip
+
+            ngx.say(header)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+resource=http%3A%2F%2Fbk-apigateway.bkapi.example.com%2Fprod%2Fapi%2Fv2%2Fmcp-servers%2Fbk-apigateway-prod-debugger%2Fmcp%2F.*
+
+=== TEST 9: should not strip prefix when disabled
+--- config
+    location /t {
+        content_by_lua_block {
+            local bk_core = require("apisix.plugins.bk-core.init")
+            local oauth2 = require("apisix.plugins.bk-core.oauth2")
+            local old_get_tmpl = bk_core.config.get_bk_apigateway_api_tmpl
+            local old_should_strip = bk_core.config.should_strip_subpath_prefix
+
+            bk_core.config.get_bk_apigateway_api_tmpl = function()
+                return "http://{api_name}.bkapi.example.com"
+            end
+            bk_core.config.should_strip_subpath_prefix = function()
+                return false
+            end
+
+            local header = oauth2.build_www_authenticate_header({
+                var = {
+                    bk_gateway_name = "bk-apigateway",
+                    uri = "/api/bk-apigateway/prod/api/v2/mcp-servers/bk-apigateway-prod-debugger/mcp/",
+                },
+            }, "invalid_request", "no valid authentication header found")
+
+            bk_core.config.get_bk_apigateway_api_tmpl = old_get_tmpl
+            bk_core.config.should_strip_subpath_prefix = old_should_strip
+
+            ngx.say(header)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+resource=http%3A%2F%2Fbk-apigateway.bkapi.example.com%2Fapi%2Fbk-apigateway%2Fprod%2Fapi%2Fv2%2Fmcp-servers%2Fbk-apigateway-prod-debugger%2Fmcp%2F.*
+
+=== TEST 10: should not strip partial gateway name prefix
+--- config
+    location /t {
+        content_by_lua_block {
+            local bk_core = require("apisix.plugins.bk-core.init")
+            local oauth2 = require("apisix.plugins.bk-core.oauth2")
+            local old_get_tmpl = bk_core.config.get_bk_apigateway_api_tmpl
+            local old_should_strip = bk_core.config.should_strip_subpath_prefix
+
+            bk_core.config.get_bk_apigateway_api_tmpl = function()
+                return "http://{api_name}.bkapi.example.com"
+            end
+            bk_core.config.should_strip_subpath_prefix = function()
+                return true
+            end
+
+            local header = oauth2.build_www_authenticate_header({
+                var = {
+                    bk_gateway_name = "bk-apigateway",
+                    uri = "/api/bk-apigateway-extra/prod/api/v2/mcp-servers",
+                },
+            }, "invalid_request", "no valid authentication header found")
+
+            bk_core.config.get_bk_apigateway_api_tmpl = old_get_tmpl
+            bk_core.config.should_strip_subpath_prefix = old_should_strip
+
+            ngx.say(header)
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+resource=http%3A%2F%2Fbk-apigateway.bkapi.example.com%2Fapi%2Fbk-apigateway-extra%2Fprod%2Fapi%2Fv2%2Fmcp-servers.*

--- a/src/apisix/tests/test-bk-core-config.lua
+++ b/src/apisix/tests/test-bk-core-config.lua
@@ -1,0 +1,112 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) 2025 Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+local core = require("apisix.core")
+local bk_core = require("apisix.plugins.bk-core.init")
+
+describe(
+    "bk-core.config", function()
+        after_each(
+            function()
+                if core.config.local_conf.revert then
+                    core.config.local_conf:revert()
+                end
+            end
+        )
+
+        context(
+            "should_strip_subpath_prefix", function()
+                it(
+                    "should return false when value is nil", function()
+                        stub(
+                            core.config, "local_conf", function()
+                                return { bk_gateway = {} }
+                            end
+                        )
+                        assert.is_false(bk_core.config.should_strip_subpath_prefix())
+                    end
+                )
+
+                it(
+                    "should return boolean true as-is", function()
+                        stub(
+                            core.config, "local_conf", function()
+                                return { bk_gateway = { strip_subpath_prefix = true } }
+                            end
+                        )
+                        assert.is_true(bk_core.config.should_strip_subpath_prefix())
+                    end
+                )
+
+                it(
+                    "should return boolean false as-is", function()
+                        stub(
+                            core.config, "local_conf", function()
+                                return { bk_gateway = { strip_subpath_prefix = false } }
+                            end
+                        )
+                        assert.is_false(bk_core.config.should_strip_subpath_prefix())
+                    end
+                )
+
+                it(
+                    "should parse lowercase true string", function()
+                        stub(
+                            core.config, "local_conf", function()
+                                return { bk_gateway = { strip_subpath_prefix = "true" } }
+                            end
+                        )
+                        assert.is_true(bk_core.config.should_strip_subpath_prefix())
+                    end
+                )
+
+                it(
+                    "should parse uppercase true string", function()
+                        stub(
+                            core.config, "local_conf", function()
+                                return { bk_gateway = { strip_subpath_prefix = "TRUE" } }
+                            end
+                        )
+                        assert.is_true(bk_core.config.should_strip_subpath_prefix())
+                    end
+                )
+
+                it(
+                    "should parse false string as false", function()
+                        stub(
+                            core.config, "local_conf", function()
+                                return { bk_gateway = { strip_subpath_prefix = "false" } }
+                            end
+                        )
+                        assert.is_false(bk_core.config.should_strip_subpath_prefix())
+                    end
+                )
+
+                it(
+                    "should return false for unexpected value types", function()
+                        stub(
+                            core.config, "local_conf", function()
+                                return { bk_gateway = { strip_subpath_prefix = 1 } }
+                            end
+                        )
+                        assert.is_false(bk_core.config.should_strip_subpath_prefix())
+                    end
+                )
+            end
+        )
+    end
+)

--- a/src/apisix/tests/test-bk-core-oauth2.lua
+++ b/src/apisix/tests/test-bk-core-oauth2.lua
@@ -36,12 +36,19 @@ describe(
                         return "http://bkapi.example.com/api/{api_name}"
                     end
                 )
+
+                stub(
+                    bk_core.config, "should_strip_subpath_prefix", function()
+                        return false
+                    end
+                )
             end
         )
 
         after_each(
             function()
                 bk_core.config.get_bk_apigateway_api_tmpl:revert()
+                bk_core.config.should_strip_subpath_prefix:revert()
             end
         )
 
@@ -86,6 +93,61 @@ describe(
                     "should escape both backslashes and double quotes", function()
                         local result = oauth2._escape_auth_header_value('a\\"b')
                         assert.is_equal('a\\\\\\"b', result)
+                    end
+                )
+            end
+        )
+
+        context(
+            "strip_subpath_prefix", function()
+                it(
+                    "should strip /api/{gateway_name} prefix from path", function()
+                        local result = oauth2._strip_subpath_prefix("/api/demo/prod/api/v2/users", "demo")
+                        assert.is_equal("/prod/api/v2/users", result)
+                    end
+                )
+
+                it(
+                    "should return / when path equals the prefix exactly", function()
+                        local result = oauth2._strip_subpath_prefix("/api/demo", "demo")
+                        assert.is_equal("/", result)
+                    end
+                )
+
+                it(
+                    "should not strip when path does not start with prefix", function()
+                        local result = oauth2._strip_subpath_prefix("/prod/api/v2/users", "demo")
+                        assert.is_equal("/prod/api/v2/users", result)
+                    end
+                )
+
+                it(
+                    "should not strip partial gateway name match", function()
+                        local result = oauth2._strip_subpath_prefix("/api/demo-extra/prod", "demo")
+                        assert.is_equal("/api/demo-extra/prod", result)
+                    end
+                )
+
+                it(
+                    "should handle path with only slash after prefix", function()
+                        local result = oauth2._strip_subpath_prefix("/api/demo/", "demo")
+                        assert.is_equal("/", result)
+                    end
+                )
+
+                it(
+                    "should handle gateway name with hyphens", function()
+                        local result = oauth2._strip_subpath_prefix(
+                            "/api/bk-apigateway/prod/api/v2/mcp-servers", "bk-apigateway"
+                        )
+                        assert.is_equal("/prod/api/v2/mcp-servers", result)
+                    end
+                )
+
+                it(
+                    "should return path unchanged when prefix is for different gateway", function()
+                        local result = oauth2._strip_subpath_prefix("/api/other-gw/prod", "demo")
+                        assert.is_equal("/api/other-gw/prod", result)
                     end
                 )
             end
@@ -346,6 +408,82 @@ describe(
                         -- The resource URL should end with just the origin + "/"
                         assert.is_truthy(
                             string.find(header, "resource_metadata=", 1, true)
+                        )
+                    end
+                )
+            end
+        )
+
+        context(
+            "build_www_authenticate_header - subpath prefix stripping", function()
+                it(
+                    "should strip /api/{gateway_name} from path when enabled", function()
+                        bk_core.config.should_strip_subpath_prefix:revert()
+                        stub(
+                            bk_core.config, "should_strip_subpath_prefix", function()
+                                return true
+                            end
+                        )
+                        bk_core.config.get_bk_apigateway_api_tmpl:revert()
+                        stub(
+                            bk_core.config, "get_bk_apigateway_api_tmpl", function()
+                                return "http://{api_name}.bkapi.example.com"
+                            end
+                        )
+                        ctx.var.bk_gateway_name = "bk-apigateway"
+                        ctx.var.uri = "/api/bk-apigateway/prod/api/v2/mcp-servers"
+
+                        local header = oauth2.build_www_authenticate_header(ctx)
+
+                        -- The resource URL should NOT contain /api/bk-apigateway prefix
+                        assert.is_truthy(
+                            string.find(
+                                header,
+                                "bk-apigateway.bkapi.example.com%2Fprod%2Fapi%2Fv2%2Fmcp-servers",
+                                1, true
+                            )
+                        )
+                    end
+                )
+
+                it(
+                    "should not strip when config is disabled", function()
+                        ctx.var.bk_gateway_name = "demo"
+                        ctx.var.uri = "/api/demo/prod/api/v2/users"
+
+                        local header = oauth2.build_www_authenticate_header(ctx)
+
+                        -- The resource URL should still contain /api/demo
+                        assert.is_truthy(
+                            string.find(
+                                header,
+                                "%2Fapi%2Fdemo%2Fprod%2Fapi%2Fv2%2Fusers",
+                                1, true
+                            )
+                        )
+                    end
+                )
+
+                it(
+                    "should not strip when path does not match gateway prefix", function()
+                        bk_core.config.should_strip_subpath_prefix:revert()
+                        stub(
+                            bk_core.config, "should_strip_subpath_prefix", function()
+                                return true
+                            end
+                        )
+                        ctx.var.bk_gateway_name = "demo"
+                        ctx.var.uri = "/other/path/prod"
+
+                        local header = oauth2.build_www_authenticate_header(ctx)
+
+                        -- Path should remain unchanged
+                        assert.is_truthy(
+                            string.find(
+                                header,
+                                "%2Fother%2Fpath%2Fprod",
+                                1, true
+                            )
                         )
                     end
                 )

--- a/src/apisix/tests/test-bk-error-wrapper.lua
+++ b/src/apisix/tests/test-bk-error-wrapper.lua
@@ -405,7 +405,7 @@ describe(
                             ctx.var.bk_apigw_error.error.message, "failed to read header from upstream", 1, true
                         )
                         assert.is_not_nil(start)
-                        assert.is_equal(ctx.var.proxy_phase, proxy_phases.HEAEDER_RECEIVING)
+                        assert.is_equal(ctx.var.proxy_phase, proxy_phases.HEADER_RECEIVING)
                     end
                 )
             end
@@ -601,6 +601,26 @@ describe(
                 )
 
                 it(
+                    "502 cannot read complete header", function()
+                        ngx.status = 502
+                        local ctx = {
+                            var = {
+                                upstream_connect_time = 0.1,
+                                upstream_bytes_sent = "256",
+                                upstream_bytes_received = "64",
+                                upstream_header_time = 0,
+                            },
+                        }
+                        local phase, err = plugin._get_upstream_error_msg(ctx)
+                        assert.is_equal(proxy_phases.HEADER_RECEIVING, phase)
+                        assert.is_equal(
+                            "cannot read header from upstream OR upstream prematurely closed connection", err
+                        )
+
+                    end
+                )
+
+                it(
                     "legacy fallback - cannot read header", function()
                         ngx.status = 200  -- Not 5xx, uses legacy logic
                         local ctx = {
@@ -612,7 +632,7 @@ describe(
                         }
                         local phase, err = plugin._get_upstream_error_msg(ctx)
                         assert.is_equal(proxy_phases.HEADER_WAITING, phase)
-                        assert.is_equal("cannot read header from upstream", err)
+                        assert.is_equal("cannot read header from upstream.", err)
 
                     end
                 )

--- a/src/apisix/tests/test-bk-error-wrapper.lua
+++ b/src/apisix/tests/test-bk-error-wrapper.lua
@@ -601,7 +601,7 @@ describe(
                 )
 
                 it(
-                    "502 cannot read complete header", function()
+                    "502 partial header shape waits for refactor evidence", function()
                         ngx.status = 502
                         local ctx = {
                             var = {
@@ -612,10 +612,8 @@ describe(
                             },
                         }
                         local phase, err = plugin._get_upstream_error_msg(ctx)
-                        assert.is_equal(proxy_phases.HEADER_RECEIVING, phase)
-                        assert.is_equal(
-                            "cannot read header from upstream OR upstream prematurely closed connection", err
-                        )
+                        assert.is_equal(proxy_phases.FINISH, phase)
+                        assert.is_nil(err)
 
                     end
                 )


### PR DESCRIPTION
Why this change was needed:
The bk-error-wrapper plugin needed clearer classification for upstream 502 header-read failures, and the proxy phase constant had a typo that made the header-receiving path inconsistent.

What changed:
- fixed the HEADER_RECEIVING constant name in proxy_phases
- refined 502/504 upstream error classification in bk-error-wrapper
- added a regression test for incomplete 502 response headers
- updated tests to match the corrected phase constant and message text

Problem solved:
Upstream proxy failures are labeled with more specific phases and the header-receiving path now uses the correct constant across runtime code and tests.

### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
