### PR TITLE
feat(oauth2): validate supported token app codes

### DIFF
--- a/src/apisix/plugins/README.md
+++ b/src/apisix/plugins/README.md
@@ -52,7 +52,7 @@
 - bk-auth-validate                          # priority: 17680
 - bk-user-restriction                       # priority: 17679
 - bk-oauth2-audience-validate               # priority: 17678  # OAuth2 audience 验证：验证 MCP 服务器和网关 API 的 audience 声明
-- bk-oauth2-appcode-validate                # priority: 17677  # OAuth2 app code 验证：按全局配置允许 public 和 personal 客户端
+- bk-oauth2-appcode-validate                # priority: 17677  # OAuth2 app code 验证：按路由配置允许 public 和 personal 客户端
 - bk-tenant-validate-exempt                 # priority: 17676  # 如果资源配置了此插件, 则跳过 bk-tenant-validate 校验
 - bk-tenant-verify                          # priority: 17675
 - bk-tenant-validate                        # priority: 17674

--- a/src/apisix/plugins/README.md
+++ b/src/apisix/plugins/README.md
@@ -52,6 +52,7 @@
 - bk-auth-validate                          # priority: 17680
 - bk-user-restriction                       # priority: 17679
 - bk-oauth2-audience-validate               # priority: 17678  # OAuth2 audience 验证：验证 MCP 服务器和网关 API 的 audience 声明
+- bk-oauth2-appcode-validate                # priority: 17677  # OAuth2 app code 验证：按全局配置允许 public 和 personal 客户端
 - bk-tenant-validate-exempt                 # priority: 17676  # 如果资源配置了此插件, 则跳过 bk-tenant-validate 校验
 - bk-tenant-verify                          # priority: 17675
 - bk-tenant-validate                        # priority: 17674

--- a/src/apisix/plugins/README.md
+++ b/src/apisix/plugins/README.md
@@ -51,8 +51,8 @@
 - bk-request-body-limit                     # priority: 17690
 - bk-auth-validate                          # priority: 17680
 - bk-user-restriction                       # priority: 17679
-- bk-oauth2-audience-validate               # priority: 17678  # OAuth2 audience 验证：验证 MCP 服务器和网关 API 的 audience 声明
-- bk-oauth2-appcode-validate                # priority: 17677  # OAuth2 app code 验证：按路由配置允许 public 和 personal 客户端
+- bk-oauth2-appcode-validate                # priority: 17678  # OAuth2 app code 验证：按路由配置允许 public 和 personal 客户端
+- bk-oauth2-audience-validate               # priority: 17677  # OAuth2 audience 验证：验证 MCP 服务器和网关 API 的 audience 声明
 - bk-tenant-validate-exempt                 # priority: 17676  # 如果资源配置了此插件, 则跳过 bk-tenant-validate 校验
 - bk-tenant-verify                          # priority: 17675
 - bk-tenant-validate                        # priority: 17674

--- a/src/apisix/plugins/bk-oauth2-appcode-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-appcode-validate.lua
@@ -59,6 +59,18 @@ function _M.check_schema(conf)
 end
 
 
+local function log_validation(phase, app_code, conf, ctx)
+    core.log.info(
+        plugin_name .. ": " .. phase,
+        ", bk_app_code=", app_code,
+        ", support_public=", conf.support_public,
+        ", support_personal=", conf.support_personal,
+        ", gateway=", ctx.var.bk_gateway_name,
+        ", resource=", ctx.var.bk_resource_name
+    )
+end
+
+
 function _M.rewrite(conf, ctx) -- luacheck: no unused
     if ctx.var.is_bk_oauth2 ~= true then
         core.log.info(
@@ -72,47 +84,19 @@ function _M.rewrite(conf, ctx) -- luacheck: no unused
 
     local app_code = ctx.var.bk_app_code or ""
 
-    core.log.info(
-        plugin_name .. ": checking",
-        ", bk_app_code=", app_code,
-        ", support_public=", conf.support_public,
-        ", support_personal=", conf.support_personal,
-        ", gateway=", ctx.var.bk_gateway_name,
-        ", resource=", ctx.var.bk_resource_name
-    )
+    log_validation("checking", app_code, conf, ctx)
 
     if app_code == "public" and conf.support_public then
-        core.log.info(
-            plugin_name .. ": validation passed",
-            ", bk_app_code=", app_code,
-            ", support_public=", conf.support_public,
-            ", support_personal=", conf.support_personal,
-            ", gateway=", ctx.var.bk_gateway_name,
-            ", resource=", ctx.var.bk_resource_name
-        )
+        log_validation("validation passed", app_code, conf, ctx)
         return
     end
 
     if app_code == "personal" and conf.support_personal then
-        core.log.info(
-            plugin_name .. ": validation passed",
-            ", bk_app_code=", app_code,
-            ", support_public=", conf.support_public,
-            ", support_personal=", conf.support_personal,
-            ", gateway=", ctx.var.bk_gateway_name,
-            ", resource=", ctx.var.bk_resource_name
-        )
+        log_validation("validation passed", app_code, conf, ctx)
         return
     end
 
-    core.log.info(
-        plugin_name .. ": validation failed",
-        ", bk_app_code=", app_code,
-        ", support_public=", conf.support_public,
-        ", support_personal=", conf.support_personal,
-        ", gateway=", ctx.var.bk_gateway_name,
-        ", resource=", ctx.var.bk_resource_name
-    )
+    log_validation("validation failed", app_code, conf, ctx)
 
     local err = errorx.new_general_unauthorized():with_fields(
         {

--- a/src/apisix/plugins/bk-oauth2-appcode-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-appcode-validate.lua
@@ -48,7 +48,7 @@ local schema = {
 
 local _M = {
     version = 0.1,
-    priority = 17677,
+    priority = 17678,
     name = plugin_name,
     schema = schema,
 }

--- a/src/apisix/plugins/bk-oauth2-appcode-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-appcode-validate.lua
@@ -59,18 +59,13 @@ function _M.check_schema(conf)
 end
 
 
-local function build_error_description(app_code, conf)
-    return "OAuth2 token app code is not allowed: bk_app_code=" .. app_code ..
-        ", support_public=" .. tostring(conf.support_public) ..
-        ", support_personal=" .. tostring(conf.support_personal)
-end
-
-
 function _M.rewrite(conf, ctx) -- luacheck: no unused
     if ctx.var.is_bk_oauth2 ~= true then
         core.log.info(
             plugin_name .. ": skipping",
-            ", is_bk_oauth2=", ctx.var.is_bk_oauth2
+            ", is_bk_oauth2=", ctx.var.is_bk_oauth2,
+            ", gateway=", ctx.var.bk_gateway_name,
+            ", resource=", ctx.var.bk_resource_name
         )
         return
     end
@@ -81,17 +76,31 @@ function _M.rewrite(conf, ctx) -- luacheck: no unused
         plugin_name .. ": checking",
         ", bk_app_code=", app_code,
         ", support_public=", conf.support_public,
-        ", support_personal=", conf.support_personal
+        ", support_personal=", conf.support_personal,
+        ", gateway=", ctx.var.bk_gateway_name,
+        ", resource=", ctx.var.bk_resource_name
     )
 
-    local is_allowed = app_code == "public" and conf.support_public
-        or app_code == "personal" and conf.support_personal
-    if is_allowed then
+    if app_code == "public" and conf.support_public then
         core.log.info(
             plugin_name .. ": validation passed",
             ", bk_app_code=", app_code,
             ", support_public=", conf.support_public,
-            ", support_personal=", conf.support_personal
+            ", support_personal=", conf.support_personal,
+            ", gateway=", ctx.var.bk_gateway_name,
+            ", resource=", ctx.var.bk_resource_name
+        )
+        return
+    end
+
+    if app_code == "personal" and conf.support_personal then
+        core.log.info(
+            plugin_name .. ": validation passed",
+            ", bk_app_code=", app_code,
+            ", support_public=", conf.support_public,
+            ", support_personal=", conf.support_personal,
+            ", gateway=", ctx.var.bk_gateway_name,
+            ", resource=", ctx.var.bk_resource_name
         )
         return
     end
@@ -100,21 +109,28 @@ function _M.rewrite(conf, ctx) -- luacheck: no unused
         plugin_name .. ": validation failed",
         ", bk_app_code=", app_code,
         ", support_public=", conf.support_public,
-        ", support_personal=", conf.support_personal
+        ", support_personal=", conf.support_personal,
+        ", gateway=", ctx.var.bk_gateway_name,
+        ", resource=", ctx.var.bk_resource_name
     )
 
-    local error_description = build_error_description(app_code, conf)
     local err = errorx.new_general_unauthorized():with_fields(
         {
             reason = "OAuth2 token app code is not allowed",
             bk_app_code = app_code,
             support_public = conf.support_public,
             support_personal = conf.support_personal,
+            gateway = ctx.var.bk_gateway_name or "",
+            resource = ctx.var.bk_resource_name or "",
         }
     )
 
     ngx.header["WWW-Authenticate"] = oauth2.build_www_authenticate_header(
-        ctx, "invalid_token", error_description
+        ctx,
+        "invalid_token",
+        "OAuth2 token app code is not allowed: bk_app_code=" .. app_code ..
+            ", support_public=" .. tostring(conf.support_public) ..
+            ", support_personal=" .. tostring(conf.support_personal)
     )
     return errorx.exit_with_apigw_err(ctx, err, _M)
 end

--- a/src/apisix/plugins/bk-oauth2-appcode-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-appcode-validate.lua
@@ -17,7 +17,7 @@
 --
 -- # bk-oauth2-appcode-validate
 --
--- Validate whether an OAuth2 token's application code is enabled by plugin attributes.
+-- Validate whether an OAuth2 token's application code is enabled by route configuration.
 --
 -- This plugin only runs when ctx.var.is_bk_oauth2 == true.
 --
@@ -25,7 +25,6 @@
 --     * bk-oauth2-verify: To set ctx.var.bk_app_code
 --
 local core = require("apisix.core")
-local apisix_plugin = require("apisix.plugin")
 local errorx = require("apisix.plugins.bk-core.errorx")
 local oauth2 = require("apisix.plugins.bk-core.oauth2")
 local ngx = ngx
@@ -34,11 +33,6 @@ local tostring = tostring
 local plugin_name = "bk-oauth2-appcode-validate"
 
 local schema = {
-    type = "object",
-    properties = {},
-}
-
-local attr_schema = {
     type = "object",
     properties = {
         support_public = {
@@ -57,12 +51,7 @@ local _M = {
     priority = 17677,
     name = plugin_name,
     schema = schema,
-    attr_schema = attr_schema,
 }
-
-local support_public = false
-local support_personal = false
-local allowed_app_codes = {}
 
 
 function _M.check_schema(conf)
@@ -70,59 +59,10 @@ function _M.check_schema(conf)
 end
 
 
-local function reset_validation_state()
-    support_public = false
-    support_personal = false
-    allowed_app_codes = {}
-end
-
-
-local function get_validation_state()
-    return {
-        support_public = support_public,
-        support_personal = support_personal,
-        allowed_app_codes = allowed_app_codes,
-    }
-end
-
-
-function _M.init()
-    reset_validation_state()
-
-    local plugin_info = apisix_plugin.plugin_attr(plugin_name) or {}
-    local ok, err = core.schema.check(attr_schema, plugin_info)
-    if not ok then
-        core.log.error(
-            "failed to check plugin_attr[", plugin_name, "]: ", err,
-            ", fail closed with no allowed app codes"
-        )
-        return
-    end
-
-    support_public = plugin_info.support_public == true
-    support_personal = plugin_info.support_personal == true
-
-    if support_public then
-        allowed_app_codes.public = true
-    end
-
-    if support_personal then
-        allowed_app_codes.personal = true
-    end
-
-    core.log.info(
-        plugin_name .. ": initialized",
-        ", support_public=", support_public,
-        ", support_personal=", support_personal,
-        ", allowed_app_codes=", core.json.encode(allowed_app_codes)
-    )
-end
-
-
-local function build_error_description(app_code)
+local function build_error_description(app_code, conf)
     return "OAuth2 token app code is not allowed: bk_app_code=" .. app_code ..
-        ", support_public=" .. tostring(support_public) ..
-        ", support_personal=" .. tostring(support_personal)
+        ", support_public=" .. tostring(conf.support_public) ..
+        ", support_personal=" .. tostring(conf.support_personal)
 end
 
 
@@ -140,16 +80,18 @@ function _M.rewrite(conf, ctx) -- luacheck: no unused
     core.log.info(
         plugin_name .. ": checking",
         ", bk_app_code=", app_code,
-        ", support_public=", support_public,
-        ", support_personal=", support_personal
+        ", support_public=", conf.support_public,
+        ", support_personal=", conf.support_personal
     )
 
-    if app_code ~= "" and allowed_app_codes[app_code] then
+    local is_allowed = app_code == "public" and conf.support_public
+        or app_code == "personal" and conf.support_personal
+    if is_allowed then
         core.log.info(
             plugin_name .. ": validation passed",
             ", bk_app_code=", app_code,
-            ", support_public=", support_public,
-            ", support_personal=", support_personal
+            ", support_public=", conf.support_public,
+            ", support_personal=", conf.support_personal
         )
         return
     end
@@ -157,17 +99,17 @@ function _M.rewrite(conf, ctx) -- luacheck: no unused
     core.log.info(
         plugin_name .. ": validation failed",
         ", bk_app_code=", app_code,
-        ", support_public=", support_public,
-        ", support_personal=", support_personal
+        ", support_public=", conf.support_public,
+        ", support_personal=", conf.support_personal
     )
 
-    local error_description = build_error_description(app_code)
+    local error_description = build_error_description(app_code, conf)
     local err = errorx.new_general_unauthorized():with_fields(
         {
             reason = "OAuth2 token app code is not allowed",
             bk_app_code = app_code,
-            support_public = support_public,
-            support_personal = support_personal,
+            support_public = conf.support_public,
+            support_personal = conf.support_personal,
         }
     )
 
@@ -177,9 +119,5 @@ function _M.rewrite(conf, ctx) -- luacheck: no unused
     return errorx.exit_with_apigw_err(ctx, err, _M)
 end
 
-
-if _TEST then -- luacheck: ignore
-    _M._get_validation_state = get_validation_state
-end
 
 return _M

--- a/src/apisix/plugins/bk-oauth2-appcode-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-appcode-validate.lua
@@ -1,0 +1,185 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+-- # bk-oauth2-appcode-validate
+--
+-- Validate whether an OAuth2 token's application code is enabled by plugin attributes.
+--
+-- This plugin only runs when ctx.var.is_bk_oauth2 == true.
+--
+-- This plugin depends on:
+--     * bk-oauth2-verify: To set ctx.var.bk_app_code
+--
+local core = require("apisix.core")
+local apisix_plugin = require("apisix.plugin")
+local errorx = require("apisix.plugins.bk-core.errorx")
+local oauth2 = require("apisix.plugins.bk-core.oauth2")
+local ngx = ngx
+local tostring = tostring
+
+local plugin_name = "bk-oauth2-appcode-validate"
+
+local schema = {
+    type = "object",
+    properties = {},
+}
+
+local attr_schema = {
+    type = "object",
+    properties = {
+        support_public = {
+            type = "boolean",
+            default = false,
+        },
+        support_personal = {
+            type = "boolean",
+            default = false,
+        },
+    },
+}
+
+local _M = {
+    version = 0.1,
+    priority = 17677,
+    name = plugin_name,
+    schema = schema,
+    attr_schema = attr_schema,
+}
+
+local support_public = false
+local support_personal = false
+local allowed_app_codes = {}
+
+
+function _M.check_schema(conf)
+    return core.schema.check(schema, conf)
+end
+
+
+local function reset_validation_state()
+    support_public = false
+    support_personal = false
+    allowed_app_codes = {}
+end
+
+
+local function get_validation_state()
+    return {
+        support_public = support_public,
+        support_personal = support_personal,
+        allowed_app_codes = allowed_app_codes,
+    }
+end
+
+
+function _M.init()
+    reset_validation_state()
+
+    local plugin_info = apisix_plugin.plugin_attr(plugin_name) or {}
+    local ok, err = core.schema.check(attr_schema, plugin_info)
+    if not ok then
+        core.log.error(
+            "failed to check plugin_attr[", plugin_name, "]: ", err,
+            ", fail closed with no allowed app codes"
+        )
+        return
+    end
+
+    support_public = plugin_info.support_public == true
+    support_personal = plugin_info.support_personal == true
+
+    if support_public then
+        allowed_app_codes.public = true
+    end
+
+    if support_personal then
+        allowed_app_codes.personal = true
+    end
+
+    core.log.info(
+        plugin_name .. ": initialized",
+        ", support_public=", support_public,
+        ", support_personal=", support_personal,
+        ", allowed_app_codes=", core.json.encode(allowed_app_codes)
+    )
+end
+
+
+local function build_error_description(app_code)
+    return "OAuth2 token app code is not allowed: bk_app_code=" .. app_code ..
+        ", support_public=" .. tostring(support_public) ..
+        ", support_personal=" .. tostring(support_personal)
+end
+
+
+function _M.rewrite(conf, ctx) -- luacheck: no unused
+    if ctx.var.is_bk_oauth2 ~= true then
+        core.log.info(
+            plugin_name .. ": skipping",
+            ", is_bk_oauth2=", ctx.var.is_bk_oauth2
+        )
+        return
+    end
+
+    local app_code = ctx.var.bk_app_code or ""
+
+    core.log.info(
+        plugin_name .. ": checking",
+        ", bk_app_code=", app_code,
+        ", support_public=", support_public,
+        ", support_personal=", support_personal
+    )
+
+    if app_code ~= "" and allowed_app_codes[app_code] then
+        core.log.info(
+            plugin_name .. ": validation passed",
+            ", bk_app_code=", app_code,
+            ", support_public=", support_public,
+            ", support_personal=", support_personal
+        )
+        return
+    end
+
+    core.log.info(
+        plugin_name .. ": validation failed",
+        ", bk_app_code=", app_code,
+        ", support_public=", support_public,
+        ", support_personal=", support_personal
+    )
+
+    local error_description = build_error_description(app_code)
+    local err = errorx.new_general_unauthorized():with_fields(
+        {
+            reason = "OAuth2 token app code is not allowed",
+            bk_app_code = app_code,
+            support_public = support_public,
+            support_personal = support_personal,
+        }
+    )
+
+    ngx.header["WWW-Authenticate"] = oauth2.build_www_authenticate_header(
+        ctx, "invalid_token", error_description
+    )
+    return errorx.exit_with_apigw_err(ctx, err, _M)
+end
+
+
+if _TEST then -- luacheck: ignore
+    _M._get_validation_state = get_validation_state
+end
+
+return _M

--- a/src/apisix/plugins/bk-oauth2-audience-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-audience-validate.lua
@@ -51,7 +51,7 @@ local schema = {
 
 local _M = {
     version = 0.1,
-    priority = 17678,
+    priority = 17677,
     name = plugin_name,
     schema = schema,
 }

--- a/src/apisix/t/bk-oauth2-appcode-validate.t
+++ b/src/apisix/t/bk-oauth2-appcode-validate.t
@@ -40,7 +40,10 @@ __DATA__
     location /t {
         content_by_lua_block {
             local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
-            local ok, err = plugin.check_schema({})
+            local ok, err = plugin.check_schema({
+                support_public = true,
+                support_personal = false
+            })
             if not ok then
                 ngx.say(err)
                 return
@@ -64,7 +67,10 @@ priority: 17677
                 }
             }
 
-            local result = plugin.rewrite({}, ctx)
+            local result = plugin.rewrite({
+                support_public = false,
+                support_personal = false
+            }, ctx)
             ngx.say(result == nil and "skipped" or "processed")
         }
     }
@@ -72,11 +78,6 @@ priority: 17677
 skipped
 
 === TEST 3: public-only configuration allows public
---- extra_yaml_config
-plugin_attr:
-  bk-oauth2-appcode-validate:
-    support_public: true
-    support_personal: false
 --- config
     location /t {
         content_by_lua_block {
@@ -90,7 +91,10 @@ plugin_attr:
                 }
             }
 
-            local result = plugin.rewrite({}, ctx)
+            local result = plugin.rewrite({
+                support_public = true,
+                support_personal = false
+            }, ctx)
             ngx.say(result == nil and "pass" or "fail")
         }
     }
@@ -99,10 +103,6 @@ pass
 
 === TEST 4: public-only configuration rejects personal
 --- extra_yaml_config
-plugin_attr:
-  bk-oauth2-appcode-validate:
-    support_public: true
-    support_personal: false
 bk_gateway:
   hosts:
     bk-apigateway-api:
@@ -120,7 +120,10 @@ bk_gateway:
                 }
             }
 
-            local status = plugin.rewrite({}, ctx)
+            local status = plugin.rewrite({
+                support_public = true,
+                support_personal = false
+            }, ctx)
             ngx.status = 200
             ngx.say("status: " .. tostring(status))
             ngx.say("code_name: " .. ctx.var.bk_apigw_error.error.code_name)
@@ -133,11 +136,6 @@ qr/status: 401\ncode_name: UNAUTHORIZED\nmessage: Unauthorized .*OAuth2 token ap
 WWW-Authenticate: Bearer .*error="invalid_token".*bk_app_code=personal.*support_public=true.*support_personal=false"
 
 === TEST 5: personal-only configuration allows personal
---- extra_yaml_config
-plugin_attr:
-  bk-oauth2-appcode-validate:
-    support_public: false
-    support_personal: true
 --- config
     location /t {
         content_by_lua_block {
@@ -151,7 +149,10 @@ plugin_attr:
                 }
             }
 
-            local result = plugin.rewrite({}, ctx)
+            local result = plugin.rewrite({
+                support_public = false,
+                support_personal = true
+            }, ctx)
             ngx.say(result == nil and "pass" or "fail")
         }
     }
@@ -160,10 +161,6 @@ pass
 
 === TEST 6: personal-only configuration rejects public
 --- extra_yaml_config
-plugin_attr:
-  bk-oauth2-appcode-validate:
-    support_public: false
-    support_personal: true
 bk_gateway:
   hosts:
     bk-apigateway-api:
@@ -181,7 +178,10 @@ bk_gateway:
                 }
             }
 
-            local status = plugin.rewrite({}, ctx)
+            local status = plugin.rewrite({
+                support_public = false,
+                support_personal = true
+            }, ctx)
             ngx.status = 200
             ngx.say("status: " .. tostring(status))
         }
@@ -192,11 +192,6 @@ status: 401
 WWW-Authenticate: Bearer .*error="invalid_token".*support_public=false.*support_personal=true"
 
 === TEST 7: both-enabled configuration allows both app codes
---- extra_yaml_config
-plugin_attr:
-  bk-oauth2-appcode-validate:
-    support_public: true
-    support_personal: true
 --- config
     location /t {
         content_by_lua_block {
@@ -210,9 +205,13 @@ plugin_attr:
                 }
             }
 
-            local public_result = plugin.rewrite({}, ctx)
+            local conf = {
+                support_public = true,
+                support_personal = true
+            }
+            local public_result = plugin.rewrite(conf, ctx)
             ctx.var.bk_app_code = "personal"
-            local personal_result = plugin.rewrite({}, ctx)
+            local personal_result = plugin.rewrite(conf, ctx)
 
             ngx.say(public_result == nil and "public: pass" or "public: fail")
             ngx.say(personal_result == nil and "personal: pass" or "personal: fail")
@@ -241,7 +240,10 @@ bk_gateway:
                 }
             }
 
-            local status = plugin.rewrite({}, ctx)
+            local status = plugin.rewrite({
+                support_public = false,
+                support_personal = false
+            }, ctx)
             ngx.status = 200
             ngx.say("status: " .. tostring(status))
         }
@@ -253,10 +255,6 @@ WWW-Authenticate: Bearer .*error="invalid_token".*support_public=false.*support_
 
 === TEST 9: ordinary app code stays unsupported when both flags are enabled
 --- extra_yaml_config
-plugin_attr:
-  bk-oauth2-appcode-validate:
-    support_public: true
-    support_personal: true
 bk_gateway:
   hosts:
     bk-apigateway-api:
@@ -274,7 +272,10 @@ bk_gateway:
                 }
             }
 
-            local status = plugin.rewrite({}, ctx)
+            local status = plugin.rewrite({
+                support_public = true,
+                support_personal = true
+            }, ctx)
             ngx.status = 200
             ngx.say("status: " .. tostring(status))
         }

--- a/src/apisix/t/bk-oauth2-appcode-validate.t
+++ b/src/apisix/t/bk-oauth2-appcode-validate.t
@@ -1,0 +1,285 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: sanity - schema and priority
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ok, err = plugin.check_schema({})
+            if not ok then
+                ngx.say(err)
+                return
+            end
+
+            ngx.say("priority: " .. plugin.priority)
+        }
+    }
+--- response_body
+priority: 17677
+
+=== TEST 2: non-OAuth2 requests are skipped
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    is_bk_oauth2 = false,
+                    bk_app_code = "public"
+                }
+            }
+
+            local result = plugin.rewrite({}, ctx)
+            ngx.say(result == nil and "skipped" or "processed")
+        }
+    }
+--- response_body
+skipped
+
+=== TEST 3: public-only configuration allows public
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: true
+    support_personal: false
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local result = plugin.rewrite({}, ctx)
+            ngx.say(result == nil and "pass" or "fail")
+        }
+    }
+--- response_body
+pass
+
+=== TEST 4: public-only configuration rejects personal
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: true
+    support_personal: false
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "personal"
+                }
+            }
+
+            local status = plugin.rewrite({}, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+            ngx.say("code_name: " .. ctx.var.bk_apigw_error.error.code_name)
+            ngx.say("message: " .. ctx.var.bk_apigw_error.error.message)
+        }
+    }
+--- response_body_like eval
+qr/status: 401\ncode_name: UNAUTHORIZED\nmessage: Unauthorized .*OAuth2 token app code is not allowed.*/
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*bk_app_code=personal.*support_public=true.*support_personal=false"
+
+=== TEST 5: personal-only configuration allows personal
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: false
+    support_personal: true
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "personal"
+                }
+            }
+
+            local result = plugin.rewrite({}, ctx)
+            ngx.say(result == nil and "pass" or "fail")
+        }
+    }
+--- response_body
+pass
+
+=== TEST 6: personal-only configuration rejects public
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: false
+    support_personal: true
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local status = plugin.rewrite({}, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+        }
+    }
+--- response_body
+status: 401
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*support_public=false.*support_personal=true"
+
+=== TEST 7: both-enabled configuration allows both app codes
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: true
+    support_personal: true
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local public_result = plugin.rewrite({}, ctx)
+            ctx.var.bk_app_code = "personal"
+            local personal_result = plugin.rewrite({}, ctx)
+
+            ngx.say(public_result == nil and "public: pass" or "public: fail")
+            ngx.say(personal_result == nil and "personal: pass" or "personal: fail")
+        }
+    }
+--- response_body
+public: pass
+personal: pass
+
+=== TEST 8: default configuration rejects every OAuth2 app code
+--- extra_yaml_config
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local status = plugin.rewrite({}, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+        }
+    }
+--- response_body
+status: 401
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*support_public=false.*support_personal=false"
+
+=== TEST 9: ordinary app code stays unsupported when both flags are enabled
+--- extra_yaml_config
+plugin_attr:
+  bk-oauth2-appcode-validate:
+    support_public: true
+    support_personal: true
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "ordinary-app"
+                }
+            }
+
+            local status = plugin.rewrite({}, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+        }
+    }
+--- response_body
+status: 401
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*bk_app_code=ordinary-app.*support_public=true.*support_personal=true"

--- a/src/apisix/t/bk-oauth2-appcode-validate.t
+++ b/src/apisix/t/bk-oauth2-appcode-validate.t
@@ -115,6 +115,7 @@ bk_gateway:
                 var = {
                     uri = "/api/test",
                     bk_gateway_name = "demo",
+                    bk_resource_name = "test-resource",
                     is_bk_oauth2 = true,
                     bk_app_code = "personal"
                 }
@@ -128,10 +129,18 @@ bk_gateway:
             ngx.say("status: " .. tostring(status))
             ngx.say("code_name: " .. ctx.var.bk_apigw_error.error.code_name)
             ngx.say("message: " .. ctx.var.bk_apigw_error.error.message)
+            ngx.say(
+                "has_gateway: " ..
+                tostring(string.find(ctx.var.bk_apigw_error.error.message, 'gateway="demo"', 1, true) ~= nil)
+            )
+            ngx.say(
+                "has_resource: " ..
+                tostring(string.find(ctx.var.bk_apigw_error.error.message, 'resource="test-resource"', 1, true) ~= nil)
+            )
         }
     }
 --- response_body_like eval
-qr/status: 401\ncode_name: UNAUTHORIZED\nmessage: Unauthorized .*OAuth2 token app code is not allowed.*/
+qr/status: 401\ncode_name: UNAUTHORIZED\nmessage: Unauthorized .*OAuth2 token app code is not allowed.*\nhas_gateway: true\nhas_resource: true/
 --- response_headers_like
 WWW-Authenticate: Bearer .*error="invalid_token".*bk_app_code=personal.*support_public=true.*support_personal=false"
 

--- a/src/apisix/t/bk-oauth2-appcode-validate.t
+++ b/src/apisix/t/bk-oauth2-appcode-validate.t
@@ -53,7 +53,7 @@ __DATA__
         }
     }
 --- response_body
-priority: 17677
+priority: 17678
 
 === TEST 2: non-OAuth2 requests are skipped
 --- config

--- a/src/apisix/t/bk-oauth2-audience-validate.t
+++ b/src/apisix/t/bk-oauth2-audience-validate.t
@@ -203,7 +203,7 @@ pass
     location /t {
         content_by_lua_block {
             local plugin = require("apisix.plugins.bk-oauth2-audience-validate")
-            if plugin.priority == 17678 then
+            if plugin.priority == 17677 then
                 ngx.say("pass")
             else
                 ngx.say("fail: " .. tostring(plugin.priority))

--- a/src/apisix/tests/test-bk-oauth2-appcode-validate.lua
+++ b/src/apisix/tests/test-bk-oauth2-appcode-validate.lua
@@ -17,6 +17,7 @@
 --
 local core = require("apisix.core")
 local bk_core = require("apisix.plugins.bk-core.init")
+local audience_plugin = require("apisix.plugins.bk-oauth2-audience-validate")
 local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
 
 describe(
@@ -81,6 +82,12 @@ describe(
                             },
                             plugin.schema.properties.support_personal
                         )
+                    end
+                )
+
+                it(
+                    "runs before audience validation so invalid_token takes precedence", function()
+                        assert.is_true(plugin.priority > audience_plugin.priority)
                     end
                 )
 

--- a/src/apisix/tests/test-bk-oauth2-appcode-validate.lua
+++ b/src/apisix/tests/test-bk-oauth2-appcode-validate.lua
@@ -29,6 +29,7 @@ describe(
                     var = {
                         uri = "/api/test",
                         bk_gateway_name = "demo",
+                        bk_resource_name = "test-resource",
                         is_bk_oauth2 = true,
                         bk_app_code = "public",
                     },
@@ -132,6 +133,12 @@ describe(
                         local result = plugin.rewrite(check_conf({}), ctx)
 
                         assert.is_nil(result)
+                        assert.stub(core.log.info).was_called_with(
+                            "bk-oauth2-appcode-validate: skipping",
+                            ", is_bk_oauth2=", false,
+                            ", gateway=", "demo",
+                            ", resource=", "test-resource"
+                        )
                     end
                 )
 
@@ -155,10 +162,20 @@ describe(
 
                         assert.is_nil(result)
                         assert.stub(core.log.info).was_called_with(
+                            "bk-oauth2-appcode-validate: checking",
+                            ", bk_app_code=", "public",
+                            ", support_public=", true,
+                            ", support_personal=", false,
+                            ", gateway=", "demo",
+                            ", resource=", "test-resource"
+                        )
+                        assert.stub(core.log.info).was_called_with(
                             "bk-oauth2-appcode-validate: validation passed",
                             ", bk_app_code=", "public",
                             ", support_public=", true,
-                            ", support_personal=", false
+                            ", support_personal=", false,
+                            ", gateway=", "demo",
+                            ", resource=", "test-resource"
                         )
                     end
                 )
@@ -243,6 +260,8 @@ describe(
                         assert.is_truthy(string.find(message, 'bk_app_code="public"', 1, true))
                         assert.is_truthy(string.find(message, 'support_public="false"', 1, true))
                         assert.is_truthy(string.find(message, 'support_personal="true"', 1, true))
+                        assert.is_truthy(string.find(message, 'gateway="demo"', 1, true))
+                        assert.is_truthy(string.find(message, 'resource="test-resource"', 1, true))
                         assert.is_truthy(string.find(www_auth, 'error="invalid_token"', 1, true))
                         assert.is_truthy(string.find(www_auth, "bk_app_code=public", 1, true))
                         assert.is_truthy(string.find(www_auth, "support_public=false", 1, true))
@@ -251,7 +270,9 @@ describe(
                             "bk-oauth2-appcode-validate: validation failed",
                             ", bk_app_code=", "public",
                             ", support_public=", false,
-                            ", support_personal=", true
+                            ", support_personal=", true,
+                            ", gateway=", "demo",
+                            ", resource=", "test-resource"
                         )
                     end
                 )

--- a/src/apisix/tests/test-bk-oauth2-appcode-validate.lua
+++ b/src/apisix/tests/test-bk-oauth2-appcode-validate.lua
@@ -1,0 +1,362 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+local core = require("apisix.core")
+local apisix_plugin = require("apisix.plugin")
+local bk_core = require("apisix.plugins.bk-core.init")
+local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+
+describe(
+    "bk-oauth2-appcode-validate", function()
+        local plugin_attr
+        local ctx
+
+        before_each(
+            function()
+                plugin_attr = {}
+                ctx = {
+                    var = {
+                        uri = "/api/test",
+                        bk_gateway_name = "demo",
+                        is_bk_oauth2 = true,
+                        bk_app_code = "public",
+                    },
+                }
+
+                stub(
+                    apisix_plugin, "plugin_attr", function(name)
+                        assert.is_equal("bk-oauth2-appcode-validate", name)
+                        return plugin_attr
+                    end
+                )
+                stub(
+                    bk_core.config, "get_bk_apigateway_api_tmpl", function()
+                        return "https://{api_name}.example.com"
+                    end
+                )
+                stub(core.log, "info")
+                stub(core.log, "error")
+
+                plugin.init()
+            end
+        )
+
+        after_each(
+            function()
+                apisix_plugin.plugin_attr:revert()
+                bk_core.config.get_bk_apigateway_api_tmpl:revert()
+                core.log.info:revert()
+                core.log.error:revert()
+                ngx.header["WWW-Authenticate"] = nil
+            end
+        )
+
+        context(
+            "schema", function()
+                it(
+                    "accepts empty route configuration", function()
+                        local ok, err = plugin.check_schema({})
+
+                        assert.is_true(ok)
+                        assert.is_nil(err)
+                    end
+                )
+
+                it(
+                    "accepts boolean plugin attributes", function()
+                        local ok, err = core.schema.check(
+                            plugin.attr_schema,
+                            {
+                                support_public = true,
+                                support_personal = false,
+                            }
+                        )
+
+                        assert.is_true(ok)
+                        assert.is_nil(err)
+                    end
+                )
+
+                it(
+                    "rejects non-boolean plugin attributes", function()
+                        local ok = core.schema.check(
+                            plugin.attr_schema,
+                            {
+                                support_public = "true",
+                            }
+                        )
+
+                        assert.is_false(ok)
+                    end
+                )
+            end
+        )
+
+        context(
+            "initialization", function()
+                it(
+                    "defaults to an empty allowlist", function()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_false(state.support_public)
+                        assert.is_false(state.support_personal)
+                        assert.is_nil(state.allowed_app_codes.public)
+                        assert.is_nil(state.allowed_app_codes.personal)
+                    end
+                )
+
+                it(
+                    "allows public when configured", function()
+                        plugin_attr = {
+                            support_public = true,
+                        }
+
+                        plugin.init()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_true(state.support_public)
+                        assert.is_false(state.support_personal)
+                        assert.is_true(state.allowed_app_codes.public)
+                        assert.is_nil(state.allowed_app_codes.personal)
+                    end
+                )
+
+                it(
+                    "allows personal when configured", function()
+                        plugin_attr = {
+                            support_personal = true,
+                        }
+
+                        plugin.init()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_false(state.support_public)
+                        assert.is_true(state.support_personal)
+                        assert.is_nil(state.allowed_app_codes.public)
+                        assert.is_true(state.allowed_app_codes.personal)
+                    end
+                )
+
+                it(
+                    "allows both supported app codes", function()
+                        plugin_attr = {
+                            support_public = true,
+                            support_personal = true,
+                        }
+
+                        plugin.init()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_true(state.allowed_app_codes.public)
+                        assert.is_true(state.allowed_app_codes.personal)
+                    end
+                )
+
+                it(
+                    "logs the effective initialization state", function()
+                        plugin_attr = {
+                            support_public = true,
+                        }
+
+                        plugin.init()
+
+                        assert.stub(core.log.info).was_called_with(
+                            "bk-oauth2-appcode-validate: initialized",
+                            ", support_public=", true,
+                            ", support_personal=", false,
+                            ", allowed_app_codes=", '{"public":true}'
+                        )
+                    end
+                )
+
+                it(
+                    "fails closed for invalid plugin attributes", function()
+                        plugin_attr = {
+                            support_public = "true",
+                        }
+
+                        plugin.init()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_false(state.support_public)
+                        assert.is_false(state.support_personal)
+                        assert.is_nil(state.allowed_app_codes.public)
+                        assert.is_nil(state.allowed_app_codes.personal)
+                        assert.stub(core.log.error).was_called()
+                    end
+                )
+
+                it(
+                    "does not retain stale allowlist entries after reinitialization", function()
+                        plugin_attr = {
+                            support_public = true,
+                        }
+                        plugin.init()
+
+                        plugin_attr = {
+                            support_personal = true,
+                        }
+                        plugin.init()
+                        local state = plugin._get_validation_state()
+
+                        assert.is_nil(state.allowed_app_codes.public)
+                        assert.is_true(state.allowed_app_codes.personal)
+                    end
+                )
+            end
+        )
+
+        context(
+            "rewrite", function()
+                it(
+                    "skips when is_bk_oauth2 is false", function()
+                        ctx.var.is_bk_oauth2 = false
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                    end
+                )
+
+                it(
+                    "skips when is_bk_oauth2 is absent", function()
+                        ctx.var.is_bk_oauth2 = nil
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                    end
+                )
+
+                it(
+                    "allows public when public support is enabled", function()
+                        plugin_attr = {
+                            support_public = true,
+                        }
+                        plugin.init()
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                        assert.stub(core.log.info).was_called_with(
+                            "bk-oauth2-appcode-validate: validation passed",
+                            ", bk_app_code=", "public",
+                            ", support_public=", true,
+                            ", support_personal=", false
+                        )
+                    end
+                )
+
+                it(
+                    "allows personal when personal support is enabled", function()
+                        plugin_attr = {
+                            support_personal = true,
+                        }
+                        plugin.init()
+                        ctx.var.bk_app_code = "personal"
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                    end
+                )
+
+                it(
+                    "rejects a disabled supported app code", function()
+                        local status = plugin.rewrite({}, ctx)
+
+                        assert.is_equal(401, status)
+                        assert.is_equal(
+                            "UNAUTHORIZED",
+                            ctx.var.bk_apigw_error.error.code_name
+                        )
+                    end
+                )
+
+                it(
+                    "rejects an ordinary app code even when both flags are enabled", function()
+                        plugin_attr = {
+                            support_public = true,
+                            support_personal = true,
+                        }
+                        plugin.init()
+                        ctx.var.bk_app_code = "ordinary-app"
+
+                        local status = plugin.rewrite({}, ctx)
+
+                        assert.is_equal(401, status)
+                    end
+                )
+
+                it(
+                    "rejects a missing app code", function()
+                        ctx.var.bk_app_code = nil
+
+                        local status = plugin.rewrite({}, ctx)
+
+                        assert.is_equal(401, status)
+                    end
+                )
+
+                it(
+                    "rejects an empty app code", function()
+                        ctx.var.bk_app_code = ""
+
+                        local status = plugin.rewrite({}, ctx)
+
+                        assert.is_equal(401, status)
+                    end
+                )
+
+                it(
+                    "returns rich invalid_token details", function()
+                        plugin_attr = {
+                            support_personal = true,
+                        }
+                        plugin.init()
+                        ctx.var.bk_app_code = "public"
+
+                        local status = plugin.rewrite({}, ctx)
+                        local message = ctx.var.bk_apigw_error.error.message
+                        local www_auth = ngx.header["WWW-Authenticate"]
+
+                        assert.is_equal(401, status)
+                        assert.is_truthy(string.find(
+                            message,
+                            'reason="OAuth2 token app code is not allowed"',
+                            1,
+                            true
+                        ))
+                        assert.is_truthy(string.find(message, 'bk_app_code="public"', 1, true))
+                        assert.is_truthy(string.find(message, 'support_public="false"', 1, true))
+                        assert.is_truthy(string.find(message, 'support_personal="true"', 1, true))
+                        assert.is_truthy(string.find(www_auth, 'error="invalid_token"', 1, true))
+                        assert.is_truthy(string.find(www_auth, "bk_app_code=public", 1, true))
+                        assert.is_truthy(string.find(www_auth, "support_public=false", 1, true))
+                        assert.is_truthy(string.find(www_auth, "support_personal=true", 1, true))
+                        assert.stub(core.log.info).was_called_with(
+                            "bk-oauth2-appcode-validate: validation failed",
+                            ", bk_app_code=", "public",
+                            ", support_public=", false,
+                            ", support_personal=", true
+                        )
+                    end
+                )
+            end
+        )
+    end
+)

--- a/src/apisix/tests/test-bk-oauth2-appcode-validate.lua
+++ b/src/apisix/tests/test-bk-oauth2-appcode-validate.lua
@@ -16,18 +16,15 @@
 -- to the current version of the project delivered to anyone in the future.
 --
 local core = require("apisix.core")
-local apisix_plugin = require("apisix.plugin")
 local bk_core = require("apisix.plugins.bk-core.init")
 local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
 
 describe(
     "bk-oauth2-appcode-validate", function()
-        local plugin_attr
         local ctx
 
         before_each(
             function()
-                plugin_attr = {}
                 ctx = {
                     var = {
                         uri = "/api/test",
@@ -38,26 +35,17 @@ describe(
                 }
 
                 stub(
-                    apisix_plugin, "plugin_attr", function(name)
-                        assert.is_equal("bk-oauth2-appcode-validate", name)
-                        return plugin_attr
-                    end
-                )
-                stub(
                     bk_core.config, "get_bk_apigateway_api_tmpl", function()
                         return "https://{api_name}.example.com"
                     end
                 )
                 stub(core.log, "info")
                 stub(core.log, "error")
-
-                plugin.init()
             end
         )
 
         after_each(
             function()
-                apisix_plugin.plugin_attr:revert()
                 bk_core.config.get_bk_apigateway_api_tmpl:revert()
                 core.log.info:revert()
                 core.log.error:revert()
@@ -65,21 +53,51 @@ describe(
             end
         )
 
+        local function check_conf(conf)
+            local ok, err = plugin.check_schema(conf)
+            assert.is_true(ok)
+            assert.is_nil(err)
+            return conf
+        end
+
         context(
             "schema", function()
                 it(
-                    "accepts empty route configuration", function()
-                        local ok, err = plugin.check_schema({})
-
-                        assert.is_true(ok)
-                        assert.is_nil(err)
+                    "defines support flags on the route schema", function()
+                        assert.is_nil(plugin.attr_schema)
+                        assert.is_nil(plugin.init)
+                        assert.is_same(
+                            {
+                                type = "boolean",
+                                default = false,
+                            },
+                            plugin.schema.properties.support_public
+                        )
+                        assert.is_same(
+                            {
+                                type = "boolean",
+                                default = false,
+                            },
+                            plugin.schema.properties.support_personal
+                        )
                     end
                 )
 
                 it(
-                    "accepts boolean plugin attributes", function()
-                        local ok, err = core.schema.check(
-                            plugin.attr_schema,
+                    "applies false defaults to empty route configuration", function()
+                        local conf = {}
+                        local ok, err = plugin.check_schema(conf)
+
+                        assert.is_true(ok)
+                        assert.is_nil(err)
+                        assert.is_false(conf.support_public)
+                        assert.is_false(conf.support_personal)
+                    end
+                )
+
+                it(
+                    "accepts boolean route configuration", function()
+                        local ok, err = plugin.check_schema(
                             {
                                 support_public = true,
                                 support_personal = false,
@@ -92,9 +110,8 @@ describe(
                 )
 
                 it(
-                    "rejects non-boolean plugin attributes", function()
-                        local ok = core.schema.check(
-                            plugin.attr_schema,
+                    "rejects non-boolean route configuration", function()
+                        local ok = plugin.check_schema(
                             {
                                 support_public = "true",
                             }
@@ -107,126 +124,12 @@ describe(
         )
 
         context(
-            "initialization", function()
-                it(
-                    "defaults to an empty allowlist", function()
-                        local state = plugin._get_validation_state()
-
-                        assert.is_false(state.support_public)
-                        assert.is_false(state.support_personal)
-                        assert.is_nil(state.allowed_app_codes.public)
-                        assert.is_nil(state.allowed_app_codes.personal)
-                    end
-                )
-
-                it(
-                    "allows public when configured", function()
-                        plugin_attr = {
-                            support_public = true,
-                        }
-
-                        plugin.init()
-                        local state = plugin._get_validation_state()
-
-                        assert.is_true(state.support_public)
-                        assert.is_false(state.support_personal)
-                        assert.is_true(state.allowed_app_codes.public)
-                        assert.is_nil(state.allowed_app_codes.personal)
-                    end
-                )
-
-                it(
-                    "allows personal when configured", function()
-                        plugin_attr = {
-                            support_personal = true,
-                        }
-
-                        plugin.init()
-                        local state = plugin._get_validation_state()
-
-                        assert.is_false(state.support_public)
-                        assert.is_true(state.support_personal)
-                        assert.is_nil(state.allowed_app_codes.public)
-                        assert.is_true(state.allowed_app_codes.personal)
-                    end
-                )
-
-                it(
-                    "allows both supported app codes", function()
-                        plugin_attr = {
-                            support_public = true,
-                            support_personal = true,
-                        }
-
-                        plugin.init()
-                        local state = plugin._get_validation_state()
-
-                        assert.is_true(state.allowed_app_codes.public)
-                        assert.is_true(state.allowed_app_codes.personal)
-                    end
-                )
-
-                it(
-                    "logs the effective initialization state", function()
-                        plugin_attr = {
-                            support_public = true,
-                        }
-
-                        plugin.init()
-
-                        assert.stub(core.log.info).was_called_with(
-                            "bk-oauth2-appcode-validate: initialized",
-                            ", support_public=", true,
-                            ", support_personal=", false,
-                            ", allowed_app_codes=", '{"public":true}'
-                        )
-                    end
-                )
-
-                it(
-                    "fails closed for invalid plugin attributes", function()
-                        plugin_attr = {
-                            support_public = "true",
-                        }
-
-                        plugin.init()
-                        local state = plugin._get_validation_state()
-
-                        assert.is_false(state.support_public)
-                        assert.is_false(state.support_personal)
-                        assert.is_nil(state.allowed_app_codes.public)
-                        assert.is_nil(state.allowed_app_codes.personal)
-                        assert.stub(core.log.error).was_called()
-                    end
-                )
-
-                it(
-                    "does not retain stale allowlist entries after reinitialization", function()
-                        plugin_attr = {
-                            support_public = true,
-                        }
-                        plugin.init()
-
-                        plugin_attr = {
-                            support_personal = true,
-                        }
-                        plugin.init()
-                        local state = plugin._get_validation_state()
-
-                        assert.is_nil(state.allowed_app_codes.public)
-                        assert.is_true(state.allowed_app_codes.personal)
-                    end
-                )
-            end
-        )
-
-        context(
             "rewrite", function()
                 it(
                     "skips when is_bk_oauth2 is false", function()
                         ctx.var.is_bk_oauth2 = false
 
-                        local result = plugin.rewrite({}, ctx)
+                        local result = plugin.rewrite(check_conf({}), ctx)
 
                         assert.is_nil(result)
                     end
@@ -236,7 +139,7 @@ describe(
                     "skips when is_bk_oauth2 is absent", function()
                         ctx.var.is_bk_oauth2 = nil
 
-                        local result = plugin.rewrite({}, ctx)
+                        local result = plugin.rewrite(check_conf({}), ctx)
 
                         assert.is_nil(result)
                     end
@@ -244,12 +147,11 @@ describe(
 
                 it(
                     "allows public when public support is enabled", function()
-                        plugin_attr = {
+                        local conf = check_conf({
                             support_public = true,
-                        }
-                        plugin.init()
+                        })
 
-                        local result = plugin.rewrite({}, ctx)
+                        local result = plugin.rewrite(conf, ctx)
 
                         assert.is_nil(result)
                         assert.stub(core.log.info).was_called_with(
@@ -263,13 +165,12 @@ describe(
 
                 it(
                     "allows personal when personal support is enabled", function()
-                        plugin_attr = {
+                        local conf = check_conf({
                             support_personal = true,
-                        }
-                        plugin.init()
+                        })
                         ctx.var.bk_app_code = "personal"
 
-                        local result = plugin.rewrite({}, ctx)
+                        local result = plugin.rewrite(conf, ctx)
 
                         assert.is_nil(result)
                     end
@@ -277,7 +178,7 @@ describe(
 
                 it(
                     "rejects a disabled supported app code", function()
-                        local status = plugin.rewrite({}, ctx)
+                        local status = plugin.rewrite(check_conf({}), ctx)
 
                         assert.is_equal(401, status)
                         assert.is_equal(
@@ -289,14 +190,13 @@ describe(
 
                 it(
                     "rejects an ordinary app code even when both flags are enabled", function()
-                        plugin_attr = {
+                        local conf = check_conf({
                             support_public = true,
                             support_personal = true,
-                        }
-                        plugin.init()
+                        })
                         ctx.var.bk_app_code = "ordinary-app"
 
-                        local status = plugin.rewrite({}, ctx)
+                        local status = plugin.rewrite(conf, ctx)
 
                         assert.is_equal(401, status)
                     end
@@ -306,7 +206,7 @@ describe(
                     "rejects a missing app code", function()
                         ctx.var.bk_app_code = nil
 
-                        local status = plugin.rewrite({}, ctx)
+                        local status = plugin.rewrite(check_conf({}), ctx)
 
                         assert.is_equal(401, status)
                     end
@@ -316,7 +216,7 @@ describe(
                     "rejects an empty app code", function()
                         ctx.var.bk_app_code = ""
 
-                        local status = plugin.rewrite({}, ctx)
+                        local status = plugin.rewrite(check_conf({}), ctx)
 
                         assert.is_equal(401, status)
                     end
@@ -324,13 +224,12 @@ describe(
 
                 it(
                     "returns rich invalid_token details", function()
-                        plugin_attr = {
+                        local conf = check_conf({
                             support_personal = true,
-                        }
-                        plugin.init()
+                        })
                         ctx.var.bk_app_code = "public"
 
-                        local status = plugin.rewrite({}, ctx)
+                        local status = plugin.rewrite(conf, ctx)
                         local message = ctx.var.bk_apigw_error.error.message
                         local www_auth = ngx.header["WWW-Authenticate"]
 


### PR DESCRIPTION
## Summary

- add `bk-oauth2-appcode-validate` on top of `release/1.23` without changing the APISIX runtime, submodule, build, or test images
- expose `support_public` and `support_personal` as route-level plugin schema fields, both defaulting to `false`
- validate `public` and `personal` token app codes against the current route configuration
- run app code validation before audience validation so 401 `invalid_token` takes precedence over 403
- include gateway and resource context in all validation logs and caller-visible errors
- fail closed and return a rich 401 `invalid_token` response when an OAuth2 token app code is unsupported
- add Busted and test-nginx coverage for route schema, allow/deny behavior, logs, and caller-visible errors

## Verification

- appcode Busted: 14 cases covered by the full suite
- focused test-nginx: 34 tests, `Result: PASS`
- `RUN_WITH_IT= make lint`: 92 files, 0 warnings, 0 errors
- `RUN_WITH_IT= make test`: Busted 766 successes; test-nginx 30 files / 712 tests, `Result: PASS`
- both new Lua files contain the TencentBlueKing license header
- repository-wide `make check-license` remains blocked by the pre-existing `src/apisix/tests/test-bk-traffic-label.lua` missing header on `upstream/release/1.23`
