### PR TITLE
chore(apisix): upgrade to 3.17 and validate OAuth2 app codes

### DIFF
--- a/.github/workflows/apisix.yml
+++ b/.github/workflows/apisix.yml
@@ -59,6 +59,6 @@ jobs:
       run: |
         echo "start backing up, $(date)"
         mkdir docker-images-backup
-        docker save apisix-test-busted-316 -o docker-images-backup/apisix-test-busted-images.tar
-        docker save apisix-test-nginx-316 -o docker-images-backup/apisix-test-nginx-images.tar
+        docker save apisix-test-busted-317 -o docker-images-backup/apisix-test-busted-images.tar
+        docker save apisix-test-nginx-317 -o docker-images-backup/apisix-test-nginx-images.tar
         echo "docker save done, time: $(date)"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/apisix-core"]
 	path = src/apisix-core
 	url = https://github.com/apache/apisix.git
-	branch = release/3.13
+	branch = release/3.17

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM tencentos/tencentos4-minimal:4.4-v20250922
 
-ARG APISIX_VERSION=3.16.0
+ARG APISIX_VERSION=3.17.0
 LABEL apisix_version="${APISIX_VERSION}"
 
 # 1. yum install

--- a/docs/superpowers/plans/2026-07-28-bk-oauth2-appcode-validate.md
+++ b/docs/superpowers/plans/2026-07-28-bk-oauth2-appcode-validate.md
@@ -1,0 +1,1095 @@
+# OAuth2 App Code Validation Plugin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `bk-oauth2-appcode-validate`, a fail-closed APISIX plugin that permits OAuth2 requests only for globally enabled `public` and `personal` application codes.
+
+**Architecture:** The plugin reads two boolean APISIX `plugin_attr` values during `_M.init()` and rebuilds a module-level hash-set on every initialization. Its `rewrite` handler skips non-OAuth2 traffic, validates `ctx.var.bk_app_code` after audience validation, and returns a rich 401 `invalid_token` response when the code is unsupported.
+
+**Tech Stack:** LuaJIT/OpenResty, Apache APISIX 3.17 plugin APIs, `bk-core.errorx`, `bk-core.oauth2`, Busted, test-nginx, Make, Docker.
+
+## Global Constraints
+
+- Work only in `/root/workspace/tx/wklken/blueking-apigateway-apisix/.worktrees/feat-upgrade-apisix-3.17-codex-20260723`.
+- Preserve the existing uncommitted change in `src/apisix/plugins/bk-oauth2-protected-resource.lua`; never stage, edit, or commit it.
+- Plugin name is exactly `bk-oauth2-appcode-validate`.
+- Plugin priority is exactly `17677`, after `bk-oauth2-audience-validate` at `17678`.
+- `support_public` and `support_personal` are global `plugin_attr` booleans and both default to `false`.
+- Missing or invalid attributes fail closed with an empty allowlist.
+- Only `public` and `personal` can ever be allowed; ordinary application codes remain unsupported.
+- Non-OAuth2 requests must be skipped without changing the request.
+- Rejections use HTTP 401, APIGW `UNAUTHORIZED`, and `WWW-Authenticate` error `invalid_token`.
+- Logs and caller errors include the requested app code plus both support statuses, but never include an access token or credential.
+- Add no dependency and make no unrelated refactor.
+- Use test-first red/green cycles and stage only the files named by each task.
+
+---
+
+## File Map
+
+- Create `src/apisix/plugins/bk-oauth2-appcode-validate.lua`: attribute initialization, allowlist state, request validation, logs, and caller error.
+- Create `src/apisix/tests/test-bk-oauth2-appcode-validate.lua`: Busted coverage for schemas, initialization/reload, allow/deny behavior, error details, and logs.
+- Create `src/apisix/t/bk-oauth2-appcode-validate.t`: test-nginx coverage using real per-case `plugin_attr`.
+- Modify `src/apisix/plugins/README.md`: register the plugin at priority `17677`.
+
+### Shared Plugin Interfaces
+
+The implementation tasks use these exact interfaces:
+
+```lua
+plugin.check_schema(conf) -> boolean, string|nil
+plugin.init() -> nil
+plugin.rewrite(conf, ctx) -> nil | 401, string
+plugin.attr_schema -> table
+plugin._get_validation_state() -> {
+    support_public = boolean,
+    support_personal = boolean,
+    allowed_app_codes = table<string, boolean>,
+}
+```
+
+`_get_validation_state` is exported only when `_TEST` is true.
+
+---
+
+### Task 1: Implement Initialization and Request Validation with Busted
+
+**Files:**
+- Create: `src/apisix/plugins/bk-oauth2-appcode-validate.lua`
+- Create: `src/apisix/tests/test-bk-oauth2-appcode-validate.lua`
+
+**Interfaces:**
+- Consumes: `apisix.plugin.plugin_attr(name)`, `ctx.var.is_bk_oauth2`, `ctx.var.bk_app_code`, `errorx.new_general_unauthorized()`, and `oauth2.build_www_authenticate_header(ctx, code, description)`.
+- Produces: the shared plugin interfaces defined above and a rewrite-phase plugin with priority `17677`.
+
+- [ ] **Step 1: Write the failing Busted contract**
+
+Create `src/apisix/tests/test-bk-oauth2-appcode-validate.lua` with this content:
+
+```lua
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+local core = require("apisix.core")
+local apisix_plugin = require("apisix.plugin")
+local bk_core = require("apisix.plugins.bk-core.init")
+local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+
+describe(
+    "bk-oauth2-appcode-validate", function()
+        local plugin_attr
+        local ctx
+
+        before_each(
+            function()
+                plugin_attr = {}
+                ctx = {
+                    var = {
+                        uri = "/api/test",
+                        bk_gateway_name = "demo",
+                        is_bk_oauth2 = true,
+                        bk_app_code = "public",
+                    },
+                }
+
+                stub(
+                    apisix_plugin, "plugin_attr", function(name)
+                        assert.is_equal("bk-oauth2-appcode-validate", name)
+                        return plugin_attr
+                    end
+                )
+                stub(
+                    bk_core.config, "get_bk_apigateway_api_tmpl", function()
+                        return "https://{api_name}.example.com"
+                    end
+                )
+                stub(core.log, "info")
+                stub(core.log, "error")
+
+                plugin.init()
+            end
+        )
+
+        after_each(
+            function()
+                apisix_plugin.plugin_attr:revert()
+                bk_core.config.get_bk_apigateway_api_tmpl:revert()
+                core.log.info:revert()
+                core.log.error:revert()
+                ngx.header["WWW-Authenticate"] = nil
+            end
+        )
+
+        context(
+            "schema", function()
+                it(
+                    "accepts empty route configuration", function()
+                        local ok, err = plugin.check_schema({})
+
+                        assert.is_true(ok)
+                        assert.is_nil(err)
+                    end
+                )
+
+                it(
+                    "accepts boolean plugin attributes", function()
+                        local ok, err = core.schema.check(
+                            plugin.attr_schema,
+                            {
+                                support_public = true,
+                                support_personal = false,
+                            }
+                        )
+
+                        assert.is_true(ok)
+                        assert.is_nil(err)
+                    end
+                )
+
+                it(
+                    "rejects non-boolean plugin attributes", function()
+                        local ok = core.schema.check(
+                            plugin.attr_schema,
+                            {
+                                support_public = "true",
+                            }
+                        )
+
+                        assert.is_false(ok)
+                    end
+                )
+            end
+        )
+
+        context(
+            "initialization", function()
+                it(
+                    "defaults to an empty allowlist", function()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_false(state.support_public)
+                        assert.is_false(state.support_personal)
+                        assert.is_nil(state.allowed_app_codes.public)
+                        assert.is_nil(state.allowed_app_codes.personal)
+                    end
+                )
+
+                it(
+                    "allows public when configured", function()
+                        plugin_attr = {
+                            support_public = true,
+                        }
+
+                        plugin.init()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_true(state.support_public)
+                        assert.is_false(state.support_personal)
+                        assert.is_true(state.allowed_app_codes.public)
+                        assert.is_nil(state.allowed_app_codes.personal)
+                    end
+                )
+
+                it(
+                    "allows personal when configured", function()
+                        plugin_attr = {
+                            support_personal = true,
+                        }
+
+                        plugin.init()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_false(state.support_public)
+                        assert.is_true(state.support_personal)
+                        assert.is_nil(state.allowed_app_codes.public)
+                        assert.is_true(state.allowed_app_codes.personal)
+                    end
+                )
+
+                it(
+                    "allows both supported app codes", function()
+                        plugin_attr = {
+                            support_public = true,
+                            support_personal = true,
+                        }
+
+                        plugin.init()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_true(state.allowed_app_codes.public)
+                        assert.is_true(state.allowed_app_codes.personal)
+                    end
+                )
+
+                it(
+                    "logs the effective initialization state", function()
+                        plugin_attr = {
+                            support_public = true,
+                        }
+
+                        plugin.init()
+
+                        assert.stub(core.log.info).was_called_with(
+                            "bk-oauth2-appcode-validate: initialized",
+                            ", support_public=", true,
+                            ", support_personal=", false,
+                            ", allowed_app_codes=", '{"public":true}'
+                        )
+                    end
+                )
+
+                it(
+                    "fails closed for invalid plugin attributes", function()
+                        plugin_attr = {
+                            support_public = "true",
+                        }
+
+                        plugin.init()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_false(state.support_public)
+                        assert.is_false(state.support_personal)
+                        assert.is_nil(state.allowed_app_codes.public)
+                        assert.is_nil(state.allowed_app_codes.personal)
+                        assert.stub(core.log.error).was_called()
+                    end
+                )
+
+                it(
+                    "does not retain stale allowlist entries after reinitialization", function()
+                        plugin_attr = {
+                            support_public = true,
+                        }
+                        plugin.init()
+
+                        plugin_attr = {
+                            support_personal = true,
+                        }
+                        plugin.init()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_nil(state.allowed_app_codes.public)
+                        assert.is_true(state.allowed_app_codes.personal)
+                    end
+                )
+            end
+        )
+
+        context(
+            "rewrite", function()
+                it(
+                    "skips when is_bk_oauth2 is false", function()
+                        ctx.var.is_bk_oauth2 = false
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                    end
+                )
+
+                it(
+                    "skips when is_bk_oauth2 is absent", function()
+                        ctx.var.is_bk_oauth2 = nil
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                    end
+                )
+
+                it(
+                    "allows public when public support is enabled", function()
+                        plugin_attr = {
+                            support_public = true,
+                        }
+                        plugin.init()
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                        assert.stub(core.log.info).was_called_with(
+                            "bk-oauth2-appcode-validate: validation passed",
+                            ", bk_app_code=", "public",
+                            ", support_public=", true,
+                            ", support_personal=", false
+                        )
+                    end
+                )
+
+                it(
+                    "allows personal when personal support is enabled", function()
+                        plugin_attr = {
+                            support_personal = true,
+                        }
+                        plugin.init()
+                        ctx.var.bk_app_code = "personal"
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                    end
+                )
+
+                it(
+                    "rejects a disabled supported app code", function()
+                        local status = plugin.rewrite({}, ctx)
+
+                        assert.is_equal(401, status)
+                        assert.is_equal(
+                            "UNAUTHORIZED",
+                            ctx.var.bk_apigw_error.error.code_name
+                        )
+                    end
+                )
+
+                it(
+                    "rejects an ordinary app code even when both flags are enabled", function()
+                        plugin_attr = {
+                            support_public = true,
+                            support_personal = true,
+                        }
+                        plugin.init()
+                        ctx.var.bk_app_code = "ordinary-app"
+
+                        local status = plugin.rewrite({}, ctx)
+
+                        assert.is_equal(401, status)
+                    end
+                )
+
+                it(
+                    "rejects a missing app code", function()
+                        ctx.var.bk_app_code = nil
+
+                        local status = plugin.rewrite({}, ctx)
+
+                        assert.is_equal(401, status)
+                    end
+                )
+
+                it(
+                    "rejects an empty app code", function()
+                        ctx.var.bk_app_code = ""
+
+                        local status = plugin.rewrite({}, ctx)
+
+                        assert.is_equal(401, status)
+                    end
+                )
+
+                it(
+                    "returns rich invalid_token details", function()
+                        plugin_attr = {
+                            support_personal = true,
+                        }
+                        plugin.init()
+                        ctx.var.bk_app_code = "public"
+
+                        local status = plugin.rewrite({}, ctx)
+                        local message = ctx.var.bk_apigw_error.error.message
+                        local www_auth = ngx.header["WWW-Authenticate"]
+
+                        assert.is_equal(401, status)
+                        assert.is_truthy(string.find(
+                            message,
+                            'reason="OAuth2 token app code is not allowed"',
+                            1,
+                            true
+                        ))
+                        assert.is_truthy(string.find(message, 'bk_app_code="public"', 1, true))
+                        assert.is_truthy(string.find(message, 'support_public="false"', 1, true))
+                        assert.is_truthy(string.find(message, 'support_personal="true"', 1, true))
+                        assert.is_truthy(string.find(www_auth, 'error="invalid_token"', 1, true))
+                        assert.is_truthy(string.find(www_auth, "bk_app_code=public", 1, true))
+                        assert.is_truthy(string.find(www_auth, "support_public=false", 1, true))
+                        assert.is_truthy(string.find(www_auth, "support_personal=true", 1, true))
+                        assert.stub(core.log.info).was_called_with(
+                            "bk-oauth2-appcode-validate: validation failed",
+                            ", bk_app_code=", "public",
+                            ", support_public=", false,
+                            ", support_personal=", true
+                        )
+                    end
+                )
+            end
+        )
+    end
+)
+```
+
+- [ ] **Step 2: Run the focused Busted file and confirm the red state**
+
+Run from `src/apisix`:
+
+```bash
+docker run --rm \
+  -v "$PWD/tests/conf/config.yaml:/usr/local/apisix/conf/config.yaml" \
+  -v "$PWD/tests:/bkgateway/tests/" \
+  -v "$PWD/logs/:/bkgateway/logs/" \
+  -v "$PWD/tests/conf/nginx.conf:/bkgateway/conf/nginx.conf" \
+  -v "$PWD/plugins:/bkgateway/apisix/plugins" \
+  apisix-test-busted-317 \
+  resty -c 4096 --errlog-level error \
+  --http-include ./conf/nginx.conf -I . \
+  ./tests/busted_runner.lua --verbose \
+  --helper ./tests/busted_helper.lua \
+  ./tests/test-bk-oauth2-appcode-validate.lua
+```
+
+Expected: FAIL while requiring `apisix.plugins.bk-oauth2-appcode-validate`, because the plugin file does not exist.
+
+- [ ] **Step 3: Implement the minimal complete plugin**
+
+Create `src/apisix/plugins/bk-oauth2-appcode-validate.lua` with the standard TencentBlueKing MIT header and this implementation:
+
+```lua
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+-- # bk-oauth2-appcode-validate
+--
+-- Validate whether an OAuth2 token's application code is enabled by plugin attributes.
+--
+-- This plugin only runs when ctx.var.is_bk_oauth2 == true.
+--
+-- This plugin depends on:
+--     * bk-oauth2-verify: To set ctx.var.bk_app_code
+--
+local core = require("apisix.core")
+local apisix_plugin = require("apisix.plugin")
+local errorx = require("apisix.plugins.bk-core.errorx")
+local oauth2 = require("apisix.plugins.bk-core.oauth2")
+local ngx = ngx
+local tostring = tostring
+
+local plugin_name = "bk-oauth2-appcode-validate"
+
+local schema = {
+    type = "object",
+    properties = {},
+}
+
+local attr_schema = {
+    type = "object",
+    properties = {
+        support_public = {
+            type = "boolean",
+            default = false,
+        },
+        support_personal = {
+            type = "boolean",
+            default = false,
+        },
+    },
+}
+
+local _M = {
+    version = 0.1,
+    priority = 17677,
+    name = plugin_name,
+    schema = schema,
+    attr_schema = attr_schema,
+}
+
+local support_public = false
+local support_personal = false
+local allowed_app_codes = {}
+
+
+function _M.check_schema(conf)
+    return core.schema.check(schema, conf)
+end
+
+
+local function reset_validation_state()
+    support_public = false
+    support_personal = false
+    allowed_app_codes = {}
+end
+
+
+local function get_validation_state()
+    return {
+        support_public = support_public,
+        support_personal = support_personal,
+        allowed_app_codes = allowed_app_codes,
+    }
+end
+
+
+function _M.init()
+    reset_validation_state()
+
+    local plugin_info = apisix_plugin.plugin_attr(plugin_name) or {}
+    local ok, err = core.schema.check(attr_schema, plugin_info)
+    if not ok then
+        core.log.error(
+            "failed to check plugin_attr[", plugin_name, "]: ", err,
+            ", fail closed with no allowed app codes"
+        )
+        return
+    end
+
+    support_public = plugin_info.support_public == true
+    support_personal = plugin_info.support_personal == true
+
+    if support_public then
+        allowed_app_codes.public = true
+    end
+
+    if support_personal then
+        allowed_app_codes.personal = true
+    end
+
+    core.log.info(
+        plugin_name .. ": initialized",
+        ", support_public=", support_public,
+        ", support_personal=", support_personal,
+        ", allowed_app_codes=", core.json.encode(allowed_app_codes)
+    )
+end
+
+
+local function build_error_description(app_code)
+    return "OAuth2 token app code is not allowed: bk_app_code=" .. app_code ..
+        ", support_public=" .. tostring(support_public) ..
+        ", support_personal=" .. tostring(support_personal)
+end
+
+
+function _M.rewrite(conf, ctx) -- luacheck: no unused
+    if ctx.var.is_bk_oauth2 ~= true then
+        core.log.info(
+            plugin_name .. ": skipping",
+            ", is_bk_oauth2=", ctx.var.is_bk_oauth2
+        )
+        return
+    end
+
+    local app_code = ctx.var.bk_app_code or ""
+
+    core.log.info(
+        plugin_name .. ": checking",
+        ", bk_app_code=", app_code,
+        ", support_public=", support_public,
+        ", support_personal=", support_personal
+    )
+
+    if app_code ~= "" and allowed_app_codes[app_code] then
+        core.log.info(
+            plugin_name .. ": validation passed",
+            ", bk_app_code=", app_code,
+            ", support_public=", support_public,
+            ", support_personal=", support_personal
+        )
+        return
+    end
+
+    core.log.info(
+        plugin_name .. ": validation failed",
+        ", bk_app_code=", app_code,
+        ", support_public=", support_public,
+        ", support_personal=", support_personal
+    )
+
+    local error_description = build_error_description(app_code)
+    local err = errorx.new_general_unauthorized():with_fields(
+        {
+            reason = "OAuth2 token app code is not allowed",
+            bk_app_code = app_code,
+            support_public = support_public,
+            support_personal = support_personal,
+        }
+    )
+
+    ngx.header["WWW-Authenticate"] = oauth2.build_www_authenticate_header(
+        ctx, "invalid_token", error_description
+    )
+    return errorx.exit_with_apigw_err(ctx, err, _M)
+end
+
+
+if _TEST then -- luacheck: ignore
+    _M._get_validation_state = get_validation_state
+end
+
+return _M
+```
+
+- [ ] **Step 4: Run the focused Busted file and confirm green**
+
+Repeat the focused Docker command from Step 2.
+
+Expected: the new file reports only successes, with zero failures and zero errors.
+
+- [ ] **Step 5: Run the full Busted suite**
+
+Run from `src/apisix`:
+
+```bash
+RUN_WITH_IT= make test-busted
+```
+
+Expected: all Busted tests pass with zero failures and zero errors.
+
+- [ ] **Step 6: Commit the plugin and Busted contract**
+
+```bash
+git add -- \
+  src/apisix/plugins/bk-oauth2-appcode-validate.lua \
+  src/apisix/tests/test-bk-oauth2-appcode-validate.lua
+git diff --cached --name-status
+git diff --cached --check
+git commit -m "feat(oauth2): validate supported token app codes"
+```
+
+Expected staged files: exactly the plugin and its Busted test. Do not stage `bk-oauth2-protected-resource.lua`.
+
+---
+
+### Task 2: Add Real Plugin-Attribute Functional Coverage
+
+**Files:**
+- Create: `src/apisix/t/bk-oauth2-appcode-validate.t`
+
+**Interfaces:**
+- Consumes: the plugin created in Task 1 and APISIX `extra_yaml_config`.
+- Produces: request-level evidence that APISIX invokes `_M.init()` with real `plugin_attr` and enforces the 401/header contract.
+
+- [ ] **Step 1: Create the test-nginx suite**
+
+Create `src/apisix/t/bk-oauth2-appcode-validate.t` with the following complete content:
+
+```perl
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: sanity - schema and priority
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ok, err = plugin.check_schema({})
+            if not ok then
+                ngx.say(err)
+                return
+            end
+
+            ngx.say("priority: " .. plugin.priority)
+        }
+    }
+--- response_body
+priority: 17677
+
+=== TEST 2: non-OAuth2 requests are skipped
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    is_bk_oauth2 = false,
+                    bk_app_code = "public"
+                }
+            }
+
+            local result = plugin.rewrite({}, ctx)
+            ngx.say(result == nil and "skipped" or "processed")
+        }
+    }
+--- response_body
+skipped
+
+=== TEST 3: public-only configuration allows public
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: true
+    support_personal: false
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local result = plugin.rewrite({}, ctx)
+            ngx.say(result == nil and "pass" or "fail")
+        }
+    }
+--- response_body
+pass
+
+=== TEST 4: public-only configuration rejects personal
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: true
+    support_personal: false
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "personal"
+                }
+            }
+
+            local status = plugin.rewrite({}, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+            ngx.say("code_name: " .. ctx.var.bk_apigw_error.error.code_name)
+            ngx.say("message: " .. ctx.var.bk_apigw_error.error.message)
+        }
+    }
+--- response_body_like eval
+qr/status: 401\ncode_name: UNAUTHORIZED\nmessage: Unauthorized .*OAuth2 token app code is not allowed.*/
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*bk_app_code=personal.*support_public=true.*support_personal=false"
+
+=== TEST 5: personal-only configuration allows personal
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: false
+    support_personal: true
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "personal"
+                }
+            }
+
+            local result = plugin.rewrite({}, ctx)
+            ngx.say(result == nil and "pass" or "fail")
+        }
+    }
+--- response_body
+pass
+
+=== TEST 6: personal-only configuration rejects public
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: false
+    support_personal: true
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local status = plugin.rewrite({}, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+        }
+    }
+--- response_body
+status: 401
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*support_public=false.*support_personal=true"
+
+=== TEST 7: both-enabled configuration allows both app codes
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: true
+    support_personal: true
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local public_result = plugin.rewrite({}, ctx)
+            ctx.var.bk_app_code = "personal"
+            local personal_result = plugin.rewrite({}, ctx)
+
+            ngx.say(public_result == nil and "public: pass" or "public: fail")
+            ngx.say(personal_result == nil and "personal: pass" or "personal: fail")
+        }
+    }
+--- response_body
+public: pass
+personal: pass
+
+=== TEST 8: default configuration rejects every OAuth2 app code
+--- extra_yaml_config
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local status = plugin.rewrite({}, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+        }
+    }
+--- response_body
+status: 401
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*support_public=false.*support_personal=false"
+
+=== TEST 9: ordinary app code stays unsupported when both flags are enabled
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: true
+    support_personal: true
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "ordinary-app"
+                }
+            }
+
+            local status = plugin.rewrite({}, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+        }
+    }
+--- response_body
+status: 401
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*bk_app_code=ordinary-app.*support_public=true.*support_personal=true"
+```
+
+- [ ] **Step 2: Run the focused test-nginx suite**
+
+Run from `src/apisix`:
+
+```bash
+RUN_WITH_IT= make test-nginx CASE_FILE=bk-oauth2-appcode-validate.t
+```
+
+Expected: `t/bk-00.t` and `t/bk-oauth2-appcode-validate.t` both report `ok`, followed by `Result: PASS`.
+
+- [ ] **Step 3: Commit the functional test**
+
+```bash
+git add -- src/apisix/t/bk-oauth2-appcode-validate.t
+git diff --cached --name-status
+git diff --cached --check
+git commit -m "test(oauth2): cover app code validation plugin"
+```
+
+Expected staged file: exactly `src/apisix/t/bk-oauth2-appcode-validate.t`.
+
+---
+
+### Task 3: Register the Plugin and Run Completion Gates
+
+**Files:**
+- Modify: `src/apisix/plugins/README.md:54`
+
+**Interfaces:**
+- Consumes: plugin name and priority from Task 1.
+- Produces: repository plugin registry documentation and fresh completion evidence for the entire change.
+
+- [ ] **Step 1: Register the plugin beside audience validation**
+
+In `src/apisix/plugins/README.md`, keep the existing audience line and insert this exact line immediately after it:
+
+```markdown
+- bk-oauth2-appcode-validate                # priority: 17677  # OAuth2 app code 验证：按全局配置允许 public 和 personal 客户端
+```
+
+- [ ] **Step 2: Verify the new Lua license header**
+
+Run from the repository root:
+
+```bash
+make check-license
+```
+
+Expected: exit code 0 and a final count of `0` files missing the TencentBlueKing license. If an
+unrelated file already fails this repository-wide gate, confirm it also fails on the base branch,
+verify the new Lua files directly, and report the pre-existing failure without changing that file.
+
+- [ ] **Step 3: Run lint**
+
+Run from `src/apisix`:
+
+```bash
+RUN_WITH_IT= make lint
+```
+
+Expected: zero warnings and zero errors.
+
+- [ ] **Step 4: Run the complete APISIX test suite**
+
+Run from `src/apisix`:
+
+```bash
+RUN_WITH_IT= make test
+```
+
+Expected: Busted reports zero failures/errors, every `t/bk-*.t` file reports `ok`, and test-nginx ends with `Result: PASS`.
+
+- [ ] **Step 5: Audit the intended diff and dirty-file isolation**
+
+Run from the repository root:
+
+```bash
+git status --short
+git diff --check
+git diff --name-status origin/feat/upgrade-apisix-3.17...HEAD
+git diff -- src/apisix/plugins/bk-oauth2-protected-resource.lua
+```
+
+Expected:
+
+- The implementation history contains only the design/plan documentation and the four in-scope implementation files.
+- `src/apisix/plugins/bk-oauth2-protected-resource.lua` remains an unstaged user modification and is absent from every implementation commit.
+- No whitespace errors are reported.
+
+- [ ] **Step 6: Commit the registry documentation**
+
+```bash
+git add -- src/apisix/plugins/README.md
+git diff --cached --name-status
+git diff --cached --check
+git commit -m "docs(plugins): register OAuth2 app code validation"
+```
+
+Expected staged file: exactly `src/apisix/plugins/README.md`.
+
+- [ ] **Step 7: Record final evidence**
+
+Capture these values for the handoff:
+
+```bash
+git log --oneline -5
+git status --short --branch
+git rev-parse HEAD
+```
+
+Report:
+
+- Commit IDs for the plugin/Busted, test-nginx, and README commits.
+- Focused Busted result.
+- Focused test-nginx result.
+- `make check-license`, lint, and full test results.
+- Confirmation that the pre-existing `bk-oauth2-protected-resource.lua` modification was preserved and excluded.

--- a/docs/superpowers/specs/2026-07-28-bk-oauth2-appcode-validate-design.md
+++ b/docs/superpowers/specs/2026-07-28-bk-oauth2-appcode-validate-design.md
@@ -1,0 +1,194 @@
+# OAuth2 App Code Validation Plugin Design
+
+## Status
+
+Approved in design discussion on 2026-07-28.
+
+## Context
+
+`bk-oauth2-verify` validates an OAuth2 access token and stores its application
+code in `ctx.var.bk_app_code`. The gateway needs a separate policy plugin that
+allows OAuth2 requests only when that application code is one of the globally
+enabled special client types:
+
+- `public`
+- `personal`
+
+This policy is independent of audience validation. The new plugin will run
+after `bk-oauth2-audience-validate` and will not change legacy, non-OAuth2
+authentication.
+
+## Goals
+
+- Add a self-contained plugin named `bk-oauth2-appcode-validate`.
+- Read `support_public` and `support_personal` from APISIX `plugin_attr`.
+- Build the effective application-code allowlist during plugin initialization.
+- Fail closed when configuration is absent or invalid.
+- Reject an OAuth2 token whose application code is not allowed.
+- Return caller-visible support status and emit diagnostic logs without logging
+  token contents.
+- Cover initialization and request behavior with Busted and test-nginx tests.
+
+## Non-Goals
+
+- Allow arbitrary application codes.
+- Add route-level configuration.
+- Change token verification, audience validation, or legacy authentication.
+- Change `bk-oauth2-protected-resource`.
+- Add control-plane or chart configuration in this change.
+
+## Plugin Contract
+
+### Identity and Ordering
+
+- Name: `bk-oauth2-appcode-validate`
+- Phase: `rewrite`
+- Priority: `17677`
+
+The resulting OAuth2 request order is:
+
+1. `bk-oauth2-verify`
+2. `bk-oauth2-audience-validate`
+3. `bk-oauth2-appcode-validate`
+
+If both audience and application code are invalid, audience validation returns
+first.
+
+### Route Schema
+
+The route-level plugin schema is empty. Enabling the plugin on a route activates
+the global application-code policy; a route cannot override it.
+
+### Plugin Attributes
+
+```yaml
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: false
+    support_personal: false
+```
+
+The plugin exposes an `attr_schema` containing:
+
+| Field | Type | Default |
+| --- | --- | --- |
+| `support_public` | boolean | `false` |
+| `support_personal` | boolean | `false` |
+
+## Initialization
+
+`_M.init()` reads `plugin.plugin_attr(plugin_name)` and validates it against
+`attr_schema`. Each invocation first resets all derived state so APISIX plugin
+reloads cannot retain stale allowed values.
+
+For valid configuration:
+
+- `support_public == true` adds `public` to `allowed_app_codes`.
+- `support_personal == true` adds `personal` to `allowed_app_codes`.
+
+`allowed_app_codes` is a module-level hash set for constant-time request lookup.
+
+When attributes are absent, both support flags are false and the set is empty.
+When attributes are invalid, initialization logs the schema error, resets both
+support flags to false, keeps the set empty, and leaves request validation
+active. This is fail-closed behavior.
+
+Initialization logs the effective support flags and generated allowlist.
+
+## Request Processing
+
+`_M.rewrite(conf, ctx)` behaves as follows:
+
+1. If `ctx.var.is_bk_oauth2 ~= true`, log the skip reason and return without
+   changing the request.
+2. Read `ctx.var.bk_app_code`, which is populated by `bk-oauth2-verify`.
+3. Log the requested application code and current support flags.
+4. If the application code exists in `allowed_app_codes`, log success and
+   return.
+5. Otherwise, reject the request as an invalid token.
+
+Missing, empty, ordinary, disabled, and unknown application codes all follow
+the same rejection path. With both flags false, every OAuth2 request is
+rejected.
+
+## Failure Contract
+
+A rejected application code returns:
+
+- HTTP status: `401`
+- APIGW error: `UNAUTHORIZED`
+- `WWW-Authenticate` error: `invalid_token`
+
+The APIGW error is created with `errorx.new_general_unauthorized()` and enriched
+through `with_fields` with:
+
+- `reason = "OAuth2 token app code is not allowed"`
+- `bk_app_code`
+- `support_public`
+- `support_personal`
+
+The `WWW-Authenticate` error description states that the current token
+application code is unsupported and includes the effective public and personal
+support statuses. The rejection log contains the same diagnostic context.
+
+The plugin never logs the access token or other credentials.
+
+## Test Design
+
+### Busted
+
+The Busted suite will cover:
+
+- Empty route configuration is accepted.
+- Attribute booleans are accepted and non-booleans are rejected.
+- Initialization with absent attributes produces an empty set.
+- Public-only, personal-only, and both-enabled initialization.
+- Invalid attributes fail closed and log the schema failure.
+- Re-initialization rebuilds state without retaining previous entries.
+- Non-OAuth2 requests are skipped.
+- Enabled `public` and `personal` application codes pass.
+- Disabled, ordinary, missing, and empty application codes fail.
+- Rejection returns 401 and populates the APIGW error.
+- `WWW-Authenticate` contains `invalid_token`, the requested application code,
+  and both support statuses.
+- Initialization, success, and failure logs contain the required context and no
+  token data.
+
+Private state or helper access required for focused tests will be exposed only
+under `_TEST`, following repository conventions.
+
+### test-nginx
+
+The test-nginx suite will use per-case `extra_yaml_config` to exercise real
+`plugin_attr` initialization:
+
+- Public-only configuration allows `public` and rejects `personal`.
+- Personal-only configuration allows `personal` and rejects `public`.
+- Both-enabled configuration allows both application codes.
+- Default configuration rejects every application code.
+- An ordinary application code returns 401 with the rich error and
+  `WWW-Authenticate` information.
+- Non-OAuth2 requests are skipped.
+- Schema and priority sanity checks pass.
+
+## Files in Scope
+
+- `src/apisix/plugins/bk-oauth2-appcode-validate.lua`
+- `src/apisix/tests/test-bk-oauth2-appcode-validate.lua`
+- `src/apisix/t/bk-oauth2-appcode-validate.t`
+- `src/apisix/plugins/README.md`
+
+No existing OAuth2 plugin will be modified.
+
+## Verification
+
+Run from `src/apisix` unless otherwise noted:
+
+1. Focused Busted test for the new plugin.
+2. `RUN_WITH_IT= make test-nginx CASE_FILE=bk-oauth2-appcode-validate.t`
+3. `RUN_WITH_IT= make lint`
+4. `RUN_WITH_IT= make test`
+5. From the repository root, `make check-license`
+
+All commands must pass on the final diff. Existing unrelated worktree changes
+must remain unstaged and unmodified.

--- a/src/apisix/Makefile
+++ b/src/apisix/Makefile
@@ -4,11 +4,11 @@ RUN_WITH_IT ?= -it
 
 .PHONY: apisix-test-busted
 apisix-test-busted:
-	docker build -t apisix-test-busted-316 -f ci/Dockerfile.apisix-test-busted .
+	docker build -t apisix-test-busted-317 -f ci/Dockerfile.apisix-test-busted .
 
 .PHONY: apisix-test-nginx
 apisix-test-nginx:
-	docker build -t apisix-test-nginx-316 -f ci/Dockerfile.apisix-test-nginx .
+	docker build -t apisix-test-nginx-317 -f ci/Dockerfile.apisix-test-nginx .
 
 .PHONY: test-busted
 test-busted:
@@ -18,7 +18,7 @@ test-busted:
 	-v ${ROOT_DIR}/logs/:/bkgateway/logs/ \
 	-v ${ROOT_DIR}/tests/conf/nginx.conf:/bkgateway/conf/nginx.conf \
 	-v ${ROOT_DIR}/plugins:/bkgateway/apisix/plugins \
-	apisix-test-busted-316 "/run-test-busted.sh"
+	apisix-test-busted-317 "/run-test-busted.sh"
 
 # make test-nginx
 # make test-nginx CASE_FILE=bk-traffic-label.t
@@ -27,7 +27,7 @@ test-nginx:
 	@docker run --rm ${RUN_WITH_IT} \
 	-v ${ROOT_DIR}/t:/bkgateway/t/ \
 	-v ${ROOT_DIR}/plugins:/bkgateway/apisix/plugins \
-	apisix-test-nginx-316 "/run-test-nginx.sh" $(if $(CASE_FILE),$(CASE_FILE))
+	apisix-test-nginx-317 "/run-test-nginx.sh" $(if $(CASE_FILE),$(CASE_FILE))
 
 .PHONY: apisix-test-images
 apisix-test-images: apisix-test-busted apisix-test-nginx
@@ -42,7 +42,7 @@ lint:
 	-v ${ROOT_DIR}/plugins:/bkgateway/apisix/plugins \
 	-v ${ROOT_DIR}/tests:/bkgateway/tests/ \
 	-w /bkgateway/apisix \
-	apisix-test-busted-316 \
+	apisix-test-busted-317 \
 	luacheck --config /bkgateway/.luacheckrc ./plugins
 
 .PHONY: edition

--- a/src/apisix/ci/Dockerfile.apisix-test-busted
+++ b/src/apisix/ci/Dockerfile.apisix-test-busted
@@ -1,5 +1,7 @@
-ARG APISIX_VERSION="3.16.0"
+ARG APISIX_VERSION="3.17.0"
 FROM apache/apisix:$APISIX_VERSION-redhat
+
+USER root
 
 RUN yum install -y sudo make gcc wget unzip git # valgrind
 

--- a/src/apisix/ci/Dockerfile.apisix-test-nginx
+++ b/src/apisix/ci/Dockerfile.apisix-test-nginx
@@ -1,5 +1,7 @@
-ARG APISIX_VERSION="3.16.0"
+ARG APISIX_VERSION="3.17.0"
 FROM apache/apisix:$APISIX_VERSION-redhat
+
+USER root
 
 # reference: 
 # - https://github.com/apache/apisix/blob/release/3.11/.github/workflows/redhat-ci.yaml

--- a/src/apisix/ci/redhat-ci.sh
+++ b/src/apisix/ci/redhat-ci.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 # CHANGES:
-# 1. based on APISIX 3.16 redhat-ci.sh
-# 2. use UBI9 repos to match apache/apisix:3.16.0-redhat
+# 1. based on APISIX 3.17 redhat-ci.sh
+# 2. use UBI9 repos to match apache/apisix:3.17.0-redhat
 # 3. remove unused tools in install_dependencies
 
-# reference: https://github.com/apache/apisix/blob/3.16.0/ci/redhat-ci.sh
+# reference: https://github.com/apache/apisix/blob/3.17.0/ci/redhat-ci.sh
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -31,9 +31,9 @@ install_dependencies() {
 
     # install build & runtime deps
     yum install -y --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms \
-    wget tar gcc gcc-c++ automake autoconf libtool make unzip git sudo openldap-devel hostname patch \
+    wget tar gcc gcc-c++ automake autoconf libtool make cmake unzip git sudo openldap-devel hostname patch \
     which ca-certificates pcre pcre-devel pcre2 pcre2-devel xz \
-    openssl-devel
+    openssl-devel libxml2-devel libxslt-devel
 
     # FIXME: yum uninstall the build tools
 

--- a/src/apisix/plugins/README.md
+++ b/src/apisix/plugins/README.md
@@ -52,6 +52,7 @@
 - bk-auth-validate                          # priority: 17680
 - bk-user-restriction                       # priority: 17679
 - bk-oauth2-audience-validate               # priority: 17678  # OAuth2 audience 验证：验证 MCP 服务器和网关 API 的 audience 声明
+- bk-oauth2-appcode-validate                # priority: 17677  # OAuth2 app code 验证：按全局配置允许 public 和 personal 客户端
 - bk-tenant-validate-exempt                 # priority: 17676  # 如果资源配置了此插件, 则跳过 bk-tenant-validate 校验
 - bk-tenant-verify                          # priority: 17675
 - bk-tenant-validate                        # priority: 17674

--- a/src/apisix/plugins/bk-oauth2-appcode-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-appcode-validate.lua
@@ -1,0 +1,185 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+-- # bk-oauth2-appcode-validate
+--
+-- Validate whether an OAuth2 token's application code is enabled by plugin attributes.
+--
+-- This plugin only runs when ctx.var.is_bk_oauth2 == true.
+--
+-- This plugin depends on:
+--     * bk-oauth2-verify: To set ctx.var.bk_app_code
+--
+local core = require("apisix.core")
+local apisix_plugin = require("apisix.plugin")
+local errorx = require("apisix.plugins.bk-core.errorx")
+local oauth2 = require("apisix.plugins.bk-core.oauth2")
+local ngx = ngx
+local tostring = tostring
+
+local plugin_name = "bk-oauth2-appcode-validate"
+
+local schema = {
+    type = "object",
+    properties = {},
+}
+
+local attr_schema = {
+    type = "object",
+    properties = {
+        support_public = {
+            type = "boolean",
+            default = false,
+        },
+        support_personal = {
+            type = "boolean",
+            default = false,
+        },
+    },
+}
+
+local _M = {
+    version = 0.1,
+    priority = 17677,
+    name = plugin_name,
+    schema = schema,
+    attr_schema = attr_schema,
+}
+
+local support_public = false
+local support_personal = false
+local allowed_app_codes = {}
+
+
+function _M.check_schema(conf)
+    return core.schema.check(schema, conf)
+end
+
+
+local function reset_validation_state()
+    support_public = false
+    support_personal = false
+    allowed_app_codes = {}
+end
+
+
+local function get_validation_state()
+    return {
+        support_public = support_public,
+        support_personal = support_personal,
+        allowed_app_codes = allowed_app_codes,
+    }
+end
+
+
+function _M.init()
+    reset_validation_state()
+
+    local plugin_info = apisix_plugin.plugin_attr(plugin_name) or {}
+    local ok, err = core.schema.check(attr_schema, plugin_info)
+    if not ok then
+        core.log.error(
+            "failed to check plugin_attr[", plugin_name, "]: ", err,
+            ", fail closed with no allowed app codes"
+        )
+        return
+    end
+
+    support_public = plugin_info.support_public == true
+    support_personal = plugin_info.support_personal == true
+
+    if support_public then
+        allowed_app_codes.public = true
+    end
+
+    if support_personal then
+        allowed_app_codes.personal = true
+    end
+
+    core.log.info(
+        plugin_name .. ": initialized",
+        ", support_public=", support_public,
+        ", support_personal=", support_personal,
+        ", allowed_app_codes=", core.json.encode(allowed_app_codes)
+    )
+end
+
+
+local function build_error_description(app_code)
+    return "OAuth2 token app code is not allowed: bk_app_code=" .. app_code ..
+        ", support_public=" .. tostring(support_public) ..
+        ", support_personal=" .. tostring(support_personal)
+end
+
+
+function _M.rewrite(conf, ctx) -- luacheck: no unused
+    if ctx.var.is_bk_oauth2 ~= true then
+        core.log.info(
+            plugin_name .. ": skipping",
+            ", is_bk_oauth2=", ctx.var.is_bk_oauth2
+        )
+        return
+    end
+
+    local app_code = ctx.var.bk_app_code or ""
+
+    core.log.info(
+        plugin_name .. ": checking",
+        ", bk_app_code=", app_code,
+        ", support_public=", support_public,
+        ", support_personal=", support_personal
+    )
+
+    if app_code ~= "" and allowed_app_codes[app_code] then
+        core.log.info(
+            plugin_name .. ": validation passed",
+            ", bk_app_code=", app_code,
+            ", support_public=", support_public,
+            ", support_personal=", support_personal
+        )
+        return
+    end
+
+    core.log.info(
+        plugin_name .. ": validation failed",
+        ", bk_app_code=", app_code,
+        ", support_public=", support_public,
+        ", support_personal=", support_personal
+    )
+
+    local error_description = build_error_description(app_code)
+    local err = errorx.new_general_unauthorized():with_fields(
+        {
+            reason = "OAuth2 token app code is not allowed",
+            bk_app_code = app_code,
+            support_public = support_public,
+            support_personal = support_personal,
+        }
+    )
+
+    ngx.header["WWW-Authenticate"] = oauth2.build_www_authenticate_header(
+        ctx, "invalid_token", error_description
+    )
+    return errorx.exit_with_apigw_err(ctx, err, _M)
+end
+
+
+if _TEST then -- luacheck: ignore
+    _M._get_validation_state = get_validation_state
+end
+
+return _M

--- a/src/apisix/t/bk-oauth2-appcode-validate.t
+++ b/src/apisix/t/bk-oauth2-appcode-validate.t
@@ -1,0 +1,285 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: sanity - schema and priority
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ok, err = plugin.check_schema({})
+            if not ok then
+                ngx.say(err)
+                return
+            end
+
+            ngx.say("priority: " .. plugin.priority)
+        }
+    }
+--- response_body
+priority: 17677
+
+=== TEST 2: non-OAuth2 requests are skipped
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    is_bk_oauth2 = false,
+                    bk_app_code = "public"
+                }
+            }
+
+            local result = plugin.rewrite({}, ctx)
+            ngx.say(result == nil and "skipped" or "processed")
+        }
+    }
+--- response_body
+skipped
+
+=== TEST 3: public-only configuration allows public
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: true
+    support_personal: false
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local result = plugin.rewrite({}, ctx)
+            ngx.say(result == nil and "pass" or "fail")
+        }
+    }
+--- response_body
+pass
+
+=== TEST 4: public-only configuration rejects personal
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: true
+    support_personal: false
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "personal"
+                }
+            }
+
+            local status = plugin.rewrite({}, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+            ngx.say("code_name: " .. ctx.var.bk_apigw_error.error.code_name)
+            ngx.say("message: " .. ctx.var.bk_apigw_error.error.message)
+        }
+    }
+--- response_body_like eval
+qr/status: 401\ncode_name: UNAUTHORIZED\nmessage: Unauthorized .*OAuth2 token app code is not allowed.*/
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*bk_app_code=personal.*support_public=true.*support_personal=false"
+
+=== TEST 5: personal-only configuration allows personal
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: false
+    support_personal: true
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "personal"
+                }
+            }
+
+            local result = plugin.rewrite({}, ctx)
+            ngx.say(result == nil and "pass" or "fail")
+        }
+    }
+--- response_body
+pass
+
+=== TEST 6: personal-only configuration rejects public
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: false
+    support_personal: true
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local status = plugin.rewrite({}, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+        }
+    }
+--- response_body
+status: 401
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*support_public=false.*support_personal=true"
+
+=== TEST 7: both-enabled configuration allows both app codes
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: true
+    support_personal: true
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local public_result = plugin.rewrite({}, ctx)
+            ctx.var.bk_app_code = "personal"
+            local personal_result = plugin.rewrite({}, ctx)
+
+            ngx.say(public_result == nil and "public: pass" or "public: fail")
+            ngx.say(personal_result == nil and "personal: pass" or "personal: fail")
+        }
+    }
+--- response_body
+public: pass
+personal: pass
+
+=== TEST 8: default configuration rejects every OAuth2 app code
+--- extra_yaml_config
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local status = plugin.rewrite({}, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+        }
+    }
+--- response_body
+status: 401
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*support_public=false.*support_personal=false"
+
+=== TEST 9: ordinary app code stays unsupported when both flags are enabled
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: true
+    support_personal: true
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "ordinary-app"
+                }
+            }
+
+            local status = plugin.rewrite({}, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+        }
+    }
+--- response_body
+status: 401
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*bk_app_code=ordinary-app.*support_public=true.*support_personal=true"

--- a/src/apisix/t/bk-stage-context.t
+++ b/src/apisix/t/bk-stage-context.t
@@ -92,56 +92,60 @@ done
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
+            local json = require("toolkit.json")
+            local route = {
+                plugins = {
+                    ["bk-stage-context"] = {
+                        bk_gateway_name = "demo",
+                        bk_gateway_id = 1,
+                        bk_stage_name = "prod",
+                        jwt_private_key = "dGhpcyBpcyBhIGZha2Ugand0IHByaXZhdGUga2V5",
+                        bk_api_auth = {
+                            api_type = 10,
+                            unfiltered_sensitive_keys = {"a", "b"},
+                            include_system_headers = {"c", "d"},
+                            allow_auth_from_params = true,
+                            allow_delete_sensitive_params = false,
+                            uin_conf = {
+                                user_type = "uin",
+                                from_uin_skey = true,
+                                skey_type = 1,
+                                domain_id = 1,
+                                search_rtx = true,
+                                search_rtx_source = 1,
+                                from_auth_token = false,
+                            },
+                            rtx_conf = {
+                                user_type = "rtx",
+                                from_operator = true,
+                                from_bk_ticket = true,
+                                from_auth_token = true,
+                            },
+                            user_conf = {
+                                user_type = "user",
+                                from_bk_token = true,
+                                from_username = true,
+                            },
+                        },
+                    },
+                    ["serverless-post-function"] = {
+                        phase = "rewrite",
+                        functions = {
+                            "return function(conf, ctx) ngx.say(string.format(\"instance_id: %s, bk_gateway_name: %s, bk_gateway_id: %s, bk_stage_name: %s, jwt_private_key: %s\", ctx.var.instance_id, ctx.var.bk_gateway_name, ctx.var.bk_gateway_id, ctx.var.bk_stage_name, ctx.var.jwt_private_key)); ngx.exit(200); end",
+                        },
+                    },
+                },
+                upstream = {
+                    nodes = {
+                        ["127.0.0.1:1980"] = 1,
+                    },
+                    type = "roundrobin",
+                },
+                uri = "/hello",
+            }
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
-                [[{
-                        "plugins": {
-                            "bk-stage-context": {
-                                "bk_gateway_name": "demo",
-                                "bk_gateway_id": 1,
-                                "bk_stage_name": "prod",
-                                "jwt_private_key": "dGhpcyBpcyBhIGZha2Ugand0IHByaXZhdGUga2V5",
-                                "bk_api_auth": {
-                                    "api_type": 10,
-                                    "unfiltered_sensitive_keys": ["a", "b"],
-                                    "include_system_headers": ["c", "d"],
-                                    "allow_auth_from_params": true,
-                                    "allow_delete_sensitive_params": false,
-                                    "uin_conf": {
-                                        "user_type": "uin",
-                                        "from_uin_skey": true,
-                                        "skey_type": 1,
-                                        "domain_id": 1,
-                                        "search_rtx": true,
-                                        "search_rtx_source": 1,
-                                        "from_auth_token": false
-                                    },
-                                    "rtx_conf": {
-                                        "user_type": "rtx",
-                                        "from_operator": true,
-                                        "from_bk_ticket": true,
-                                        "from_auth_token": true
-                                    },
-                                    "user_conf": {
-                                        "user_type": "user",
-                                        "from_bk_token": true,
-                                        "from_username": true
-                                    }
-                                }
-                            },
-                            "serverless-post-function": {
-                                "phase": "rewrite",
-                                "functions" : ["return function(conf, ctx) ngx.say(string.format(\"instance_id: %s, bk_gateway_name: %s, bk_gateway_id: %s, bk_stage_name: %s, jwt_private_key: %s\", ctx.var.instance_id, ctx.var.bk_gateway_name, ctx.var.bk_gateway_id, ctx.var.bk_stage_name, ctx.var.jwt_private_key)); ngx.exit(200); end"]
-                            }
-                        },
-                        "upstream": {
-                            "nodes": {
-                                "127.0.0.1:1980": 1
-                            },
-                            "type": "roundrobin"
-                        },
-                        "uri": "/hello"
-                }]]
+                json.encode(route)
                 )
             if code >= 300 then
                 ngx.status = code
@@ -170,56 +174,60 @@ instance_id: 2c4562899afc453f85bb9c228ed6febd, bk_gateway_name: demo, bk_gateway
     location /t {
         content_by_lua_block {
             local t = require("lib.test_admin").test
+            local json = require("toolkit.json")
+            local route = {
+                plugins = {
+                    ["bk-stage-context"] = {
+                        bk_gateway_name = "demo",
+                        bk_gateway_id = 1,
+                        bk_stage_name = "prod",
+                        jwt_private_key = "dGhpcyBpcyBhIGZha2Ugand0IHByaXZhdGUga2V5",
+                        bk_api_auth = {
+                            api_type = 10,
+                            unfiltered_sensitive_keys = {"a", "b"},
+                            include_system_headers = {"c", "d"},
+                            allow_auth_from_params = true,
+                            allow_delete_sensitive_params = false,
+                            uin_conf = {
+                                user_type = "uin",
+                                from_uin_skey = true,
+                                skey_type = 1,
+                                domain_id = 1,
+                                search_rtx = true,
+                                search_rtx_source = 1,
+                                from_auth_token = false,
+                            },
+                            rtx_conf = {
+                                user_type = "rtx",
+                                from_operator = true,
+                                from_bk_ticket = true,
+                                from_auth_token = true,
+                            },
+                            user_conf = {
+                                user_type = "user",
+                                from_bk_token = true,
+                                from_username = true,
+                            },
+                        },
+                    },
+                    ["serverless-post-function"] = {
+                        phase = "rewrite",
+                        functions = {
+                            "return function(conf, ctx) ngx.say(string.format(\"bk_api_auth: %s, bk_resource_name: %s, bk_service_name: %s\", require(\"toolkit.json\").encode(ctx.var.bk_api_auth), ctx.var.bk_resource_name, ctx.var.bk_service_name)); ngx.exit(200); end",
+                        },
+                    },
+                },
+                upstream = {
+                    nodes = {
+                        ["127.0.0.1:1980"] = 1,
+                    },
+                    type = "roundrobin",
+                },
+                uri = "/hello",
+            }
             local code, body = t('/apisix/admin/routes/1',
                 ngx.HTTP_PUT,
-                [[{
-                        "plugins": {
-                            "bk-stage-context": {
-                                "bk_gateway_name": "demo",
-                                "bk_gateway_id": 1,
-                                "bk_stage_name": "prod",
-                                "jwt_private_key": "dGhpcyBpcyBhIGZha2Ugand0IHByaXZhdGUga2V5",
-                                "bk_api_auth": {
-                                    "api_type": 10,
-                                    "unfiltered_sensitive_keys": ["a", "b"],
-                                    "include_system_headers": ["c", "d"],
-                                    "allow_auth_from_params": true,
-                                    "allow_delete_sensitive_params": false,
-                                    "uin_conf": {
-                                        "user_type": "uin",
-                                        "from_uin_skey": true,
-                                        "skey_type": 1,
-                                        "domain_id": 1,
-                                        "search_rtx": true,
-                                        "search_rtx_source": 1,
-                                        "from_auth_token": false
-                                    },
-                                    "rtx_conf": {
-                                        "user_type": "rtx",
-                                        "from_operator": true,
-                                        "from_bk_ticket": true,
-                                        "from_auth_token": true
-                                    },
-                                    "user_conf": {
-                                        "user_type": "user",
-                                        "from_bk_token": true,
-                                        "from_username": true
-                                    }
-                                }
-                            },
-                            "serverless-post-function": {
-                                "phase": "rewrite",
-                                "functions" : ["return function(conf, ctx) ngx.say(string.format(\"bk_api_auth: %s, bk_resource_name: %s, bk_service_name: %s\", require(\"toolkit.json\").encode(ctx.var.bk_api_auth), ctx.var.bk_resource_name, ctx.var.bk_service_name)); ngx.exit(200); end"]
-                            }
-                        },
-                        "upstream": {
-                            "nodes": {
-                                "127.0.0.1:1980": 1
-                            },
-                            "type": "roundrobin"
-                        },
-                        "uri": "/hello"
-                }]]
+                json.encode(route)
                 )
             if code >= 300 then
                 ngx.status = code

--- a/src/apisix/tests/test-bk-oauth2-appcode-validate.lua
+++ b/src/apisix/tests/test-bk-oauth2-appcode-validate.lua
@@ -1,0 +1,362 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+local core = require("apisix.core")
+local apisix_plugin = require("apisix.plugin")
+local bk_core = require("apisix.plugins.bk-core.init")
+local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+
+describe(
+    "bk-oauth2-appcode-validate", function()
+        local plugin_attr
+        local ctx
+
+        before_each(
+            function()
+                plugin_attr = {}
+                ctx = {
+                    var = {
+                        uri = "/api/test",
+                        bk_gateway_name = "demo",
+                        is_bk_oauth2 = true,
+                        bk_app_code = "public",
+                    },
+                }
+
+                stub(
+                    apisix_plugin, "plugin_attr", function(name)
+                        assert.is_equal("bk-oauth2-appcode-validate", name)
+                        return plugin_attr
+                    end
+                )
+                stub(
+                    bk_core.config, "get_bk_apigateway_api_tmpl", function()
+                        return "https://{api_name}.example.com"
+                    end
+                )
+                stub(core.log, "info")
+                stub(core.log, "error")
+
+                plugin.init()
+            end
+        )
+
+        after_each(
+            function()
+                apisix_plugin.plugin_attr:revert()
+                bk_core.config.get_bk_apigateway_api_tmpl:revert()
+                core.log.info:revert()
+                core.log.error:revert()
+                ngx.header["WWW-Authenticate"] = nil
+            end
+        )
+
+        context(
+            "schema", function()
+                it(
+                    "accepts empty route configuration", function()
+                        local ok, err = plugin.check_schema({})
+
+                        assert.is_true(ok)
+                        assert.is_nil(err)
+                    end
+                )
+
+                it(
+                    "accepts boolean plugin attributes", function()
+                        local ok, err = core.schema.check(
+                            plugin.attr_schema,
+                            {
+                                support_public = true,
+                                support_personal = false,
+                            }
+                        )
+
+                        assert.is_true(ok)
+                        assert.is_nil(err)
+                    end
+                )
+
+                it(
+                    "rejects non-boolean plugin attributes", function()
+                        local ok = core.schema.check(
+                            plugin.attr_schema,
+                            {
+                                support_public = "true",
+                            }
+                        )
+
+                        assert.is_false(ok)
+                    end
+                )
+            end
+        )
+
+        context(
+            "initialization", function()
+                it(
+                    "defaults to an empty allowlist", function()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_false(state.support_public)
+                        assert.is_false(state.support_personal)
+                        assert.is_nil(state.allowed_app_codes.public)
+                        assert.is_nil(state.allowed_app_codes.personal)
+                    end
+                )
+
+                it(
+                    "allows public when configured", function()
+                        plugin_attr = {
+                            support_public = true,
+                        }
+
+                        plugin.init()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_true(state.support_public)
+                        assert.is_false(state.support_personal)
+                        assert.is_true(state.allowed_app_codes.public)
+                        assert.is_nil(state.allowed_app_codes.personal)
+                    end
+                )
+
+                it(
+                    "allows personal when configured", function()
+                        plugin_attr = {
+                            support_personal = true,
+                        }
+
+                        plugin.init()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_false(state.support_public)
+                        assert.is_true(state.support_personal)
+                        assert.is_nil(state.allowed_app_codes.public)
+                        assert.is_true(state.allowed_app_codes.personal)
+                    end
+                )
+
+                it(
+                    "allows both supported app codes", function()
+                        plugin_attr = {
+                            support_public = true,
+                            support_personal = true,
+                        }
+
+                        plugin.init()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_true(state.allowed_app_codes.public)
+                        assert.is_true(state.allowed_app_codes.personal)
+                    end
+                )
+
+                it(
+                    "logs the effective initialization state", function()
+                        plugin_attr = {
+                            support_public = true,
+                        }
+
+                        plugin.init()
+
+                        assert.stub(core.log.info).was_called_with(
+                            "bk-oauth2-appcode-validate: initialized",
+                            ", support_public=", true,
+                            ", support_personal=", false,
+                            ", allowed_app_codes=", '{"public":true}'
+                        )
+                    end
+                )
+
+                it(
+                    "fails closed for invalid plugin attributes", function()
+                        plugin_attr = {
+                            support_public = "true",
+                        }
+
+                        plugin.init()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_false(state.support_public)
+                        assert.is_false(state.support_personal)
+                        assert.is_nil(state.allowed_app_codes.public)
+                        assert.is_nil(state.allowed_app_codes.personal)
+                        assert.stub(core.log.error).was_called()
+                    end
+                )
+
+                it(
+                    "does not retain stale allowlist entries after reinitialization", function()
+                        plugin_attr = {
+                            support_public = true,
+                        }
+                        plugin.init()
+
+                        plugin_attr = {
+                            support_personal = true,
+                        }
+                        plugin.init()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_nil(state.allowed_app_codes.public)
+                        assert.is_true(state.allowed_app_codes.personal)
+                    end
+                )
+            end
+        )
+
+        context(
+            "rewrite", function()
+                it(
+                    "skips when is_bk_oauth2 is false", function()
+                        ctx.var.is_bk_oauth2 = false
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                    end
+                )
+
+                it(
+                    "skips when is_bk_oauth2 is absent", function()
+                        ctx.var.is_bk_oauth2 = nil
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                    end
+                )
+
+                it(
+                    "allows public when public support is enabled", function()
+                        plugin_attr = {
+                            support_public = true,
+                        }
+                        plugin.init()
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                        assert.stub(core.log.info).was_called_with(
+                            "bk-oauth2-appcode-validate: validation passed",
+                            ", bk_app_code=", "public",
+                            ", support_public=", true,
+                            ", support_personal=", false
+                        )
+                    end
+                )
+
+                it(
+                    "allows personal when personal support is enabled", function()
+                        plugin_attr = {
+                            support_personal = true,
+                        }
+                        plugin.init()
+                        ctx.var.bk_app_code = "personal"
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                    end
+                )
+
+                it(
+                    "rejects a disabled supported app code", function()
+                        local status = plugin.rewrite({}, ctx)
+
+                        assert.is_equal(401, status)
+                        assert.is_equal(
+                            "UNAUTHORIZED",
+                            ctx.var.bk_apigw_error.error.code_name
+                        )
+                    end
+                )
+
+                it(
+                    "rejects an ordinary app code even when both flags are enabled", function()
+                        plugin_attr = {
+                            support_public = true,
+                            support_personal = true,
+                        }
+                        plugin.init()
+                        ctx.var.bk_app_code = "ordinary-app"
+
+                        local status = plugin.rewrite({}, ctx)
+
+                        assert.is_equal(401, status)
+                    end
+                )
+
+                it(
+                    "rejects a missing app code", function()
+                        ctx.var.bk_app_code = nil
+
+                        local status = plugin.rewrite({}, ctx)
+
+                        assert.is_equal(401, status)
+                    end
+                )
+
+                it(
+                    "rejects an empty app code", function()
+                        ctx.var.bk_app_code = ""
+
+                        local status = plugin.rewrite({}, ctx)
+
+                        assert.is_equal(401, status)
+                    end
+                )
+
+                it(
+                    "returns rich invalid_token details", function()
+                        plugin_attr = {
+                            support_personal = true,
+                        }
+                        plugin.init()
+                        ctx.var.bk_app_code = "public"
+
+                        local status = plugin.rewrite({}, ctx)
+                        local message = ctx.var.bk_apigw_error.error.message
+                        local www_auth = ngx.header["WWW-Authenticate"]
+
+                        assert.is_equal(401, status)
+                        assert.is_truthy(string.find(
+                            message,
+                            'reason="OAuth2 token app code is not allowed"',
+                            1,
+                            true
+                        ))
+                        assert.is_truthy(string.find(message, 'bk_app_code="public"', 1, true))
+                        assert.is_truthy(string.find(message, 'support_public="false"', 1, true))
+                        assert.is_truthy(string.find(message, 'support_personal="true"', 1, true))
+                        assert.is_truthy(string.find(www_auth, 'error="invalid_token"', 1, true))
+                        assert.is_truthy(string.find(www_auth, "bk_app_code=public", 1, true))
+                        assert.is_truthy(string.find(www_auth, "support_public=false", 1, true))
+                        assert.is_truthy(string.find(www_auth, "support_personal=true", 1, true))
+                        assert.stub(core.log.info).was_called_with(
+                            "bk-oauth2-appcode-validate: validation failed",
+                            ", bk_app_code=", "public",
+                            ", support_public=", false,
+                            ", support_personal=", true
+                        )
+                    end
+                )
+            end
+        )
+    end
+)

--- a/src/build/patches/001_change_prometheus_default_buckets.patch
+++ b/src/build/patches/001_change_prometheus_default_buckets.patch
@@ -1,8 +1,8 @@
 diff --git a/apisix/plugins/prometheus/exporter.lua b/apisix/plugins/prometheus/exporter.lua
-index ed219a49..fb277e67 100644
+index ce89ca0..f10fae5 100644
 --- a/apisix/plugins/prometheus/exporter.lua
 +++ b/apisix/plugins/prometheus/exporter.lua
-@@ -308,6 +308,12 @@
+@@ -291,6 +291,12 @@ end
  
  
  function _M.http_log(conf, ctx)
@@ -15,24 +15,28 @@ index ed219a49..fb277e67 100644
      local vars = ctx.var
  
      local route_id = ""
-@@ -335,62 +341,70 @@
+@@ -318,64 +324,72 @@ function _M.http_log(conf, ctx)
          matched_host = ctx.curr_req_matched._host or ""
      end
+ 
+-    local response_source = core.response.get_response_source(ctx)
++    if official and official.enable_status then
++        local response_source = core.response.get_response_source(ctx)
  
 -    metrics.status:inc(1,
 -        gen_arr(vars.status, route_id, matched_uri, matched_host,
 -                service_id, consumer_name, balancer_ip,
 -                vars.request_type, vars.request_llm_model, vars.llm_model,
+-                response_source,
 -                unpack(extra_labels("http_status", ctx))))
-+    if official and official.enable_status then
 +        metrics.status:inc(1,
 +            gen_arr(vars.status, route_id, matched_uri, matched_host,
 +                    service_id, consumer_name, balancer_ip,
 +                    vars.request_type, vars.request_llm_model, vars.llm_model,
++                    response_source,
 +                    unpack(extra_labels("http_status", ctx))))
 +    end
--
-+
+ 
 -    local latency, upstream_latency, apisix_latency = latency_details(ctx)
 -    local latency_extra_label_values = extra_labels("http_latency", ctx)
 +    if official and official.enable_latency then
@@ -43,94 +47,87 @@ index ed219a49..fb277e67 100644
 -        gen_arr("request", route_id, service_id, consumer_name, balancer_ip,
 -        vars.request_type, vars.request_llm_model, vars.llm_model,
 -        unpack(latency_extra_label_values)))
--
--    if upstream_latency then
--        metrics.latency:observe(upstream_latency,
--            gen_arr("upstream", route_id, service_id, consumer_name, balancer_ip,
 +        metrics.latency:observe(latency,
 +            gen_arr("request", route_id, service_id, consumer_name, balancer_ip,
-             vars.request_type, vars.request_llm_model, vars.llm_model,
-             unpack(latency_extra_label_values)))
--    end
- 
--    metrics.latency:observe(apisix_latency,
--        gen_arr("apisix", route_id, service_id, consumer_name, balancer_ip,
--        vars.request_type, vars.request_llm_model, vars.llm_model,
--        unpack(latency_extra_label_values)))
--
--    local bandwidth_extra_label_values = extra_labels("bandwidth", ctx)
--
--    metrics.bandwidth:inc(vars.request_length,
--        gen_arr("ingress", route_id, service_id, consumer_name, balancer_ip,
--        vars.request_type, vars.request_llm_model, vars.llm_model,
--        unpack(bandwidth_extra_label_values)))
--
--    metrics.bandwidth:inc(vars.bytes_sent,
--        gen_arr("egress", route_id, service_id, consumer_name, balancer_ip,
--        vars.request_type, vars.request_llm_model, vars.llm_model,
--        unpack(bandwidth_extra_label_values)))
--
--    local llm_time_to_first_token = vars.llm_time_to_first_token
--    if llm_time_to_first_token ~= "" then
--        metrics.llm_latency:observe(tonumber(llm_time_to_first_token),
--            gen_arr(route_id, service_id, consumer_name, balancer_ip,
++            vars.request_type, vars.request_llm_model, vars.llm_model,
++            unpack(latency_extra_label_values)))
++
 +        if upstream_latency then
 +            metrics.latency:observe(upstream_latency,
 +                gen_arr("upstream", route_id, service_id, consumer_name, balancer_ip,
 +                vars.request_type, vars.request_llm_model, vars.llm_model,
 +                unpack(latency_extra_label_values)))
 +        end
-+
+ 
+-    if upstream_latency then
+-        metrics.latency:observe(upstream_latency,
+-            gen_arr("upstream", route_id, service_id, consumer_name, balancer_ip,
 +        metrics.latency:observe(apisix_latency,
 +            gen_arr("apisix", route_id, service_id, consumer_name, balancer_ip,
              vars.request_type, vars.request_llm_model, vars.llm_model,
--            unpack(extra_labels("llm_latency", ctx))))
-+            unpack(latency_extra_label_values)))
+             unpack(latency_extra_label_values)))
      end
--    if vars.llm_prompt_tokens ~= "" then
--        metrics.llm_prompt_tokens:inc(tonumber(vars.llm_prompt_tokens),
--            gen_arr(route_id, service_id, consumer_name, balancer_ip,
-+
+ 
+-    metrics.latency:observe(apisix_latency,
+-        gen_arr("apisix", route_id, service_id, consumer_name, balancer_ip,
+-        vars.request_type, vars.request_llm_model, vars.llm_model,
+-        unpack(latency_extra_label_values)))
 +    if official and official.enable_bandwidth then
 +        local bandwidth_extra_label_values = extra_labels("bandwidth", ctx)
-+
+ 
+-    local bandwidth_extra_label_values = extra_labels("bandwidth", ctx)
 +        metrics.bandwidth:inc(vars.request_length,
 +            gen_arr("ingress", route_id, service_id, consumer_name, balancer_ip,
-             vars.request_type, vars.request_llm_model, vars.llm_model,
--            unpack(extra_labels("llm_prompt_tokens", ctx))))
--    end
--    if vars.llm_completion_tokens ~= "" then
--        metrics.llm_completion_tokens:inc(tonumber(vars.llm_completion_tokens),
--            gen_arr(route_id, service_id, consumer_name, balancer_ip,
++            vars.request_type, vars.request_llm_model, vars.llm_model,
 +            unpack(bandwidth_extra_label_values)))
-+
+ 
+-    metrics.bandwidth:inc(vars.request_length,
+-        gen_arr("ingress", route_id, service_id, consumer_name, balancer_ip,
+-        vars.request_type, vars.request_llm_model, vars.llm_model,
+-        unpack(bandwidth_extra_label_values)))
 +        metrics.bandwidth:inc(vars.bytes_sent,
 +            gen_arr("egress", route_id, service_id, consumer_name, balancer_ip,
-             vars.request_type, vars.request_llm_model, vars.llm_model,
--            unpack(extra_labels("llm_completion_tokens", ctx))))
++            vars.request_type, vars.request_llm_model, vars.llm_model,
 +            unpack(bandwidth_extra_label_values)))
 +    end
-+
+ 
+-    metrics.bandwidth:inc(vars.bytes_sent,
+-        gen_arr("egress", route_id, service_id, consumer_name, balancer_ip,
+-        vars.request_type, vars.request_llm_model, vars.llm_model,
+-        unpack(bandwidth_extra_label_values)))
 +    if official and official.enable_llm then
-+        local llm_time_to_first_token = vars.llm_time_to_first_token
-+        if llm_time_to_first_token ~= "" then
-+            metrics.llm_latency:observe(tonumber(llm_time_to_first_token),
-+                gen_arr(route_id, service_id, consumer_name, balancer_ip,
-+                vars.request_type, vars.request_llm_model, vars.llm_model,
-+                unpack(extra_labels("llm_latency", ctx))))
-+        end
-+        if vars.llm_prompt_tokens ~= "" then
++        if vars.request_type == "ai_stream" or vars.request_type == "ai_chat" then
++            local llm_time_to_first_token = vars.llm_time_to_first_token
++            if llm_time_to_first_token ~= "0" then
++                metrics.llm_latency:observe(tonumber(llm_time_to_first_token),
++                    gen_arr(route_id, service_id, consumer_name, balancer_ip,
++                        vars.request_type, vars.request_llm_model, vars.llm_model,
++                        unpack(extra_labels("llm_latency", ctx))))
++            end
 +            metrics.llm_prompt_tokens:inc(tonumber(vars.llm_prompt_tokens),
 +                gen_arr(route_id, service_id, consumer_name, balancer_ip,
-+                vars.request_type, vars.request_llm_model, vars.llm_model,
-+                unpack(extra_labels("llm_prompt_tokens", ctx))))
-+        end
-+        if vars.llm_completion_tokens ~= "" then
++                    vars.request_type, vars.request_llm_model, vars.llm_model,
++                    unpack(extra_labels("llm_prompt_tokens", ctx))))
+ 
+-    if vars.request_type == "ai_stream" or vars.request_type == "ai_chat" then
+-        local llm_time_to_first_token = vars.llm_time_to_first_token
+-        if llm_time_to_first_token ~= "0" then
+-            metrics.llm_latency:observe(tonumber(llm_time_to_first_token),
 +            metrics.llm_completion_tokens:inc(tonumber(vars.llm_completion_tokens),
-+                gen_arr(route_id, service_id, consumer_name, balancer_ip,
-+                vars.request_type, vars.request_llm_model, vars.llm_model,
-+                unpack(extra_labels("llm_completion_tokens", ctx))))
-+        end
+                 gen_arr(route_id, service_id, consumer_name, balancer_ip,
+                     vars.request_type, vars.request_llm_model, vars.llm_model,
+-                    unpack(extra_labels("llm_latency", ctx))))
++                    unpack(extra_labels("llm_completion_tokens", ctx))))
+         end
+-        metrics.llm_prompt_tokens:inc(tonumber(vars.llm_prompt_tokens),
+-            gen_arr(route_id, service_id, consumer_name, balancer_ip,
+-                vars.request_type, vars.request_llm_model, vars.llm_model,
+-                unpack(extra_labels("llm_prompt_tokens", ctx))))
+-
+-        metrics.llm_completion_tokens:inc(tonumber(vars.llm_completion_tokens),
+-            gen_arr(route_id, service_id, consumer_name, balancer_ip,
+-                vars.request_type, vars.request_llm_model, vars.llm_model,
+-                unpack(extra_labels("llm_completion_tokens", ctx))))
      end
  end
  

--- a/src/build/patches/008_log_rotate_file_logger_access_log.patch
+++ b/src/build/patches/008_log_rotate_file_logger_access_log.patch
@@ -1,0 +1,16 @@
+diff --git a/apisix/plugins/log-rotate.lua b/apisix/plugins/log-rotate.lua
+index f90226d8..c841e20c 100644
+--- a/apisix/plugins/log-rotate.lua
++++ b/apisix/plugins/log-rotate.lua
+@@ -188,8 +188,9 @@ local function compression_file(new_file, timeout)
+ 
+ local function init_default_logs(logs_info, log_type)
+     local_conf = core.config.local_conf()
+-    enable_access_log = core.table.try_read_attr(
+-        local_conf, "nginx_config", "http", "enable_access_log")
++    -- BlueKing uses file-logger to write logs/access.log with Nginx access logging disabled.
++    -- Keep rotating that file to prevent unbounded growth and preserve APISIX 3.13 behavior.
++    enable_access_log = true
+     local filepath, filename = get_log_path_info(log_type)
+     logs_info[log_type] = { type = log_type }
+     if filename ~= "off" then


### PR DESCRIPTION
## Summary

- Upgrade the APISIX runtime to 3.17.0, including the upstream submodule, test image, compatibility patches, and related build/runtime updates.
- Add the fail-closed bk-oauth2-appcode-validate plugin with plugin_attr support_public and support_personal controls.
- Return 401 invalid_token responses with rich error details and logging for unsupported application codes.
- Add Busted and test-nginx coverage and register the plugin in the plugin README.

## Verification

- RUN_WITH_IT= make lint (from src/apisix): 92 files checked, 0 warnings, 0 errors.
- RUN_WITH_IT= make test: Busted 771 successes, 0 failures, 0 errors; test-nginx Files=30, Tests=712, Result PASS.
- Focused Busted: 19 successes, 0 failures, 0 errors.
- Focused test-nginx: Files=2, Tests=34, Result PASS.
- Repository-wide make check-license remains red only for the pre-existing tracked file src/apisix/tests/test-bk-traffic-label.lua, which also lacks the header on origin/feat/upgrade-apisix-3.17. Direct license checks for both new Lua files pass.