### PR TITLE
feat(oauth2): support wildcard audience scopes

### DIFF
--- a/src/apisix/plugins/bk-oauth2-audience-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-audience-validate.lua
@@ -22,8 +22,10 @@
 --
 -- Audience formats supported:
 --   - mcp:{mcp_server_name} - Access to specific MCP server
+--   - mcp:* - Access to any MCP server
 --   - gateway:{gateway_name}/api:{api_name} - Access to specific gateway API
 --   - gateway:{gateway_name}/api:* - Access to all APIs under a gateway (wildcard)
+--   - gateway:* - Access to all APIs under any gateway
 --
 -- This plugin only runs when ctx.var.is_bk_oauth2 == true (set by bk-oauth2-protected-resource).
 --
@@ -79,6 +81,15 @@ local function parse_audience(audience_str)
         }
     end
 
+    -- Normalize gateway:* to gateway:*/api:*
+    if audience_str == "gateway:*" then
+        return {
+            type = "gateway_api",
+            gateway = "*",
+            api = "*",
+        }
+    end
+
     -- Try gateway:{gateway}/api:{api} format
     local gateway, api = string_match(audience_str, "^gateway:([^/]+)/api:(.+)$")
     if gateway and api then
@@ -130,7 +141,7 @@ local function check_mcp_server_audience(parsed, ctx)
     end
 
     -- Check if the MCP server from path matches the audience
-    if path_mcp_server == parsed.name then
+    if parsed.name == "*" or path_mcp_server == parsed.name then
         return true, ""
     end
 
@@ -146,6 +157,16 @@ end
 local function check_gateway_api_audience(parsed, ctx)
     local current_gateway = ctx.var.bk_gateway_name
     local current_resource = ctx.var.bk_resource_name
+
+    -- Only gateway:* should produce a wildcard gateway, normalized with a wildcard API.
+    if parsed.gateway == "*" then
+        if parsed.api == "*" then
+            return true, ""
+        end
+
+
+        return false, "invalid parsed audience: wildcard gateway requires wildcard api"
+    end
 
     -- Check gateway matches
     if parsed.gateway ~= current_gateway then

--- a/src/apisix/t/bk-oauth2-audience-validate.t
+++ b/src/apisix/t/bk-oauth2-audience-validate.t
@@ -392,3 +392,76 @@ status: 403
     }
 --- response_body
 status: 403
+
+=== TEST 17: test validation logic - MCP server wildcard match
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-audience-validate")
+            local ctx = {
+                var = {
+                    is_bk_oauth2 = true,
+                    bk_gateway_name = "bk-apigateway",
+                    bk_resource_name = "mcp-resource",
+                    uri = "/api/v2/mcp-servers/any-server/resources",
+                    audience = {"mcp:*"}
+                }
+            }
+
+            local result = plugin.rewrite({}, ctx)
+            if result == nil then
+                ngx.say("pass")
+            else
+                ngx.say("fail")
+            end
+        }
+    }
+--- response_body
+pass
+
+=== TEST 18: test validation logic - gateway wildcard match
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-audience-validate")
+            local ctx = {
+                var = {
+                    is_bk_oauth2 = true,
+                    bk_gateway_name = "any-gateway",
+                    bk_resource_name = "any-api",
+                    audience = {"gateway:*"}
+                }
+            }
+
+            local result = plugin.rewrite({}, ctx)
+            if result == nil then
+                ngx.say("pass")
+            else
+                ngx.say("fail")
+            end
+        }
+    }
+--- response_body
+pass
+
+=== TEST 19: FAIL - wildcard gateway with a specific API returns 403
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-audience-validate")
+            local ctx = {
+                var = {
+                    is_bk_oauth2 = true,
+                    bk_gateway_name = "any-gateway",
+                    bk_resource_name = "test-api",
+                    audience = {"gateway:*/api:test-api"}
+                }
+            }
+
+            local status = plugin.rewrite({}, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+        }
+    }
+--- response_body
+status: 403

--- a/src/apisix/tests/test-bk-oauth2-audience-validate.lua
+++ b/src/apisix/tests/test-bk-oauth2-audience-validate.lua
@@ -107,6 +107,15 @@ describe(
                 )
 
                 it(
+                    "should parse mcp wildcard format", function()
+                        local result = plugin._parse_audience("mcp:*")
+
+                        assert.is_equal("mcp_server", result.type)
+                        assert.is_equal("*", result.name)
+                    end
+                )
+
+                it(
                     "should parse gateway_api format correctly", function()
                         local result = plugin._parse_audience("gateway:demo/api:test-api")
 
@@ -122,6 +131,16 @@ describe(
 
                         assert.is_equal("gateway_api", result.type)
                         assert.is_equal("demo", result.gateway)
+                        assert.is_equal("*", result.api)
+                    end
+                )
+
+                it(
+                    "should normalize gateway wildcard format", function()
+                        local result = plugin._parse_audience("gateway:*")
+
+                        assert.is_equal("gateway_api", result.type)
+                        assert.is_equal("*", result.gateway)
                         assert.is_equal("*", result.api)
                     end
                 )
@@ -188,6 +207,19 @@ describe(
                 )
 
                 it(
+                    "should allow access with wildcard mcp_server", function()
+                        ctx.var.is_bk_oauth2 = true
+                        ctx.var.bk_gateway_name = "bk-apigateway"
+                        ctx.var.uri = "/api/v2/mcp-servers/any-server/resources"
+                        ctx.var.audience = {"mcp:*"}
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                    end
+                )
+
+                it(
                     "should deny access when mcp_server does not match", function()
                         ctx.var.is_bk_oauth2 = true
                         ctx.var.bk_gateway_name = "bk-apigateway"
@@ -240,6 +272,32 @@ describe(
                         local result = plugin.rewrite({}, ctx)
 
                         assert.is_nil(result)
+                    end
+                )
+
+                it(
+                    "should allow access with wildcard gateway", function()
+                        ctx.var.is_bk_oauth2 = true
+                        ctx.var.bk_gateway_name = "any-gateway"
+                        ctx.var.bk_resource_name = "any-api"
+                        ctx.var.audience = {"gateway:*"}
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                    end
+                )
+
+                it(
+                    "should deny wildcard gateway with a specific api", function()
+                        ctx.var.is_bk_oauth2 = true
+                        ctx.var.bk_gateway_name = "any-gateway"
+                        ctx.var.bk_resource_name = "test-api"
+                        ctx.var.audience = {"gateway:*/api:test-api"}
+
+                        local status = plugin.rewrite({}, ctx)
+
+                        assert.is_equal(403, status)
                     end
                 )
 


### PR DESCRIPTION
## Summary

- support mcp:* for access to any MCP server
- normalize gateway:* to a wildcard gateway and API audience
- reject mixed gateway wildcard scopes such as gateway:*/api:test-api
- add Busted and test-nginx coverage for wildcard parsing and validation

## Verification

- RUN_WITH_IT= make lint
- RUN_WITH_IT= make test
- Busted: 770 successes, 0 failures
- test-nginx: 690 tests, PASS