### PR TITLE
chore(apisix): upgrade runtime to 3.17.0

### DIFF
--- a/.github/workflows/apisix.yml
+++ b/.github/workflows/apisix.yml
@@ -59,6 +59,6 @@ jobs:
       run: |
         echo "start backing up, $(date)"
         mkdir docker-images-backup
-        docker save apisix-test-busted-316 -o docker-images-backup/apisix-test-busted-images.tar
-        docker save apisix-test-nginx-316 -o docker-images-backup/apisix-test-nginx-images.tar
+        docker save apisix-test-busted-317 -o docker-images-backup/apisix-test-busted-images.tar
+        docker save apisix-test-nginx-317 -o docker-images-backup/apisix-test-nginx-images.tar
         echo "docker save done, time: $(date)"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/apisix-core"]
 	path = src/apisix-core
 	url = https://github.com/apache/apisix.git
-	branch = release/3.13
+	branch = release/3.17

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM tencentos/tencentos4-minimal:4.4-v20250922
 
-ARG APISIX_VERSION=3.16.0
+ARG APISIX_VERSION=3.17.0
 LABEL apisix_version="${APISIX_VERSION}"
 
 # 1. yum install

--- a/src/apisix/Makefile
+++ b/src/apisix/Makefile
@@ -4,11 +4,11 @@ RUN_WITH_IT ?= -it
 
 .PHONY: apisix-test-busted
 apisix-test-busted:
-	docker build -t apisix-test-busted-316 -f ci/Dockerfile.apisix-test-busted .
+	docker build -t apisix-test-busted-317 -f ci/Dockerfile.apisix-test-busted .
 
 .PHONY: apisix-test-nginx
 apisix-test-nginx:
-	docker build -t apisix-test-nginx-316 -f ci/Dockerfile.apisix-test-nginx .
+	docker build -t apisix-test-nginx-317 -f ci/Dockerfile.apisix-test-nginx .
 
 .PHONY: test-busted
 test-busted:
@@ -18,7 +18,7 @@ test-busted:
 	-v ${ROOT_DIR}/logs/:/bkgateway/logs/ \
 	-v ${ROOT_DIR}/tests/conf/nginx.conf:/bkgateway/conf/nginx.conf \
 	-v ${ROOT_DIR}/plugins:/bkgateway/apisix/plugins \
-	apisix-test-busted-316 "/run-test-busted.sh"
+	apisix-test-busted-317 "/run-test-busted.sh"
 
 # make test-nginx
 # make test-nginx CASE_FILE=bk-traffic-label.t
@@ -27,7 +27,7 @@ test-nginx:
 	@docker run --rm ${RUN_WITH_IT} \
 	-v ${ROOT_DIR}/t:/bkgateway/t/ \
 	-v ${ROOT_DIR}/plugins:/bkgateway/apisix/plugins \
-	apisix-test-nginx-316 "/run-test-nginx.sh" $(if $(CASE_FILE),$(CASE_FILE))
+	apisix-test-nginx-317 "/run-test-nginx.sh" $(if $(CASE_FILE),$(CASE_FILE))
 
 .PHONY: apisix-test-images
 apisix-test-images: apisix-test-busted apisix-test-nginx
@@ -42,7 +42,7 @@ lint:
 	-v ${ROOT_DIR}/plugins:/bkgateway/apisix/plugins \
 	-v ${ROOT_DIR}/tests:/bkgateway/tests/ \
 	-w /bkgateway/apisix \
-	apisix-test-busted-316 \
+	apisix-test-busted-317 \
 	luacheck --config /bkgateway/.luacheckrc ./plugins
 
 .PHONY: edition

--- a/src/apisix/ci/Dockerfile.apisix-test-busted
+++ b/src/apisix/ci/Dockerfile.apisix-test-busted
@@ -1,5 +1,7 @@
-ARG APISIX_VERSION="3.16.0"
+ARG APISIX_VERSION="3.17.0"
 FROM apache/apisix:$APISIX_VERSION-redhat
+
+USER root
 
 RUN yum install -y sudo make gcc wget unzip git # valgrind
 

--- a/src/apisix/ci/Dockerfile.apisix-test-nginx
+++ b/src/apisix/ci/Dockerfile.apisix-test-nginx
@@ -1,5 +1,7 @@
-ARG APISIX_VERSION="3.16.0"
+ARG APISIX_VERSION="3.17.0"
 FROM apache/apisix:$APISIX_VERSION-redhat
+
+USER root
 
 # reference: 
 # - https://github.com/apache/apisix/blob/release/3.11/.github/workflows/redhat-ci.yaml

--- a/src/apisix/ci/redhat-ci.sh
+++ b/src/apisix/ci/redhat-ci.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 # CHANGES:
-# 1. based on APISIX 3.16 redhat-ci.sh
-# 2. use UBI9 repos to match apache/apisix:3.16.0-redhat
+# 1. based on APISIX 3.17 redhat-ci.sh
+# 2. use UBI9 repos to match apache/apisix:3.17.0-redhat
 # 3. remove unused tools in install_dependencies
 
-# reference: https://github.com/apache/apisix/blob/3.16.0/ci/redhat-ci.sh
+# reference: https://github.com/apache/apisix/blob/3.17.0/ci/redhat-ci.sh
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -31,9 +31,9 @@ install_dependencies() {
 
     # install build & runtime deps
     yum install -y --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms \
-    wget tar gcc gcc-c++ automake autoconf libtool make unzip git sudo openldap-devel hostname patch \
+    wget tar gcc gcc-c++ automake autoconf libtool make cmake unzip git sudo openldap-devel hostname patch \
     which ca-certificates pcre pcre-devel pcre2 pcre2-devel xz \
-    openssl-devel
+    openssl-devel libxml2-devel libxslt-devel
 
     # FIXME: yum uninstall the build tools
 

--- a/src/apisix/t/bk-stage-context.t
+++ b/src/apisix/t/bk-stage-context.t
@@ -92,56 +92,60 @@ done
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
+            local json = require("toolkit.json")
+            local route = {
+                plugins = {
+                    ["bk-stage-context"] = {
+                        bk_gateway_name = "demo",
+                        bk_gateway_id = 1,
+                        bk_stage_name = "prod",
+                        jwt_private_key = "dGhpcyBpcyBhIGZha2Ugand0IHByaXZhdGUga2V5",
+                        bk_api_auth = {
+                            api_type = 10,
+                            unfiltered_sensitive_keys = {"a", "b"},
+                            include_system_headers = {"c", "d"},
+                            allow_auth_from_params = true,
+                            allow_delete_sensitive_params = false,
+                            uin_conf = {
+                                user_type = "uin",
+                                from_uin_skey = true,
+                                skey_type = 1,
+                                domain_id = 1,
+                                search_rtx = true,
+                                search_rtx_source = 1,
+                                from_auth_token = false,
+                            },
+                            rtx_conf = {
+                                user_type = "rtx",
+                                from_operator = true,
+                                from_bk_ticket = true,
+                                from_auth_token = true,
+                            },
+                            user_conf = {
+                                user_type = "user",
+                                from_bk_token = true,
+                                from_username = true,
+                            },
+                        },
+                    },
+                    ["serverless-post-function"] = {
+                        phase = "rewrite",
+                        functions = {
+                            "return function(conf, ctx) ngx.say(string.format(\"instance_id: %s, bk_gateway_name: %s, bk_gateway_id: %s, bk_stage_name: %s, jwt_private_key: %s\", ctx.var.instance_id, ctx.var.bk_gateway_name, ctx.var.bk_gateway_id, ctx.var.bk_stage_name, ctx.var.jwt_private_key)); ngx.exit(200); end",
+                        },
+                    },
+                },
+                upstream = {
+                    nodes = {
+                        ["127.0.0.1:1980"] = 1,
+                    },
+                    type = "roundrobin",
+                },
+                uri = "/hello",
+            }
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
-                [[{
-                        "plugins": {
-                            "bk-stage-context": {
-                                "bk_gateway_name": "demo",
-                                "bk_gateway_id": 1,
-                                "bk_stage_name": "prod",
-                                "jwt_private_key": "dGhpcyBpcyBhIGZha2Ugand0IHByaXZhdGUga2V5",
-                                "bk_api_auth": {
-                                    "api_type": 10,
-                                    "unfiltered_sensitive_keys": ["a", "b"],
-                                    "include_system_headers": ["c", "d"],
-                                    "allow_auth_from_params": true,
-                                    "allow_delete_sensitive_params": false,
-                                    "uin_conf": {
-                                        "user_type": "uin",
-                                        "from_uin_skey": true,
-                                        "skey_type": 1,
-                                        "domain_id": 1,
-                                        "search_rtx": true,
-                                        "search_rtx_source": 1,
-                                        "from_auth_token": false
-                                    },
-                                    "rtx_conf": {
-                                        "user_type": "rtx",
-                                        "from_operator": true,
-                                        "from_bk_ticket": true,
-                                        "from_auth_token": true
-                                    },
-                                    "user_conf": {
-                                        "user_type": "user",
-                                        "from_bk_token": true,
-                                        "from_username": true
-                                    }
-                                }
-                            },
-                            "serverless-post-function": {
-                                "phase": "rewrite",
-                                "functions" : ["return function(conf, ctx) ngx.say(string.format(\"instance_id: %s, bk_gateway_name: %s, bk_gateway_id: %s, bk_stage_name: %s, jwt_private_key: %s\", ctx.var.instance_id, ctx.var.bk_gateway_name, ctx.var.bk_gateway_id, ctx.var.bk_stage_name, ctx.var.jwt_private_key)); ngx.exit(200); end"]
-                            }
-                        },
-                        "upstream": {
-                            "nodes": {
-                                "127.0.0.1:1980": 1
-                            },
-                            "type": "roundrobin"
-                        },
-                        "uri": "/hello"
-                }]]
+                json.encode(route)
                 )
             if code >= 300 then
                 ngx.status = code
@@ -170,56 +174,60 @@ instance_id: 2c4562899afc453f85bb9c228ed6febd, bk_gateway_name: demo, bk_gateway
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
+            local json = require("toolkit.json")
+            local route = {
+                plugins = {
+                    ["bk-stage-context"] = {
+                        bk_gateway_name = "demo",
+                        bk_gateway_id = 1,
+                        bk_stage_name = "prod",
+                        jwt_private_key = "dGhpcyBpcyBhIGZha2Ugand0IHByaXZhdGUga2V5",
+                        bk_api_auth = {
+                            api_type = 10,
+                            unfiltered_sensitive_keys = {"a", "b"},
+                            include_system_headers = {"c", "d"},
+                            allow_auth_from_params = true,
+                            allow_delete_sensitive_params = false,
+                            uin_conf = {
+                                user_type = "uin",
+                                from_uin_skey = true,
+                                skey_type = 1,
+                                domain_id = 1,
+                                search_rtx = true,
+                                search_rtx_source = 1,
+                                from_auth_token = false,
+                            },
+                            rtx_conf = {
+                                user_type = "rtx",
+                                from_operator = true,
+                                from_bk_ticket = true,
+                                from_auth_token = true,
+                            },
+                            user_conf = {
+                                user_type = "user",
+                                from_bk_token = true,
+                                from_username = true,
+                            },
+                        },
+                    },
+                    ["serverless-post-function"] = {
+                        phase = "rewrite",
+                        functions = {
+                            "return function(conf, ctx) ngx.say(string.format(\"bk_api_auth: %s, bk_resource_name: %s, bk_service_name: %s\", require(\"toolkit.json\").encode(ctx.var.bk_api_auth), ctx.var.bk_resource_name, ctx.var.bk_service_name)); ngx.exit(200); end",
+                        },
+                    },
+                },
+                upstream = {
+                    nodes = {
+                        ["127.0.0.1:1980"] = 1,
+                    },
+                    type = "roundrobin",
+                },
+                uri = "/hello",
+            }
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
-                [[{
-                        "plugins": {
-                            "bk-stage-context": {
-                                "bk_gateway_name": "demo",
-                                "bk_gateway_id": 1,
-                                "bk_stage_name": "prod",
-                                "jwt_private_key": "dGhpcyBpcyBhIGZha2Ugand0IHByaXZhdGUga2V5",
-                                "bk_api_auth": {
-                                    "api_type": 10,
-                                    "unfiltered_sensitive_keys": ["a", "b"],
-                                    "include_system_headers": ["c", "d"],
-                                    "allow_auth_from_params": true,
-                                    "allow_delete_sensitive_params": false,
-                                    "uin_conf": {
-                                        "user_type": "uin",
-                                        "from_uin_skey": true,
-                                        "skey_type": 1,
-                                        "domain_id": 1,
-                                        "search_rtx": true,
-                                        "search_rtx_source": 1,
-                                        "from_auth_token": false
-                                    },
-                                    "rtx_conf": {
-                                        "user_type": "rtx",
-                                        "from_operator": true,
-                                        "from_bk_ticket": true,
-                                        "from_auth_token": true
-                                    },
-                                    "user_conf": {
-                                        "user_type": "user",
-                                        "from_bk_token": true,
-                                        "from_username": true
-                                    }
-                                }
-                            },
-                            "serverless-post-function": {
-                                "phase": "rewrite",
-                                "functions" : ["return function(conf, ctx) ngx.say(string.format(\"bk_api_auth: %s, bk_resource_name: %s, bk_service_name: %s\", require(\"toolkit.json\").encode(ctx.var.bk_api_auth), ctx.var.bk_resource_name, ctx.var.bk_service_name)); ngx.exit(200); end"]
-                            }
-                        },
-                        "upstream": {
-                            "nodes": {
-                                "127.0.0.1:1980": 1
-                            },
-                            "type": "roundrobin"
-                        },
-                        "uri": "/hello"
-                }]]
+                json.encode(route)
                 )
             if code >= 300 then
                 ngx.status = code

--- a/src/build/patches/001_change_prometheus_default_buckets.patch
+++ b/src/build/patches/001_change_prometheus_default_buckets.patch
@@ -1,8 +1,8 @@
 diff --git a/apisix/plugins/prometheus/exporter.lua b/apisix/plugins/prometheus/exporter.lua
-index ed219a49..fb277e67 100644
+index ce89ca0..f10fae5 100644
 --- a/apisix/plugins/prometheus/exporter.lua
 +++ b/apisix/plugins/prometheus/exporter.lua
-@@ -308,6 +308,12 @@
+@@ -291,6 +291,12 @@ end
  
  
  function _M.http_log(conf, ctx)
@@ -15,24 +15,28 @@ index ed219a49..fb277e67 100644
      local vars = ctx.var
  
      local route_id = ""
-@@ -335,62 +341,70 @@
+@@ -318,64 +324,72 @@ function _M.http_log(conf, ctx)
          matched_host = ctx.curr_req_matched._host or ""
      end
+ 
+-    local response_source = core.response.get_response_source(ctx)
++    if official and official.enable_status then
++        local response_source = core.response.get_response_source(ctx)
  
 -    metrics.status:inc(1,
 -        gen_arr(vars.status, route_id, matched_uri, matched_host,
 -                service_id, consumer_name, balancer_ip,
 -                vars.request_type, vars.request_llm_model, vars.llm_model,
+-                response_source,
 -                unpack(extra_labels("http_status", ctx))))
-+    if official and official.enable_status then
 +        metrics.status:inc(1,
 +            gen_arr(vars.status, route_id, matched_uri, matched_host,
 +                    service_id, consumer_name, balancer_ip,
 +                    vars.request_type, vars.request_llm_model, vars.llm_model,
++                    response_source,
 +                    unpack(extra_labels("http_status", ctx))))
 +    end
--
-+
+ 
 -    local latency, upstream_latency, apisix_latency = latency_details(ctx)
 -    local latency_extra_label_values = extra_labels("http_latency", ctx)
 +    if official and official.enable_latency then
@@ -43,94 +47,87 @@ index ed219a49..fb277e67 100644
 -        gen_arr("request", route_id, service_id, consumer_name, balancer_ip,
 -        vars.request_type, vars.request_llm_model, vars.llm_model,
 -        unpack(latency_extra_label_values)))
--
--    if upstream_latency then
--        metrics.latency:observe(upstream_latency,
--            gen_arr("upstream", route_id, service_id, consumer_name, balancer_ip,
 +        metrics.latency:observe(latency,
 +            gen_arr("request", route_id, service_id, consumer_name, balancer_ip,
-             vars.request_type, vars.request_llm_model, vars.llm_model,
-             unpack(latency_extra_label_values)))
--    end
- 
--    metrics.latency:observe(apisix_latency,
--        gen_arr("apisix", route_id, service_id, consumer_name, balancer_ip,
--        vars.request_type, vars.request_llm_model, vars.llm_model,
--        unpack(latency_extra_label_values)))
--
--    local bandwidth_extra_label_values = extra_labels("bandwidth", ctx)
--
--    metrics.bandwidth:inc(vars.request_length,
--        gen_arr("ingress", route_id, service_id, consumer_name, balancer_ip,
--        vars.request_type, vars.request_llm_model, vars.llm_model,
--        unpack(bandwidth_extra_label_values)))
--
--    metrics.bandwidth:inc(vars.bytes_sent,
--        gen_arr("egress", route_id, service_id, consumer_name, balancer_ip,
--        vars.request_type, vars.request_llm_model, vars.llm_model,
--        unpack(bandwidth_extra_label_values)))
--
--    local llm_time_to_first_token = vars.llm_time_to_first_token
--    if llm_time_to_first_token ~= "" then
--        metrics.llm_latency:observe(tonumber(llm_time_to_first_token),
--            gen_arr(route_id, service_id, consumer_name, balancer_ip,
++            vars.request_type, vars.request_llm_model, vars.llm_model,
++            unpack(latency_extra_label_values)))
++
 +        if upstream_latency then
 +            metrics.latency:observe(upstream_latency,
 +                gen_arr("upstream", route_id, service_id, consumer_name, balancer_ip,
 +                vars.request_type, vars.request_llm_model, vars.llm_model,
 +                unpack(latency_extra_label_values)))
 +        end
-+
+ 
+-    if upstream_latency then
+-        metrics.latency:observe(upstream_latency,
+-            gen_arr("upstream", route_id, service_id, consumer_name, balancer_ip,
 +        metrics.latency:observe(apisix_latency,
 +            gen_arr("apisix", route_id, service_id, consumer_name, balancer_ip,
              vars.request_type, vars.request_llm_model, vars.llm_model,
--            unpack(extra_labels("llm_latency", ctx))))
-+            unpack(latency_extra_label_values)))
+             unpack(latency_extra_label_values)))
      end
--    if vars.llm_prompt_tokens ~= "" then
--        metrics.llm_prompt_tokens:inc(tonumber(vars.llm_prompt_tokens),
--            gen_arr(route_id, service_id, consumer_name, balancer_ip,
-+
+ 
+-    metrics.latency:observe(apisix_latency,
+-        gen_arr("apisix", route_id, service_id, consumer_name, balancer_ip,
+-        vars.request_type, vars.request_llm_model, vars.llm_model,
+-        unpack(latency_extra_label_values)))
 +    if official and official.enable_bandwidth then
 +        local bandwidth_extra_label_values = extra_labels("bandwidth", ctx)
-+
+ 
+-    local bandwidth_extra_label_values = extra_labels("bandwidth", ctx)
 +        metrics.bandwidth:inc(vars.request_length,
 +            gen_arr("ingress", route_id, service_id, consumer_name, balancer_ip,
-             vars.request_type, vars.request_llm_model, vars.llm_model,
--            unpack(extra_labels("llm_prompt_tokens", ctx))))
--    end
--    if vars.llm_completion_tokens ~= "" then
--        metrics.llm_completion_tokens:inc(tonumber(vars.llm_completion_tokens),
--            gen_arr(route_id, service_id, consumer_name, balancer_ip,
++            vars.request_type, vars.request_llm_model, vars.llm_model,
 +            unpack(bandwidth_extra_label_values)))
-+
+ 
+-    metrics.bandwidth:inc(vars.request_length,
+-        gen_arr("ingress", route_id, service_id, consumer_name, balancer_ip,
+-        vars.request_type, vars.request_llm_model, vars.llm_model,
+-        unpack(bandwidth_extra_label_values)))
 +        metrics.bandwidth:inc(vars.bytes_sent,
 +            gen_arr("egress", route_id, service_id, consumer_name, balancer_ip,
-             vars.request_type, vars.request_llm_model, vars.llm_model,
--            unpack(extra_labels("llm_completion_tokens", ctx))))
++            vars.request_type, vars.request_llm_model, vars.llm_model,
 +            unpack(bandwidth_extra_label_values)))
 +    end
-+
+ 
+-    metrics.bandwidth:inc(vars.bytes_sent,
+-        gen_arr("egress", route_id, service_id, consumer_name, balancer_ip,
+-        vars.request_type, vars.request_llm_model, vars.llm_model,
+-        unpack(bandwidth_extra_label_values)))
 +    if official and official.enable_llm then
-+        local llm_time_to_first_token = vars.llm_time_to_first_token
-+        if llm_time_to_first_token ~= "" then
-+            metrics.llm_latency:observe(tonumber(llm_time_to_first_token),
-+                gen_arr(route_id, service_id, consumer_name, balancer_ip,
-+                vars.request_type, vars.request_llm_model, vars.llm_model,
-+                unpack(extra_labels("llm_latency", ctx))))
-+        end
-+        if vars.llm_prompt_tokens ~= "" then
++        if vars.request_type == "ai_stream" or vars.request_type == "ai_chat" then
++            local llm_time_to_first_token = vars.llm_time_to_first_token
++            if llm_time_to_first_token ~= "0" then
++                metrics.llm_latency:observe(tonumber(llm_time_to_first_token),
++                    gen_arr(route_id, service_id, consumer_name, balancer_ip,
++                        vars.request_type, vars.request_llm_model, vars.llm_model,
++                        unpack(extra_labels("llm_latency", ctx))))
++            end
 +            metrics.llm_prompt_tokens:inc(tonumber(vars.llm_prompt_tokens),
 +                gen_arr(route_id, service_id, consumer_name, balancer_ip,
-+                vars.request_type, vars.request_llm_model, vars.llm_model,
-+                unpack(extra_labels("llm_prompt_tokens", ctx))))
-+        end
-+        if vars.llm_completion_tokens ~= "" then
++                    vars.request_type, vars.request_llm_model, vars.llm_model,
++                    unpack(extra_labels("llm_prompt_tokens", ctx))))
+ 
+-    if vars.request_type == "ai_stream" or vars.request_type == "ai_chat" then
+-        local llm_time_to_first_token = vars.llm_time_to_first_token
+-        if llm_time_to_first_token ~= "0" then
+-            metrics.llm_latency:observe(tonumber(llm_time_to_first_token),
 +            metrics.llm_completion_tokens:inc(tonumber(vars.llm_completion_tokens),
-+                gen_arr(route_id, service_id, consumer_name, balancer_ip,
-+                vars.request_type, vars.request_llm_model, vars.llm_model,
-+                unpack(extra_labels("llm_completion_tokens", ctx))))
-+        end
+                 gen_arr(route_id, service_id, consumer_name, balancer_ip,
+                     vars.request_type, vars.request_llm_model, vars.llm_model,
+-                    unpack(extra_labels("llm_latency", ctx))))
++                    unpack(extra_labels("llm_completion_tokens", ctx))))
+         end
+-        metrics.llm_prompt_tokens:inc(tonumber(vars.llm_prompt_tokens),
+-            gen_arr(route_id, service_id, consumer_name, balancer_ip,
+-                vars.request_type, vars.request_llm_model, vars.llm_model,
+-                unpack(extra_labels("llm_prompt_tokens", ctx))))
+-
+-        metrics.llm_completion_tokens:inc(tonumber(vars.llm_completion_tokens),
+-            gen_arr(route_id, service_id, consumer_name, balancer_ip,
+-                vars.request_type, vars.request_llm_model, vars.llm_model,
+-                unpack(extra_labels("llm_completion_tokens", ctx))))
      end
  end
  


### PR DESCRIPTION
### Description

Upgrade the BlueKing API Gateway data plane from APISIX 3.16.0 to 3.17.0 while preserving the existing BlueKing build and Prometheus metric-gating behavior.

### Changes

- Pin the production image, test images, CI image names, and APISIX submodule to 3.17.0.
- Track the APISIX `release/3.17` submodule branch.
- Add the UBI9 build dependencies needed by the 3.17 test image.
- Rebase the Prometheus exporter customization onto the 3.17 implementation, including its `response_source` label and LLM metric behavior.
- Encode the two large `bk-stage-context` route payloads at runtime to avoid the OpenResty 1.29 config-buffer parser boundary exposed by APISIX 3.17.

### Verification

- Production image build: passed; image label and `apisix version` both report `3.17.0`.
- `RUN_WITH_IT= make lint`: 91 files, 0 warnings, 0 errors.
- `RUN_WITH_IT= make test`: 752 Busted tests and 681 test-nginx tests passed.
- Both APISIX 3.17 test images built successfully.
- All repository patches applied during the production image build.

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [x] 本地开发联调环境验证通过 (local development environment verification passed)
