### PR TITLE
fix(plugins): run query string rewrite before proxy rewrite

### DIFF
--- a/src/apisix/plugins/README.md
+++ b/src/apisix/plugins/README.md
@@ -71,11 +71,11 @@ proxy 预处理：17000 ~ 17500
 - bk-traffic-label                          # priority: 17460
 - bk-delete-sensitive                       # priority: 17450
 - bk-delete-cookie                          # priority: 17440
+- bk-query-string-rewrite                   # priority: 17435
 - bk-proxy-rewrite                          # priority: 17430 # 该插件供 operator 进行后端地址转换使用
 - bk-default-tenant                         # priority: 17425
 - bk-stage-header-rewrite                   # priority: 17421
 - bk-resource-header-rewrite                # priority: 17420
-- bk-query-string-rewrite                   # priority: 17410
 - bk-mock                                   # priority: 17150
 
 官方插件：

--- a/src/apisix/plugins/bk-query-string-rewrite.lua
+++ b/src/apisix/plugins/bk-query-string-rewrite.lua
@@ -70,7 +70,7 @@ local schema = {
 
 local _M = {
     version = 0.1,
-    priority = 17410,
+    priority = 17435,
     name = plugin_name,
     schema = schema,
 }
@@ -111,7 +111,6 @@ function _M.rewrite(conf, ctx)
             end
         end
     end
-
     if changed then
         core.request.set_uri_args(ctx, uri_args)
     end

--- a/src/apisix/t/bk-query-string-rewrite.t
+++ b/src/apisix/t/bk-query-string-rewrite.t
@@ -282,7 +282,57 @@ GET /hello?added=original&forced=old&unwanted=bye
 --- response_body_like
 args:(?=.*added=original)(?=.*forced=value)(?!.*unwanted=).*
 
-=== TEST 16: disable plugin
+=== TEST 16: set route with proxy rewrite
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "plugins": {
+                        "bk-query-string-rewrite": {
+                            "set": {
+                                "version": "v2",
+                                "bk_app_code": "demo"
+                            },
+                            "remove": ["debug"]
+                        },
+                        "bk-proxy-rewrite": {
+                            "uri": "/plugin_proxy_rewrite_args"
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+
+=== TEST 17: proxy rewrite uses rewritten query params
+--- request
+GET /hello?name=tom&debug=true
+--- response_body
+uri: /plugin_proxy_rewrite_args
+bk_app_code: demo
+name: tom
+version: v2
+
+=== TEST 18: disable plugin
 --- config
     location /t {
         content_by_lua_block {


### PR DESCRIPTION
## Summary
- Run bk-query-string-rewrite before bk-proxy-rewrite so upstream_uri is built from rewritten args.
- Update the plugin priority README entry.
- Add a test-nginx regression covering query rewrite with proxy rewrite.

## Verification
- make edition-ee
- RUN_WITH_IT= make lint
- RUN_WITH_IT= make test
