### PR TITLE
chore(license): remove year from file headers

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 Tencent is pleased to support the open source community by making 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-Copyright (C) 2025 Tencent.  All rights reserved.
+Copyright (C) Tencent.  All rights reserved.
 If you have downloaded a copy of the 蓝鲸智云 - API 网关(BlueKing - APIGateway) binary from Tencent, please note that the 蓝鲸智云 - API 网关(BlueKing - APIGateway) binary is licensed under the MIT License.
 If you have downloaded a copy of the 蓝鲸智云 - API 网关(BlueKing - APIGateway) source code from Tencent, please note that 蓝鲸智云 - API 网关(BlueKing - APIGateway) source code is licensed under the MIT License, except for the third-party components listed below which are subject to different license terms.  Your integration of 蓝鲸智云 - API 网关(BlueKing - APIGateway) into your own projects may require compliance with the MIT License, as well as the other licenses applicable to the third-party components included within 蓝鲸智云 - API 网关(BlueKing - APIGateway).
 A copy of the MIT License is included in this file.

--- a/src/apisix/editions/ee/plugins/bk-auth-verify/app-account-utils.lua
+++ b/src/apisix/editions/ee/plugins/bk-auth-verify/app-account-utils.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/plugins/bk-auth-verify/legacy-utils.lua
+++ b/src/apisix/editions/ee/plugins/bk-auth-verify/legacy-utils.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/plugins/bk-auth-verify/legacy-verifier.lua
+++ b/src/apisix/editions/ee/plugins/bk-auth-verify/legacy-verifier.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/plugins/bk-cache/access-token.lua
+++ b/src/apisix/editions/ee/plugins/bk-cache/access-token.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/plugins/bk-cache/bk-token.lua
+++ b/src/apisix/editions/ee/plugins/bk-cache/bk-token.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/plugins/bk-cache/init.lua
+++ b/src/apisix/editions/ee/plugins/bk-cache/init.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/plugins/bk-components/bklogin.lua
+++ b/src/apisix/editions/ee/plugins/bk-components/bklogin.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/plugins/bk-components/ssm.lua
+++ b/src/apisix/editions/ee/plugins/bk-components/ssm.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/plugins/bk-define/app.lua
+++ b/src/apisix/editions/ee/plugins/bk-define/app.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/plugins/bk-define/user.lua
+++ b/src/apisix/editions/ee/plugins/bk-define/user.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/tests/bk-auth-verify/test-app-account-utils.lua
+++ b/src/apisix/editions/ee/tests/bk-auth-verify/test-app-account-utils.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/tests/bk-auth-verify/test-legacy-utils.lua
+++ b/src/apisix/editions/ee/tests/bk-auth-verify/test-legacy-utils.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/tests/bk-auth-verify/test-legacy-verifier.lua
+++ b/src/apisix/editions/ee/tests/bk-auth-verify/test-legacy-verifier.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/tests/bk-cache/test-access-token.lua
+++ b/src/apisix/editions/ee/tests/bk-cache/test-access-token.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/tests/bk-cache/test-bk-token.lua
+++ b/src/apisix/editions/ee/tests/bk-cache/test-bk-token.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/tests/bk-components/test-bklogin.lua
+++ b/src/apisix/editions/ee/tests/bk-components/test-bklogin.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/tests/bk-components/test-ssm.lua
+++ b/src/apisix/editions/ee/tests/bk-components/test-ssm.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/tests/bk-define/test-app.lua
+++ b/src/apisix/editions/ee/tests/bk-define/test-app.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/editions/ee/tests/bk-define/test-user.lua
+++ b/src/apisix/editions/ee/tests/bk-define/test-user.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-access-token-source.lua
+++ b/src/apisix/plugins/bk-access-token-source.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-auth-validate.lua
+++ b/src/apisix/plugins/bk-auth-validate.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-auth-verify.lua
+++ b/src/apisix/plugins/bk-auth-verify.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-auth-verify/access-token-utils.lua
+++ b/src/apisix/plugins/bk-auth-verify/access-token-utils.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-auth-verify/access-token-verifier.lua
+++ b/src/apisix/plugins/bk-auth-verify/access-token-verifier.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-auth-verify/app-account-verifier.lua
+++ b/src/apisix/plugins/bk-auth-verify/app-account-verifier.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-auth-verify/auth-params.lua
+++ b/src/apisix/plugins/bk-auth-verify/auth-params.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-auth-verify/init.lua
+++ b/src/apisix/plugins/bk-auth-verify/init.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-auth-verify/inner-jwt-verifier.lua
+++ b/src/apisix/plugins/bk-auth-verify/inner-jwt-verifier.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-auth-verify/jwt-utils.lua
+++ b/src/apisix/plugins/bk-auth-verify/jwt-utils.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-auth-verify/jwt-verifier.lua
+++ b/src/apisix/plugins/bk-auth-verify/jwt-verifier.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-auth-verify/signature.lua
+++ b/src/apisix/plugins/bk-auth-verify/signature.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-backend-context.lua
+++ b/src/apisix/plugins/bk-backend-context.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-break-recursive-call.lua
+++ b/src/apisix/plugins/bk-break-recursive-call.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-cache-fallback/init.lua
+++ b/src/apisix/plugins/bk-cache-fallback/init.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-cache/app-account.lua
+++ b/src/apisix/plugins/bk-cache/app-account.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-cache/app-tenant-info.lua
+++ b/src/apisix/plugins/bk-cache/app-tenant-info.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-cache/jwt-key.lua
+++ b/src/apisix/plugins/bk-cache/jwt-key.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-cache/oauth2-access-token.lua
+++ b/src/apisix/plugins/bk-cache/oauth2-access-token.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-cache/user-tenant-info.lua
+++ b/src/apisix/plugins/bk-cache/user-tenant-info.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-components/bk-apigateway-core.lua
+++ b/src/apisix/plugins/bk-components/bk-apigateway-core.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-components/bkauth.lua
+++ b/src/apisix/plugins/bk-components/bkauth.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-components/bkuser.lua
+++ b/src/apisix/plugins/bk-components/bkuser.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-components/utils.lua
+++ b/src/apisix/plugins/bk-components/utils.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-concurrency-limit.lua
+++ b/src/apisix/plugins/bk-concurrency-limit.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-core/config.lua
+++ b/src/apisix/plugins/bk-core/config.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-core/cookie.lua
+++ b/src/apisix/plugins/bk-core/cookie.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-core/errorx.lua
+++ b/src/apisix/plugins/bk-core/errorx.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-core/hmac.lua
+++ b/src/apisix/plugins/bk-core/hmac.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-core/init.lua
+++ b/src/apisix/plugins/bk-core/init.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-core/oauth2.lua
+++ b/src/apisix/plugins/bk-core/oauth2.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-core/proxy_phases.lua
+++ b/src/apisix/plugins/bk-core/proxy_phases.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-core/request.lua
+++ b/src/apisix/plugins/bk-core/request.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-core/string.lua
+++ b/src/apisix/plugins/bk-core/string.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-core/upstream.lua
+++ b/src/apisix/plugins/bk-core/upstream.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-core/url.lua
+++ b/src/apisix/plugins/bk-core/url.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-cors.lua
+++ b/src/apisix/plugins/bk-cors.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-debug.lua
+++ b/src/apisix/plugins/bk-debug.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-default-tenant.lua
+++ b/src/apisix/plugins/bk-default-tenant.lua
@@ -2,7 +2,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-define/access-token.lua
+++ b/src/apisix/plugins/bk-define/access-token.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-define/context-api-bkauth.lua
+++ b/src/apisix/plugins/bk-define/context-api-bkauth.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-define/context-resource-bkauth.lua
+++ b/src/apisix/plugins/bk-define/context-resource-bkauth.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-delete-cookie.lua
+++ b/src/apisix/plugins/bk-delete-cookie.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-delete-sensitive.lua
+++ b/src/apisix/plugins/bk-delete-sensitive.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-error-wrapper.lua
+++ b/src/apisix/plugins/bk-error-wrapper.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-ip-restriction.lua
+++ b/src/apisix/plugins/bk-ip-restriction.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-jwt.lua
+++ b/src/apisix/plugins/bk-jwt.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-legacy-invalid-params.lua
+++ b/src/apisix/plugins/bk-legacy-invalid-params.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-log-context.lua
+++ b/src/apisix/plugins/bk-log-context.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-mock.lua
+++ b/src/apisix/plugins/bk-mock.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-not-found-handler.lua
+++ b/src/apisix/plugins/bk-not-found-handler.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-oauth2-audience-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-audience-validate.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-oauth2-protected-resource.lua
+++ b/src/apisix/plugins/bk-oauth2-protected-resource.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-oauth2-verify.lua
+++ b/src/apisix/plugins/bk-oauth2-verify.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-opentelemetry.lua
+++ b/src/apisix/plugins/bk-opentelemetry.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-permission.lua
+++ b/src/apisix/plugins/bk-permission.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-proxy-rewrite.lua
+++ b/src/apisix/plugins/bk-proxy-rewrite.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-rate-limit/init.lua
+++ b/src/apisix/plugins/bk-rate-limit/init.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-rate-limit/rate-limit-redis.lua
+++ b/src/apisix/plugins/bk-rate-limit/rate-limit-redis.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-real-ip.lua
+++ b/src/apisix/plugins/bk-real-ip.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-repl-debugger.lua
+++ b/src/apisix/plugins/bk-repl-debugger.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-request-body-limit.lua
+++ b/src/apisix/plugins/bk-request-body-limit.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-request-id.lua
+++ b/src/apisix/plugins/bk-request-id.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-resource-context.lua
+++ b/src/apisix/plugins/bk-resource-context.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-resource-header-rewrite.lua
+++ b/src/apisix/plugins/bk-resource-header-rewrite.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-resource-rate-limit.lua
+++ b/src/apisix/plugins/bk-resource-rate-limit.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-response-check.lua
+++ b/src/apisix/plugins/bk-response-check.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-stage-context.lua
+++ b/src/apisix/plugins/bk-stage-context.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-stage-global-rate-limit.lua
+++ b/src/apisix/plugins/bk-stage-global-rate-limit.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-stage-header-rewrite.lua
+++ b/src/apisix/plugins/bk-stage-header-rewrite.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-stage-rate-limit.lua
+++ b/src/apisix/plugins/bk-stage-rate-limit.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-status-rewrite.lua
+++ b/src/apisix/plugins/bk-status-rewrite.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-tenant-validate.lua
+++ b/src/apisix/plugins/bk-tenant-validate.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-tenant-verify.lua
+++ b/src/apisix/plugins/bk-tenant-verify.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-traffic-label.lua
+++ b/src/apisix/plugins/bk-traffic-label.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-user-restriction.lua
+++ b/src/apisix/plugins/bk-user-restriction.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-username-required.lua
+++ b/src/apisix/plugins/bk-username-required.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/plugins/bk-verified-user-exempted-apps.lua
+++ b/src/apisix/plugins/bk-verified-user-exempted-apps.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/t/bk-00.t
+++ b/src/apisix/t/bk-00.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-access-token-source.t
+++ b/src/apisix/t/bk-access-token-source.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-auth-validate.t
+++ b/src/apisix/t/bk-auth-validate.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-auth-verify.t
+++ b/src/apisix/t/bk-auth-verify.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-backend-context.t
+++ b/src/apisix/t/bk-backend-context.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-default-tenant.t
+++ b/src/apisix/t/bk-default-tenant.t
@@ -2,7 +2,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-delete-cookie.t
+++ b/src/apisix/t/bk-delete-cookie.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-delete-sensitive.t
+++ b/src/apisix/t/bk-delete-sensitive.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-demo.t
+++ b/src/apisix/t/bk-demo.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-legacy-invalid-params.t
+++ b/src/apisix/t/bk-legacy-invalid-params.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-log-context.t
+++ b/src/apisix/t/bk-log-context.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-mock.t
+++ b/src/apisix/t/bk-mock.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-oauth2-audience-validate.t
+++ b/src/apisix/t/bk-oauth2-audience-validate.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-oauth2-protected-resource.t
+++ b/src/apisix/t/bk-oauth2-protected-resource.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-oauth2-verify.t
+++ b/src/apisix/t/bk-oauth2-verify.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-real-ip.t
+++ b/src/apisix/t/bk-real-ip.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-request-id.t
+++ b/src/apisix/t/bk-request-id.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-resource-context.t
+++ b/src/apisix/t/bk-resource-context.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-resource-header-rewrite.t
+++ b/src/apisix/t/bk-resource-header-rewrite.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-response-check.t
+++ b/src/apisix/t/bk-response-check.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-stage-context.t
+++ b/src/apisix/t/bk-stage-context.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-stage-header-rewrite.t
+++ b/src/apisix/t/bk-stage-header-rewrite.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-status-rewrite.t
+++ b/src/apisix/t/bk-status-rewrite.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-traffic-label.t
+++ b/src/apisix/t/bk-traffic-label.t
@@ -2,7 +2,7 @@
 
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-user-restriction.t
+++ b/src/apisix/t/bk-user-restriction.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/t/bk-username-required.t
+++ b/src/apisix/t/bk-username-required.t
@@ -1,7 +1,7 @@
 #
 # TencentBlueKing is pleased to support the open source community by making
 # 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
-# Copyright (C) 2025 Tencent. All rights reserved.
+# Copyright (C) Tencent. All rights reserved.
 # Licensed under the MIT License (the "License") you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
 #

--- a/src/apisix/tests/bk-auth-verify/test-access-token-utils.lua
+++ b/src/apisix/tests/bk-auth-verify/test-access-token-utils.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-auth-verify/test-access-token-verifier.lua
+++ b/src/apisix/tests/bk-auth-verify/test-access-token-verifier.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-auth-verify/test-app-account-verifier.lua
+++ b/src/apisix/tests/bk-auth-verify/test-app-account-verifier.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-auth-verify/test-auth-params.lua
+++ b/src/apisix/tests/bk-auth-verify/test-auth-params.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-auth-verify/test-init.lua
+++ b/src/apisix/tests/bk-auth-verify/test-init.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-auth-verify/test-inner-jwt-verifier.lua
+++ b/src/apisix/tests/bk-auth-verify/test-inner-jwt-verifier.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-auth-verify/test-jwt-utils.lua
+++ b/src/apisix/tests/bk-auth-verify/test-jwt-utils.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-auth-verify/test-jwt-verifier.lua
+++ b/src/apisix/tests/bk-auth-verify/test-jwt-verifier.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-auth-verify/test-signature.lua
+++ b/src/apisix/tests/bk-auth-verify/test-signature.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-cache-fallback/test-init.lua
+++ b/src/apisix/tests/bk-cache-fallback/test-init.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-cache/test-app-account.lua
+++ b/src/apisix/tests/bk-cache/test-app-account.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-cache/test-app-tenant-info.lua
+++ b/src/apisix/tests/bk-cache/test-app-tenant-info.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-cache/test-cookie.lua
+++ b/src/apisix/tests/bk-cache/test-cookie.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-cache/test-jwt-key.lua
+++ b/src/apisix/tests/bk-cache/test-jwt-key.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-cache/test-user-tenant-info.lua
+++ b/src/apisix/tests/bk-cache/test-user-tenant-info.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-components/test-bkauth.lua
+++ b/src/apisix/tests/bk-components/test-bkauth.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-components/test-bkuser.lua
+++ b/src/apisix/tests/bk-components/test-bkuser.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-components/test-utils.lua
+++ b/src/apisix/tests/bk-components/test-utils.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-core/test-errorx.lua
+++ b/src/apisix/tests/bk-core/test-errorx.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-core/test-hmac.lua
+++ b/src/apisix/tests/bk-core/test-hmac.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-core/test-request.lua
+++ b/src/apisix/tests/bk-core/test-request.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-core/test-string.lua
+++ b/src/apisix/tests/bk-core/test-string.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-core/test-upstream.lua
+++ b/src/apisix/tests/bk-core/test-upstream.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-core/test-url.lua
+++ b/src/apisix/tests/bk-core/test-url.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-define/test-access-token.lua
+++ b/src/apisix/tests/bk-define/test-access-token.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-define/test-context-api-bkauth.lua
+++ b/src/apisix/tests/bk-define/test-context-api-bkauth.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-define/test-context-resource-bkauth.lua
+++ b/src/apisix/tests/bk-define/test-context-resource-bkauth.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/bk-rate-limit/test-init.lua
+++ b/src/apisix/tests/bk-rate-limit/test-init.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/busted_helper.lua
+++ b/src/apisix/tests/busted_helper.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/busted_runner.lua
+++ b/src/apisix/tests/busted_runner.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-access-token-source.lua
+++ b/src/apisix/tests/test-bk-access-token-source.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-auth-validate.lua
+++ b/src/apisix/tests/test-bk-auth-validate.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-auth-verify.lua
+++ b/src/apisix/tests/test-bk-auth-verify.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-backend-context.lua
+++ b/src/apisix/tests/test-bk-backend-context.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-break-recursive-call.lua
+++ b/src/apisix/tests/test-bk-break-recursive-call.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-concurrency-limit.lua
+++ b/src/apisix/tests/test-bk-concurrency-limit.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-core-config.lua
+++ b/src/apisix/tests/test-bk-core-config.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-core-oauth2.lua
+++ b/src/apisix/tests/test-bk-core-oauth2.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-cors.lua
+++ b/src/apisix/tests/test-bk-cors.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-debug.lua
+++ b/src/apisix/tests/test-bk-debug.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-default-tenant.lua
+++ b/src/apisix/tests/test-bk-default-tenant.lua
@@ -2,7 +2,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-delete-cookie.lua
+++ b/src/apisix/tests/test-bk-delete-cookie.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-delete-sensitive.lua
+++ b/src/apisix/tests/test-bk-delete-sensitive.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-error-wrapper.lua
+++ b/src/apisix/tests/test-bk-error-wrapper.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-ip-restriction.lua
+++ b/src/apisix/tests/test-bk-ip-restriction.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-jwt.lua
+++ b/src/apisix/tests/test-bk-jwt.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-legacy-invalid-params.lua
+++ b/src/apisix/tests/test-bk-legacy-invalid-params.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-log-context.lua
+++ b/src/apisix/tests/test-bk-log-context.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-mock.lua
+++ b/src/apisix/tests/test-bk-mock.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-oauth2-audience-validate.lua
+++ b/src/apisix/tests/test-bk-oauth2-audience-validate.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-oauth2-protected-resource.lua
+++ b/src/apisix/tests/test-bk-oauth2-protected-resource.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-oauth2-verify.lua
+++ b/src/apisix/tests/test-bk-oauth2-verify.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-opentelemetry.lua
+++ b/src/apisix/tests/test-bk-opentelemetry.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-permission.lua
+++ b/src/apisix/tests/test-bk-permission.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-proxy-rewrite.lua
+++ b/src/apisix/tests/test-bk-proxy-rewrite.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-real-ip.lua
+++ b/src/apisix/tests/test-bk-real-ip.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-request-body-limit.lua
+++ b/src/apisix/tests/test-bk-request-body-limit.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-request-id.lua
+++ b/src/apisix/tests/test-bk-request-id.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-resource-context.lua
+++ b/src/apisix/tests/test-bk-resource-context.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-resource-header-rewrite.lua
+++ b/src/apisix/tests/test-bk-resource-header-rewrite.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-resource-rate-limit.lua
+++ b/src/apisix/tests/test-bk-resource-rate-limit.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-response-check.lua
+++ b/src/apisix/tests/test-bk-response-check.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-stage-context.lua
+++ b/src/apisix/tests/test-bk-stage-context.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-stage-global-rate-limit.lua
+++ b/src/apisix/tests/test-bk-stage-global-rate-limit.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-stage-header-rewrite.lua
+++ b/src/apisix/tests/test-bk-stage-header-rewrite.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-stage-rate-limit.lua
+++ b/src/apisix/tests/test-bk-stage-rate-limit.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-status-rewrite.lua
+++ b/src/apisix/tests/test-bk-status-rewrite.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-tenant-validate.lua
+++ b/src/apisix/tests/test-bk-tenant-validate.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-tenant-verify.lua
+++ b/src/apisix/tests/test-bk-tenant-verify.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-user-restriction.lua
+++ b/src/apisix/tests/test-bk-user-restriction.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-username-required.lua
+++ b/src/apisix/tests/test-bk-username-required.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-bk-verified-user-exempted-apps.lua
+++ b/src/apisix/tests/test-bk-verified-user-exempted-apps.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-example.lua
+++ b/src/apisix/tests/test-example.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-lrucache.lua
+++ b/src/apisix/tests/test-lrucache.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-router.lua
+++ b/src/apisix/tests/test-router.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/tests/test-test.lua
+++ b/src/apisix/tests/test-test.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --

--- a/src/apisix/typing.lua
+++ b/src/apisix/typing.lua
@@ -1,7 +1,7 @@
 --
 -- TencentBlueKing is pleased to support the open source community by making
 -- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
--- Copyright (C) 2025 Tencent. All rights reserved.
+-- Copyright (C) Tencent. All rights reserved.
 -- Licensed under the MIT License (the "License"); you may not use this file except
 -- in compliance with the License. You may obtain a copy of the License at
 --


### PR DESCRIPTION
## Summary
- remove the hard-coded 2025 year from Tencent copyright headers
- keep the existing header text otherwise unchanged across committed plugin, test, and edition files

## Verification
- `rg -n "Copyright \(C\) 2025 Tencent\. All rights reserved\."` in the worktree returned no matches after the replacement
- `git diff --check` passed
- `make check-license` fails on pre-existing `src/apisix/tests/test-bk-traffic-label.lua`, which already lacks the required `TencentBlueKing is pleased to` header on `upstream/master`