### PR TITLE
[1.22.x] fix(auth): preserve bklogin legacy invalid token reason

### DIFF
--- a/src/apisix/editions/ee/plugins/bk-components/bklogin.lua
+++ b/src/apisix/editions/ee/plugins/bk-components/bklogin.lua
@@ -121,10 +121,15 @@ function _M.get_username_by_bk_token(bk_token)
     end
     -- {"data": {"bk_username": "cpyjg3xo3ta0op6t", "tenant_id": "system"}}
 
+    if not _M.enable_multi_tenant_mode and result.result == false then
+        return {
+            error_message = result.bk_error_msg,
+        }, nil
+    end
+
     return {
         username = result.data.bk_username,
     }, nil
 end
 
 return _M
-

--- a/src/apisix/editions/ee/plugins/bk-components/bklogin.lua
+++ b/src/apisix/editions/ee/plugins/bk-components/bklogin.lua
@@ -121,6 +121,10 @@ function _M.get_username_by_bk_token(bk_token)
     end
     -- {"data": {"bk_username": "cpyjg3xo3ta0op6t", "tenant_id": "system"}}
 
+
+    -- legacy verify
+    -- status: 200, but result is false
+    -- {"result": false, "bk_error_code": 1302100, "bk_error_msg": "\u53c2\u6570 bk_token \u975e\u6cd5", "data": {}}
     if not _M.enable_multi_tenant_mode and result.result == false then
         return {
             error_message = result.bk_error_msg,

--- a/src/apisix/editions/ee/tests/bk-components/test-bklogin.lua
+++ b/src/apisix/editions/ee/tests/bk-components/test-bklogin.lua
@@ -23,11 +23,13 @@ describe(
     "bklogin", function()
 
         local response, response_err
+        local enable_multi_tenant_mode
 
         before_each(
             function()
                 response = nil
                 response_err = nil
+                enable_multi_tenant_mode = bklogin.enable_multi_tenant_mode
 
                 stub(
                     bk_components_utils, "handle_request", function()
@@ -39,6 +41,7 @@ describe(
 
         after_each(
             function()
+                bklogin.enable_multi_tenant_mode = enable_multi_tenant_mode
                 bk_components_utils.handle_request:revert()
             end
         )
@@ -108,6 +111,55 @@ describe(
                         assert.is_nil(result)
                         assert.is_true(core.string.has_prefix(err, "failed to request third-party api"))
                         assert.is_true(core.string.find(err, "request_id") ~= nil)
+                    end
+                )
+
+                it(
+                    "legacy protocol result false", function()
+                        bklogin.enable_multi_tenant_mode = false
+                        response = {
+                            status = 200,
+                            body = core.json.encode(
+                                {
+                                    result = false,
+                                    bk_error_code = 1302100,
+                                    bk_error_msg = "bk_token is not valid",
+                                    data = {},
+                                }
+                            ),
+                        }
+                        response_err = nil
+
+                        local result, err = bklogin.get_username_by_bk_token("fake-bk-token")
+                        assert.is_same(
+                            result, {
+                                error_message = "bk_token is not valid",
+                            }
+                        )
+                        assert.is_nil(err)
+                    end
+                )
+
+                it(
+                    "legacy protocol success without result field", function()
+                        bklogin.enable_multi_tenant_mode = false
+                        response = {
+                            status = 200,
+                            body = core.json.encode(
+                                {
+                                    bk_error_code = 0,
+                                    bk_error_msg = "",
+                                    data = {
+                                        bk_username = "admin",
+                                    },
+                                }
+                            ),
+                        }
+                        response_err = nil
+
+                        local result, err = bklogin.get_username_by_bk_token("fake-bk-token")
+                        assert.is_equal(result.username, "admin")
+                        assert.is_nil(err)
                     end
                 )
 


### PR DESCRIPTION
Why this change was needed:
Legacy bklogin can return HTTP 200 with result=false when bk_token is invalid. The old flow treated that response as a successful lookup with no username, which later produced an empty auth validation reason.

What changed:
- Return bk_error_msg as error_message for legacy result=false responses
- Add regression coverage for legacy result=false invalid bk_token responses
- Add compatibility coverage for legacy success responses without result field

Problem solved:
Invalid legacy bk_token responses now keep a useful validation reason instead of surfacing as Parameters error [reason=""].

### Description

<!-- 关联相关issue Please include a summary of the change and which issue is fixed. -->
<!-- 给出必要的上下文以及review需要的必要信息 Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
