### PR TITLE
fix(build): rotate file-logger access log

### DIFF
--- a/src/build/patches/008_log_rotate_file_logger_access_log.patch
+++ b/src/build/patches/008_log_rotate_file_logger_access_log.patch
@@ -1,0 +1,16 @@
+diff --git a/apisix/plugins/log-rotate.lua b/apisix/plugins/log-rotate.lua
+index f90226d8..c841e20c 100644
+--- a/apisix/plugins/log-rotate.lua
++++ b/apisix/plugins/log-rotate.lua
+@@ -188,8 +188,9 @@ local function compression_file(new_file, timeout)
+ 
+ local function init_default_logs(logs_info, log_type)
+     local_conf = core.config.local_conf()
+-    enable_access_log = core.table.try_read_attr(
+-        local_conf, "nginx_config", "http", "enable_access_log")
++    -- BlueKing uses file-logger to write logs/access.log with Nginx access logging disabled.
++    -- Keep rotating that file to prevent unbounded growth and preserve APISIX 3.13 behavior.
++    enable_access_log = true
+     local filepath, filename = get_log_path_info(log_type)
+     logs_info[log_type] = { type = log_type }
+     if filename ~= "off" then


### PR DESCRIPTION
### Description

APISIX 3.16 `log-rotate` skips `logs/access.log` when `nginx_config.http.enable_access_log` is false. BlueKing disables native Nginx access logging and uses `file-logger` to write that file, so it is not rotated and can grow without bounds.

This build patch forces only the internal log-rotation eligibility flag to true. Native Nginx access logging remains disabled, so this restores the APISIX 3.13 rotation behavior without adding a second log writer.

### Verification

- [x] Patch applies cleanly to the pinned APISIX source with `git apply --check`
- [x] Patch applies cleanly with the build-compatible `patch -p1 --dry-run`
- [x] `RUN_WITH_IT= make lint` — 0 warnings / 0 errors
- [x] `RUN_WITH_IT= make test` — 752 Busted successes and 681 test-nginx tests passed

### Checklist

- [x] PR description and context provided
- [x] Code style checks passed
- [ ] Dedicated unit test included — not applicable to this build-time upstream patch
- [x] Existing unit and integration tests passed
- [ ] Local deployment validation — not run