### PR TITLE
[1.23] chore(apisix): upgrade runtime to 3.16

### DIFF
--- a/.github/workflows/apisix.yml
+++ b/.github/workflows/apisix.yml
@@ -59,6 +59,6 @@ jobs:
       run: |
         echo "start backing up, $(date)"
         mkdir docker-images-backup
-        docker save apisix-test-busted-313 -o docker-images-backup/apisix-test-busted-images.tar
-        docker save apisix-test-nginx-313 -o docker-images-backup/apisix-test-nginx-images.tar
+        docker save apisix-test-busted-316 -o docker-images-backup/apisix-test-busted-images.tar
+        docker save apisix-test-nginx-316 -o docker-images-backup/apisix-test-nginx-images.tar
         echo "docker save done, time: $(date)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM tencentos/tencentos4-minimal:4.4-v20250922
 
-ARG APISIX_VERSION=3.13.0
+ARG APISIX_VERSION=3.16.0
 LABEL apisix_version="${APISIX_VERSION}"
 
 # 1. yum install
 COPY ./src/build/yum.repos.d/ /etc/yum.repos.d/
-RUN sed -i 's/$releasever/8/g' /etc/yum.repos.d/apache-apisix.repo && sed -i 's/$releasever/8/g' /etc/yum.repos.d/openresty.repo
+RUN sed -i 's/$releasever/9/g' /etc/yum.repos.d/apache-apisix.repo && sed -i 's/$releasever/8/g' /etc/yum.repos.d/openresty.repo
 RUN yum clean packages
 # you can add more tools for debug
 # alreay on image: ifconfig nslookup dig ip ss route
 # install openresty & apisix
-RUN yum install -y apisix-${APISIX_VERSION} && \
+RUN yum install -y apisix-${APISIX_VERSION} libxcrypt && \
     yum install -y tar m4 findutils procps less iproute traceroute telnet lsof net-tools tcpdump mtr vim bind-utils libyaml-devel hostname gawk iputils python3 python3-pip sudo && \
     yum install -y wget unzip patch make
 

--- a/src/apisix/Makefile
+++ b/src/apisix/Makefile
@@ -4,11 +4,11 @@ RUN_WITH_IT ?= -it
 
 .PHONY: apisix-test-busted
 apisix-test-busted:
-	docker build -t apisix-test-busted-313 -f ci/Dockerfile.apisix-test-busted .
+	docker build -t apisix-test-busted-316 -f ci/Dockerfile.apisix-test-busted .
 
 .PHONY: apisix-test-nginx
 apisix-test-nginx:
-	docker build -t apisix-test-nginx-313 -f ci/Dockerfile.apisix-test-nginx .
+	docker build -t apisix-test-nginx-316 -f ci/Dockerfile.apisix-test-nginx .
 
 .PHONY: test-busted
 test-busted:
@@ -18,7 +18,7 @@ test-busted:
 	-v ${ROOT_DIR}/logs/:/bkgateway/logs/ \
 	-v ${ROOT_DIR}/tests/conf/nginx.conf:/bkgateway/conf/nginx.conf \
 	-v ${ROOT_DIR}/plugins:/bkgateway/apisix/plugins \
-	apisix-test-busted-313 "/run-test-busted.sh"
+	apisix-test-busted-316 "/run-test-busted.sh"
 
 # make test-nginx
 # make test-nginx CASE_FILE=bk-traffic-label.t
@@ -27,7 +27,7 @@ test-nginx:
 	@docker run --rm ${RUN_WITH_IT} \
 	-v ${ROOT_DIR}/t:/bkgateway/t/ \
 	-v ${ROOT_DIR}/plugins:/bkgateway/apisix/plugins \
-	apisix-test-nginx-313 "/run-test-nginx.sh" $(if $(CASE_FILE),$(CASE_FILE))
+	apisix-test-nginx-316 "/run-test-nginx.sh" $(if $(CASE_FILE),$(CASE_FILE))
 
 .PHONY: apisix-test-images
 apisix-test-images: apisix-test-busted apisix-test-nginx
@@ -42,7 +42,7 @@ lint:
 	-v ${ROOT_DIR}/plugins:/bkgateway/apisix/plugins \
 	-v ${ROOT_DIR}/tests:/bkgateway/tests/ \
 	-w /bkgateway/apisix \
-	apisix-test-busted-313 \
+	apisix-test-busted-316 \
 	luacheck --config /bkgateway/.luacheckrc ./plugins
 
 .PHONY: edition

--- a/src/apisix/ci/Dockerfile.apisix-test-busted
+++ b/src/apisix/ci/Dockerfile.apisix-test-busted
@@ -1,4 +1,4 @@
-ARG APISIX_VERSION="3.13.0"
+ARG APISIX_VERSION="3.16.0"
 FROM apache/apisix:$APISIX_VERSION-redhat
 
 RUN yum install -y sudo make gcc wget unzip git # valgrind

--- a/src/apisix/ci/Dockerfile.apisix-test-nginx
+++ b/src/apisix/ci/Dockerfile.apisix-test-nginx
@@ -1,4 +1,4 @@
-ARG APISIX_VERSION="3.13.0"
+ARG APISIX_VERSION="3.16.0"
 FROM apache/apisix:$APISIX_VERSION-redhat
 
 # reference: 

--- a/src/apisix/ci/redhat-ci.sh
+++ b/src/apisix/ci/redhat-ci.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
 # CHANGES:
-# 1. remove unused tools in install_dependencies
+# 1. based on APISIX 3.16 redhat-ci.sh
+# 2. use UBI9 repos to match apache/apisix:3.16.0-redhat
+# 3. remove unused tools in install_dependencies
 
-# reference: https://github.com/apache/apisix/blob/release/3.11/ci/redhat-ci.sh
+# reference: https://github.com/apache/apisix/blob/3.16.0/ci/redhat-ci.sh
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -30,7 +32,7 @@ install_dependencies() {
     # install build & runtime deps
     yum install -y --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms \
     wget tar gcc gcc-c++ automake autoconf libtool make unzip git sudo openldap-devel hostname patch \
-    which ca-certificates pcre pcre-devel xz \
+    which ca-certificates pcre pcre-devel pcre2 pcre2-devel xz \
     openssl-devel
 
     # FIXME: yum uninstall the build tools
@@ -111,6 +113,7 @@ run_case() {
     set_coredns
     # run test cases
     FLUSH_ETCD=1 TEST_EVENTS_MODULE=$TEST_EVENTS_MODULE prove --timer -Itest-nginx/lib -I./ -r ${TEST_FILE_SUB_DIR} | tee /tmp/test.result
+    fail_on_bailout /tmp/test.result
     rerun_flaky_tests /tmp/test.result
 }
 

--- a/src/apisix/ci/run-test-nginx.sh
+++ b/src/apisix/ci/run-test-nginx.sh
@@ -25,6 +25,9 @@ ls /bkgateway/apisix/plugins/ | egrep "bk-.*.lua" | awk -F '.' '{print "    \""$
 echo "append the bk-apigateway config into user_yaml_config"
 cat << EOF | sed -i '/my $profile = $ENV{"APISIX_PROFILE"};/r /dev/stdin' /usr/local/apisix/t/APISIX.pm
 \$user_yaml_config = <<_EOC_;
+apisix:
+  trusted_addresses:
+    - "127.0.0.1"
 bk_gateway:
   bkauth:
     authorization_keys:
@@ -79,4 +82,3 @@ if [ -n "$1" ]; then
 else
     FLUSH_ETCD=1 prove --timer -Itest-nginx/lib -I./ t/bk-*.t
 fi
-

--- a/src/apisix/plugins/bk-response-check.lua
+++ b/src/apisix/plugins/bk-response-check.lua
@@ -55,9 +55,17 @@ local _M = {
 }
 
 
--- Initializes the plugin and its metrics.
-function _M.init()
-    prometheus_registry = exporter.get_prometheus()
+local function ensure_metrics()
+    local registry = exporter.get_prometheus()
+    if not registry then
+        return
+    end
+
+    if prometheus_registry == registry and metric_api_requests_total then
+        return
+    end
+
+    prometheus_registry = registry
 
     -- use the same plugin attr with prometheus plugin
     local attr = plugin.plugin_attr("prometheus")
@@ -107,6 +115,12 @@ function _M.init()
     )
 end
 
+
+-- Initializes the plugin and its metrics.
+function _M.init()
+    ensure_metrics()
+end
+
 ---@param conf any
 function _M.check_schema(conf)
     return core.schema.check(schema, conf)
@@ -116,6 +130,11 @@ end
 ---@param conf any
 ---@param ctx apisix.Context
 function _M.log(conf, ctx)
+    ensure_metrics()
+    if not metric_api_requests_total then
+        return
+    end
+
     local api_name = ctx.var.bk_gateway_name or ""
     local stage_name = ctx.var.bk_stage_name or ""
     local backend_name = ctx.var.bk_backend_name or ""

--- a/src/apisix/tests/conf/nginx.conf
+++ b/src/apisix/tests/conf/nginx.conf
@@ -1,6 +1,7 @@
 lua_shared_dict lrucache-lock 1m;
 lua_shared_dict plugin-limit-conn 1m;
 lua_shared_dict prometheus-metrics 1m;
+lua_shared_dict prometheus-cache 1m;
 lua_shared_dict plugin-bk-permission 1m;
 lua_shared_dict plugin-bk-cache-fallback 1m;
 lua_shared_dict plugin-bk-cache-fallback-lock 1m;

--- a/src/build/patches/001_change_prometheus_default_buckets.patch
+++ b/src/build/patches/001_change_prometheus_default_buckets.patch
@@ -1,8 +1,8 @@
 diff --git a/apisix/plugins/prometheus/exporter.lua b/apisix/plugins/prometheus/exporter.lua
-index d34ab873..dd9d446b 100644
+index ed219a49..fb277e67 100644
 --- a/apisix/plugins/prometheus/exporter.lua
 +++ b/apisix/plugins/prometheus/exporter.lua
-@@ -235,6 +235,12 @@ end
+@@ -308,6 +308,12 @@
  
  
  function _M.http_log(conf, ctx)
@@ -15,41 +15,122 @@ index d34ab873..dd9d446b 100644
      local vars = ctx.var
  
      local route_id = ""
-@@ -262,11 +268,17 @@ function _M.http_log(conf, ctx)
+@@ -335,62 +341,70 @@
          matched_host = ctx.curr_req_matched._host or ""
      end
  
+-    metrics.status:inc(1,
+-        gen_arr(vars.status, route_id, matched_uri, matched_host,
+-                service_id, consumer_name, balancer_ip,
+-                vars.request_type, vars.request_llm_model, vars.llm_model,
+-                unpack(extra_labels("http_status", ctx))))
 +    if official and official.enable_status then
-+
-     metrics.status:inc(1,
-         gen_arr(vars.status, route_id, matched_uri, matched_host,
-                 service_id, consumer_name, balancer_ip,
-                 unpack(extra_labels("http_status", ctx))))
- 
++        metrics.status:inc(1,
++            gen_arr(vars.status, route_id, matched_uri, matched_host,
++                    service_id, consumer_name, balancer_ip,
++                    vars.request_type, vars.request_llm_model, vars.llm_model,
++                    unpack(extra_labels("http_status", ctx))))
 +    end
+-
 +
+-    local latency, upstream_latency, apisix_latency = latency_details(ctx)
+-    local latency_extra_label_values = extra_labels("http_latency", ctx)
 +    if official and official.enable_latency then
++        local latency, upstream_latency, apisix_latency = latency_details(ctx)
++        local latency_extra_label_values = extra_labels("http_latency", ctx)
+ 
+-    metrics.latency:observe(latency,
+-        gen_arr("request", route_id, service_id, consumer_name, balancer_ip,
+-        vars.request_type, vars.request_llm_model, vars.llm_model,
+-        unpack(latency_extra_label_values)))
+-
+-    if upstream_latency then
+-        metrics.latency:observe(upstream_latency,
+-            gen_arr("upstream", route_id, service_id, consumer_name, balancer_ip,
++        metrics.latency:observe(latency,
++            gen_arr("request", route_id, service_id, consumer_name, balancer_ip,
+             vars.request_type, vars.request_llm_model, vars.llm_model,
+             unpack(latency_extra_label_values)))
+-    end
+ 
+-    metrics.latency:observe(apisix_latency,
+-        gen_arr("apisix", route_id, service_id, consumer_name, balancer_ip,
+-        vars.request_type, vars.request_llm_model, vars.llm_model,
+-        unpack(latency_extra_label_values)))
+-
+-    local bandwidth_extra_label_values = extra_labels("bandwidth", ctx)
+-
+-    metrics.bandwidth:inc(vars.request_length,
+-        gen_arr("ingress", route_id, service_id, consumer_name, balancer_ip,
+-        vars.request_type, vars.request_llm_model, vars.llm_model,
+-        unpack(bandwidth_extra_label_values)))
+-
+-    metrics.bandwidth:inc(vars.bytes_sent,
+-        gen_arr("egress", route_id, service_id, consumer_name, balancer_ip,
+-        vars.request_type, vars.request_llm_model, vars.llm_model,
+-        unpack(bandwidth_extra_label_values)))
+-
+-    local llm_time_to_first_token = vars.llm_time_to_first_token
+-    if llm_time_to_first_token ~= "" then
+-        metrics.llm_latency:observe(tonumber(llm_time_to_first_token),
+-            gen_arr(route_id, service_id, consumer_name, balancer_ip,
++        if upstream_latency then
++            metrics.latency:observe(upstream_latency,
++                gen_arr("upstream", route_id, service_id, consumer_name, balancer_ip,
++                vars.request_type, vars.request_llm_model, vars.llm_model,
++                unpack(latency_extra_label_values)))
++        end
 +
-     local latency, upstream_latency, apisix_latency = latency_details(ctx)
-     local latency_extra_label_values = extra_labels("http_latency", ctx)
- 
-@@ -284,6 +296,10 @@ function _M.http_log(conf, ctx)
-         gen_arr("apisix", route_id, service_id, consumer_name, balancer_ip,
-         unpack(latency_extra_label_values)))
- 
-+    end
++        metrics.latency:observe(apisix_latency,
++            gen_arr("apisix", route_id, service_id, consumer_name, balancer_ip,
+             vars.request_type, vars.request_llm_model, vars.llm_model,
+-            unpack(extra_labels("llm_latency", ctx))))
++            unpack(latency_extra_label_values)))
+     end
+-    if vars.llm_prompt_tokens ~= "" then
+-        metrics.llm_prompt_tokens:inc(tonumber(vars.llm_prompt_tokens),
+-            gen_arr(route_id, service_id, consumer_name, balancer_ip,
 +
 +    if official and official.enable_bandwidth then
++        local bandwidth_extra_label_values = extra_labels("bandwidth", ctx)
 +
-     local bandwidth_extra_label_values = extra_labels("bandwidth", ctx)
- 
-     metrics.bandwidth:inc(vars.request_length,
-@@ -293,6 +309,8 @@ function _M.http_log(conf, ctx)
-     metrics.bandwidth:inc(vars.bytes_sent,
-         gen_arr("egress", route_id, service_id, consumer_name, balancer_ip,
-         unpack(bandwidth_extra_label_values)))
++        metrics.bandwidth:inc(vars.request_length,
++            gen_arr("ingress", route_id, service_id, consumer_name, balancer_ip,
+             vars.request_type, vars.request_llm_model, vars.llm_model,
+-            unpack(extra_labels("llm_prompt_tokens", ctx))))
+-    end
+-    if vars.llm_completion_tokens ~= "" then
+-        metrics.llm_completion_tokens:inc(tonumber(vars.llm_completion_tokens),
+-            gen_arr(route_id, service_id, consumer_name, balancer_ip,
++            unpack(bandwidth_extra_label_values)))
 +
++        metrics.bandwidth:inc(vars.bytes_sent,
++            gen_arr("egress", route_id, service_id, consumer_name, balancer_ip,
+             vars.request_type, vars.request_llm_model, vars.llm_model,
+-            unpack(extra_labels("llm_completion_tokens", ctx))))
++            unpack(bandwidth_extra_label_values)))
 +    end
++
++    if official and official.enable_llm then
++        local llm_time_to_first_token = vars.llm_time_to_first_token
++        if llm_time_to_first_token ~= "" then
++            metrics.llm_latency:observe(tonumber(llm_time_to_first_token),
++                gen_arr(route_id, service_id, consumer_name, balancer_ip,
++                vars.request_type, vars.request_llm_model, vars.llm_model,
++                unpack(extra_labels("llm_latency", ctx))))
++        end
++        if vars.llm_prompt_tokens ~= "" then
++            metrics.llm_prompt_tokens:inc(tonumber(vars.llm_prompt_tokens),
++                gen_arr(route_id, service_id, consumer_name, balancer_ip,
++                vars.request_type, vars.request_llm_model, vars.llm_model,
++                unpack(extra_labels("llm_prompt_tokens", ctx))))
++        end
++        if vars.llm_completion_tokens ~= "" then
++            metrics.llm_completion_tokens:inc(tonumber(vars.llm_completion_tokens),
++                gen_arr(route_id, service_id, consumer_name, balancer_ip,
++                vars.request_type, vars.request_llm_model, vars.llm_model,
++                unpack(extra_labels("llm_completion_tokens", ctx))))
++        end
+     end
  end
- 
  

--- a/src/build/patches/002_upstream_parse_domain_for_nodes.patch
+++ b/src/build/patches/002_upstream_parse_domain_for_nodes.patch
@@ -1,8 +1,8 @@
 diff --git a/apisix/utils/upstream.lua b/apisix/utils/upstream.lua
-index 52c14d04..0ea5648a 100644
+index c61c9f71..2549e052 100644
 --- a/apisix/utils/upstream.lua
 +++ b/apisix/utils/upstream.lua
-@@ -97,9 +97,36 @@ local function parse_domain_for_nodes(nodes)
+@@ -99,10 +99,36 @@ local function parse_domain_for_nodes(nodes)
                  core.log.error("dns resolver domain: ", host, " error: ", err)
              end
          else
@@ -29,7 +29,7 @@ index 52c14d04..0ea5648a 100644
 +
          end
      end
-+
+     span:finish(ngx.ctx)
 +    -- patch for: https://github.com/apache/apisix/issues/10093#issuecomment-1738381865
 +    if #new_nodes == 0 then
 +        local err = "no valid ip found"


### PR DESCRIPTION
## Summary
- Upgrade APISIX runtime and apisix-core submodule to 3.16.0
- Rename Docker test images to apisix-test-busted-316/apisix-test-nginx-316 and refresh redhat-ci.sh against APISIX 3.16
- Refresh APISIX patches and add 3.16 compatibility for prometheus cache/init and trusted X-Forwarded-For tests

## Verification
- RUN_WITH_IT= make lint
- RUN_WITH_IT= make test
- docker build -f Dockerfile -t bk-apigateway-apisix:apisix-3.16-check .
- patch dry-run for src/build/patches against apisix-core 3.16.0