### PR TITLE
fix(build): reclaim expired prometheus shared dict entries

### DIFF
--- a/src/build/patches/009_prometheus_reclaim_expired_shared_dict_entries.patch
+++ b/src/build/patches/009_prometheus_reclaim_expired_shared_dict_entries.patch
@@ -1,0 +1,25 @@
+diff --git a/deps/share/lua/5.1/prometheus_keys.lua b/deps/share/lua/5.1/prometheus_keys.lua
+index 0c5f102..faeaa66 100644
+--- a/deps/share/lua/5.1/prometheus_keys.lua
++++ b/deps/share/lua/5.1/prometheus_keys.lua
+@@ -44,6 +44,20 @@ function KeyIndex:remove_expired_keys()
+       self.expire_keys[i] = nil
+     end
+   end
++
++  -- The loop above only drops worker-local references. The expired shared-dict
++  -- entries themselves (both the __ngx_prom__key_N index slots and the metric
++  -- value keys, which live in the same dict) are only *logically* dead: every
++  -- dict API treats them as missing, but their slab pages stay allocated. The
++  -- passive per-write expiry scan cannot reclaim them either, because it stops
++  -- at the first non-expired entry at the LRU tail, and a permanent entry (the
++  -- error metric, or any metric registered without an exptime) inevitably ends
++  -- up sitting there. Without this call the dict grows without bound under
++  -- label churn: index slots are never reused, so free_space steps down on
++  -- every new series and never recovers (apache/apisix#13658). Since expired
++  -- entries are indistinguishable from absent ones through every dict API,
++  -- reclaiming them here cannot change any observable behaviour.
++  self.dict:flush_expired()
+ end
+ 
+ -- Loads new keys that might have been added by other workers since last sync.


### PR DESCRIPTION
### Description

Backport the physical shared-dict reclamation fix from api7/nginx-lua-prometheus#18.

The existing cleanup removes only worker-local key-index references. Expired metric values and index slots can continue occupying shared-dict slab pages under label churn, causing `prometheus-metrics` usage to grow without recovering. The build patch calls `flush_expired()` after the existing expiry scan.

Related:
- https://github.com/apache/apisix/issues/13658
- https://github.com/api7/nginx-lua-prometheus/pull/18

### Verification

- Patch dry-run with `--fuzz=0` against both `apache/apisix:3.16.0-redhat` and `apache/apisix:3.17.0-redhat`
- Built `bk-apigateway-apisix:prometheus-flush-master-codex` from this branch
- Verified the built APISIX 3.17.0 image contains exactly one `self.dict:flush_expired()` call in `prometheus_keys.lua`
- LuaJIT bytecode compilation of the patched file succeeded
- `RUN_WITH_IT= make lint`: 0 warnings / 0 errors
- `RUN_WITH_IT= make test`: Busted 752 successes; test-nginx 681 tests, all successful

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test) — dependency patch; upstream PR contains regression tests
- [x] 单元测试通过 (unit test passed)
- [x] 本地开发联调环境验证通过 (local development environment verification passed)