### PR TITLE
feat(oauth2): forward-port audience and app code validation to master

### DIFF
--- a/src/apisix/plugins/README.md
+++ b/src/apisix/plugins/README.md
@@ -51,7 +51,8 @@
 - bk-request-body-limit                     # priority: 17690
 - bk-auth-validate                          # priority: 17680
 - bk-user-restriction                       # priority: 17679
-- bk-oauth2-audience-validate               # priority: 17678  # OAuth2 audience 验证：验证 MCP 服务器和网关 API 的 audience 声明
+- bk-oauth2-appcode-validate                # priority: 17678  # OAuth2 app code 验证：按路由配置允许 public 和 personal 客户端
+- bk-oauth2-audience-validate               # priority: 17677  # OAuth2 audience 验证：验证 MCP 服务器和网关 API 的 audience 声明
 - bk-tenant-validate-exempt                 # priority: 17676  # 如果资源配置了此插件, 则跳过 bk-tenant-validate 校验
 - bk-tenant-verify                          # priority: 17675
 - bk-tenant-validate                        # priority: 17674

--- a/src/apisix/plugins/bk-oauth2-appcode-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-appcode-validate.lua
@@ -1,0 +1,123 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+-- # bk-oauth2-appcode-validate
+--
+-- Validate whether an OAuth2 token's application code is enabled by route configuration.
+--
+-- This plugin only runs when ctx.var.is_bk_oauth2 == true.
+--
+-- This plugin depends on:
+--     * bk-oauth2-verify: To set ctx.var.bk_app_code
+--
+local core = require("apisix.core")
+local errorx = require("apisix.plugins.bk-core.errorx")
+local oauth2 = require("apisix.plugins.bk-core.oauth2")
+local ngx = ngx
+local tostring = tostring
+
+local plugin_name = "bk-oauth2-appcode-validate"
+
+local schema = {
+    type = "object",
+    properties = {
+        support_public = {
+            type = "boolean",
+            default = false,
+        },
+        support_personal = {
+            type = "boolean",
+            default = false,
+        },
+    },
+}
+
+local _M = {
+    version = 0.1,
+    priority = 17678,
+    name = plugin_name,
+    schema = schema,
+}
+
+
+function _M.check_schema(conf)
+    return core.schema.check(schema, conf)
+end
+
+
+local function log_validation(phase, app_code, conf, ctx)
+    core.log.info(
+        plugin_name .. ": " .. phase,
+        ", bk_app_code=", app_code,
+        ", support_public=", conf.support_public,
+        ", support_personal=", conf.support_personal,
+        ", gateway=", ctx.var.bk_gateway_name,
+        ", resource=", ctx.var.bk_resource_name
+    )
+end
+
+
+function _M.rewrite(conf, ctx) -- luacheck: no unused
+    if ctx.var.is_bk_oauth2 ~= true then
+        core.log.info(
+            plugin_name .. ": skipping",
+            ", is_bk_oauth2=", ctx.var.is_bk_oauth2,
+            ", gateway=", ctx.var.bk_gateway_name,
+            ", resource=", ctx.var.bk_resource_name
+        )
+        return
+    end
+
+    local app_code = ctx.var.bk_app_code or ""
+
+    log_validation("checking", app_code, conf, ctx)
+
+    if app_code == "public" and conf.support_public then
+        log_validation("validation passed", app_code, conf, ctx)
+        return
+    end
+
+    if app_code == "personal" and conf.support_personal then
+        log_validation("validation passed", app_code, conf, ctx)
+        return
+    end
+
+    log_validation("validation failed", app_code, conf, ctx)
+
+    local err = errorx.new_general_unauthorized():with_fields(
+        {
+            reason = "OAuth2 token app code is not allowed",
+            bk_app_code = app_code,
+            support_public = conf.support_public,
+            support_personal = conf.support_personal,
+            gateway = ctx.var.bk_gateway_name or "",
+            resource = ctx.var.bk_resource_name or "",
+        }
+    )
+
+    ngx.header["WWW-Authenticate"] = oauth2.build_www_authenticate_header(
+        ctx,
+        "invalid_token",
+        "OAuth2 token app code is not allowed: bk_app_code=" .. app_code ..
+            ", support_public=" .. tostring(conf.support_public) ..
+            ", support_personal=" .. tostring(conf.support_personal)
+    )
+    return errorx.exit_with_apigw_err(ctx, err, _M)
+end
+
+
+return _M

--- a/src/apisix/plugins/bk-oauth2-audience-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-audience-validate.lua
@@ -22,8 +22,10 @@
 --
 -- Audience formats supported:
 --   - mcp:{mcp_server_name} - Access to specific MCP server
+--   - mcp:* - Access to any MCP server
 --   - gateway:{gateway_name}/api:{api_name} - Access to specific gateway API
 --   - gateway:{gateway_name}/api:* - Access to all APIs under a gateway (wildcard)
+--   - gateway:* - Access to all APIs under any gateway
 --
 -- This plugin only runs when ctx.var.is_bk_oauth2 == true (set by bk-oauth2-protected-resource).
 --
@@ -79,6 +81,15 @@ local function parse_audience(audience_str)
         }
     end
 
+    -- Normalize gateway:* to gateway:*/api:*
+    if audience_str == "gateway:*" then
+        return {
+            type = "gateway_api",
+            gateway = "*",
+            api = "*",
+        }
+    end
+
     -- Try gateway:{gateway}/api:{api} format
     local gateway, api = string_match(audience_str, "^gateway:([^/]+)/api:(.+)$")
     if gateway and api then
@@ -130,7 +141,7 @@ local function check_mcp_server_audience(parsed, ctx)
     end
 
     -- Check if the MCP server from path matches the audience
-    if path_mcp_server == parsed.name then
+    if parsed.name == "*" or path_mcp_server == parsed.name then
         return true, ""
     end
 
@@ -146,6 +157,16 @@ end
 local function check_gateway_api_audience(parsed, ctx)
     local current_gateway = ctx.var.bk_gateway_name
     local current_resource = ctx.var.bk_resource_name
+
+    -- Only gateway:* should produce a wildcard gateway, normalized with a wildcard API.
+    if parsed.gateway == "*" then
+        if parsed.api == "*" then
+            return true, ""
+        end
+
+
+        return false, "invalid parsed audience: wildcard gateway requires wildcard api"
+    end
 
     -- Check gateway matches
     if parsed.gateway ~= current_gateway then

--- a/src/apisix/plugins/bk-oauth2-audience-validate.lua
+++ b/src/apisix/plugins/bk-oauth2-audience-validate.lua
@@ -53,7 +53,7 @@ local schema = {
 
 local _M = {
     version = 0.1,
-    priority = 17678,
+    priority = 17677,
     name = plugin_name,
     schema = schema,
 }

--- a/src/apisix/t/bk-oauth2-appcode-validate.t
+++ b/src/apisix/t/bk-oauth2-appcode-validate.t
@@ -1,0 +1,295 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: sanity - schema and priority
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ok, err = plugin.check_schema({
+                support_public = true,
+                support_personal = false
+            })
+            if not ok then
+                ngx.say(err)
+                return
+            end
+
+            ngx.say("priority: " .. plugin.priority)
+        }
+    }
+--- response_body
+priority: 17678
+
+=== TEST 2: non-OAuth2 requests are skipped
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    is_bk_oauth2 = false,
+                    bk_app_code = "public"
+                }
+            }
+
+            local result = plugin.rewrite({
+                support_public = false,
+                support_personal = false
+            }, ctx)
+            ngx.say(result == nil and "skipped" or "processed")
+        }
+    }
+--- response_body
+skipped
+
+=== TEST 3: public-only configuration allows public
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local result = plugin.rewrite({
+                support_public = true,
+                support_personal = false
+            }, ctx)
+            ngx.say(result == nil and "pass" or "fail")
+        }
+    }
+--- response_body
+pass
+
+=== TEST 4: public-only configuration rejects personal
+--- extra_yaml_config
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    bk_resource_name = "test-resource",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "personal"
+                }
+            }
+
+            local status = plugin.rewrite({
+                support_public = true,
+                support_personal = false
+            }, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+            ngx.say("code_name: " .. ctx.var.bk_apigw_error.error.code_name)
+            ngx.say("message: " .. ctx.var.bk_apigw_error.error.message)
+            ngx.say(
+                "has_gateway: " ..
+                tostring(string.find(ctx.var.bk_apigw_error.error.message, 'gateway="demo"', 1, true) ~= nil)
+            )
+            ngx.say(
+                "has_resource: " ..
+                tostring(string.find(ctx.var.bk_apigw_error.error.message, 'resource="test-resource"', 1, true) ~= nil)
+            )
+        }
+    }
+--- response_body_like eval
+qr/status: 401\ncode_name: UNAUTHORIZED\nmessage: Unauthorized .*OAuth2 token app code is not allowed.*\nhas_gateway: true\nhas_resource: true/
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*bk_app_code=personal.*support_public=true.*support_personal=false"
+
+=== TEST 5: personal-only configuration allows personal
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "personal"
+                }
+            }
+
+            local result = plugin.rewrite({
+                support_public = false,
+                support_personal = true
+            }, ctx)
+            ngx.say(result == nil and "pass" or "fail")
+        }
+    }
+--- response_body
+pass
+
+=== TEST 6: personal-only configuration rejects public
+--- extra_yaml_config
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local status = plugin.rewrite({
+                support_public = false,
+                support_personal = true
+            }, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+        }
+    }
+--- response_body
+status: 401
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*support_public=false.*support_personal=true"
+
+=== TEST 7: both-enabled configuration allows both app codes
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local conf = {
+                support_public = true,
+                support_personal = true
+            }
+            local public_result = plugin.rewrite(conf, ctx)
+            ctx.var.bk_app_code = "personal"
+            local personal_result = plugin.rewrite(conf, ctx)
+
+            ngx.say(public_result == nil and "public: pass" or "public: fail")
+            ngx.say(personal_result == nil and "personal: pass" or "personal: fail")
+        }
+    }
+--- response_body
+public: pass
+personal: pass
+
+=== TEST 8: default configuration rejects every OAuth2 app code
+--- extra_yaml_config
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "public"
+                }
+            }
+
+            local status = plugin.rewrite({
+                support_public = false,
+                support_personal = false
+            }, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+        }
+    }
+--- response_body
+status: 401
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*support_public=false.*support_personal=false"
+
+=== TEST 9: ordinary app code stays unsupported when both flags are enabled
+--- extra_yaml_config
+bk_gateway:
+  hosts:
+    bk-apigateway-api:
+      tmpl: "http://{api_name}.bkapi.example.com"
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+            local ctx = {
+                var = {
+                    uri = "/api/test",
+                    bk_gateway_name = "demo",
+                    is_bk_oauth2 = true,
+                    bk_app_code = "ordinary-app"
+                }
+            }
+
+            local status = plugin.rewrite({
+                support_public = true,
+                support_personal = true
+            }, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+        }
+    }
+--- response_body
+status: 401
+--- response_headers_like
+WWW-Authenticate: Bearer .*error="invalid_token".*bk_app_code=ordinary-app.*support_public=true.*support_personal=true"

--- a/src/apisix/t/bk-oauth2-audience-validate.t
+++ b/src/apisix/t/bk-oauth2-audience-validate.t
@@ -203,7 +203,7 @@ pass
     location /t {
         content_by_lua_block {
             local plugin = require("apisix.plugins.bk-oauth2-audience-validate")
-            if plugin.priority == 17678 then
+            if plugin.priority == 17677 then
                 ngx.say("pass")
             else
                 ngx.say("fail: " .. tostring(plugin.priority))

--- a/src/apisix/t/bk-oauth2-audience-validate.t
+++ b/src/apisix/t/bk-oauth2-audience-validate.t
@@ -392,3 +392,76 @@ status: 403
     }
 --- response_body
 status: 403
+
+=== TEST 17: test validation logic - MCP server wildcard match
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-audience-validate")
+            local ctx = {
+                var = {
+                    is_bk_oauth2 = true,
+                    bk_gateway_name = "bk-apigateway",
+                    bk_resource_name = "mcp-resource",
+                    uri = "/api/v2/mcp-servers/any-server/resources",
+                    audience = {"mcp:*"}
+                }
+            }
+
+            local result = plugin.rewrite({}, ctx)
+            if result == nil then
+                ngx.say("pass")
+            else
+                ngx.say("fail")
+            end
+        }
+    }
+--- response_body
+pass
+
+=== TEST 18: test validation logic - gateway wildcard match
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-audience-validate")
+            local ctx = {
+                var = {
+                    is_bk_oauth2 = true,
+                    bk_gateway_name = "any-gateway",
+                    bk_resource_name = "any-api",
+                    audience = {"gateway:*"}
+                }
+            }
+
+            local result = plugin.rewrite({}, ctx)
+            if result == nil then
+                ngx.say("pass")
+            else
+                ngx.say("fail")
+            end
+        }
+    }
+--- response_body
+pass
+
+=== TEST 19: FAIL - wildcard gateway with a specific API returns 403
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.bk-oauth2-audience-validate")
+            local ctx = {
+                var = {
+                    is_bk_oauth2 = true,
+                    bk_gateway_name = "any-gateway",
+                    bk_resource_name = "test-api",
+                    audience = {"gateway:*/api:test-api"}
+                }
+            }
+
+            local status = plugin.rewrite({}, ctx)
+            ngx.status = 200
+            ngx.say("status: " .. tostring(status))
+        }
+    }
+--- response_body
+status: 403

--- a/src/apisix/tests/test-bk-oauth2-appcode-validate.lua
+++ b/src/apisix/tests/test-bk-oauth2-appcode-validate.lua
@@ -1,0 +1,289 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+local core = require("apisix.core")
+local bk_core = require("apisix.plugins.bk-core.init")
+local audience_plugin = require("apisix.plugins.bk-oauth2-audience-validate")
+local plugin = require("apisix.plugins.bk-oauth2-appcode-validate")
+
+describe(
+    "bk-oauth2-appcode-validate", function()
+        local ctx
+
+        before_each(
+            function()
+                ctx = {
+                    var = {
+                        uri = "/api/test",
+                        bk_gateway_name = "demo",
+                        bk_resource_name = "test-resource",
+                        is_bk_oauth2 = true,
+                        bk_app_code = "public",
+                    },
+                }
+
+                stub(
+                    bk_core.config, "get_bk_apigateway_api_tmpl", function()
+                        return "https://{api_name}.example.com"
+                    end
+                )
+                stub(core.log, "info")
+                stub(core.log, "error")
+            end
+        )
+
+        after_each(
+            function()
+                bk_core.config.get_bk_apigateway_api_tmpl:revert()
+                core.log.info:revert()
+                core.log.error:revert()
+                ngx.header["WWW-Authenticate"] = nil
+            end
+        )
+
+        local function check_conf(conf)
+            local ok, err = plugin.check_schema(conf)
+            assert.is_true(ok)
+            assert.is_nil(err)
+            return conf
+        end
+
+        context(
+            "schema", function()
+                it(
+                    "defines support flags on the route schema", function()
+                        assert.is_nil(plugin.attr_schema)
+                        assert.is_nil(plugin.init)
+                        assert.is_same(
+                            {
+                                type = "boolean",
+                                default = false,
+                            },
+                            plugin.schema.properties.support_public
+                        )
+                        assert.is_same(
+                            {
+                                type = "boolean",
+                                default = false,
+                            },
+                            plugin.schema.properties.support_personal
+                        )
+                    end
+                )
+
+                it(
+                    "runs before audience validation so invalid_token takes precedence", function()
+                        assert.is_true(plugin.priority > audience_plugin.priority)
+                    end
+                )
+
+                it(
+                    "applies false defaults to empty route configuration", function()
+                        local conf = {}
+                        local ok, err = plugin.check_schema(conf)
+
+                        assert.is_true(ok)
+                        assert.is_nil(err)
+                        assert.is_false(conf.support_public)
+                        assert.is_false(conf.support_personal)
+                    end
+                )
+
+                it(
+                    "accepts boolean route configuration", function()
+                        local ok, err = plugin.check_schema(
+                            {
+                                support_public = true,
+                                support_personal = false,
+                            }
+                        )
+
+                        assert.is_true(ok)
+                        assert.is_nil(err)
+                    end
+                )
+
+                it(
+                    "rejects non-boolean route configuration", function()
+                        local ok = plugin.check_schema(
+                            {
+                                support_public = "true",
+                            }
+                        )
+
+                        assert.is_false(ok)
+                    end
+                )
+            end
+        )
+
+        context(
+            "rewrite", function()
+                it(
+                    "skips when is_bk_oauth2 is false", function()
+                        ctx.var.is_bk_oauth2 = false
+
+                        local result = plugin.rewrite(check_conf({}), ctx)
+
+                        assert.is_nil(result)
+                        assert.stub(core.log.info).was_called_with(
+                            "bk-oauth2-appcode-validate: skipping",
+                            ", is_bk_oauth2=", false,
+                            ", gateway=", "demo",
+                            ", resource=", "test-resource"
+                        )
+                    end
+                )
+
+                it(
+                    "skips when is_bk_oauth2 is absent", function()
+                        ctx.var.is_bk_oauth2 = nil
+
+                        local result = plugin.rewrite(check_conf({}), ctx)
+
+                        assert.is_nil(result)
+                    end
+                )
+
+                it(
+                    "allows public when public support is enabled", function()
+                        local conf = check_conf({
+                            support_public = true,
+                        })
+
+                        local result = plugin.rewrite(conf, ctx)
+
+                        assert.is_nil(result)
+                        assert.stub(core.log.info).was_called_with(
+                            "bk-oauth2-appcode-validate: checking",
+                            ", bk_app_code=", "public",
+                            ", support_public=", true,
+                            ", support_personal=", false,
+                            ", gateway=", "demo",
+                            ", resource=", "test-resource"
+                        )
+                        assert.stub(core.log.info).was_called_with(
+                            "bk-oauth2-appcode-validate: validation passed",
+                            ", bk_app_code=", "public",
+                            ", support_public=", true,
+                            ", support_personal=", false,
+                            ", gateway=", "demo",
+                            ", resource=", "test-resource"
+                        )
+                    end
+                )
+
+                it(
+                    "allows personal when personal support is enabled", function()
+                        local conf = check_conf({
+                            support_personal = true,
+                        })
+                        ctx.var.bk_app_code = "personal"
+
+                        local result = plugin.rewrite(conf, ctx)
+
+                        assert.is_nil(result)
+                    end
+                )
+
+                it(
+                    "rejects a disabled supported app code", function()
+                        local status = plugin.rewrite(check_conf({}), ctx)
+
+                        assert.is_equal(401, status)
+                        assert.is_equal(
+                            "UNAUTHORIZED",
+                            ctx.var.bk_apigw_error.error.code_name
+                        )
+                    end
+                )
+
+                it(
+                    "rejects an ordinary app code even when both flags are enabled", function()
+                        local conf = check_conf({
+                            support_public = true,
+                            support_personal = true,
+                        })
+                        ctx.var.bk_app_code = "ordinary-app"
+
+                        local status = plugin.rewrite(conf, ctx)
+
+                        assert.is_equal(401, status)
+                    end
+                )
+
+                it(
+                    "rejects a missing app code", function()
+                        ctx.var.bk_app_code = nil
+
+                        local status = plugin.rewrite(check_conf({}), ctx)
+
+                        assert.is_equal(401, status)
+                    end
+                )
+
+                it(
+                    "rejects an empty app code", function()
+                        ctx.var.bk_app_code = ""
+
+                        local status = plugin.rewrite(check_conf({}), ctx)
+
+                        assert.is_equal(401, status)
+                    end
+                )
+
+                it(
+                    "returns rich invalid_token details", function()
+                        local conf = check_conf({
+                            support_personal = true,
+                        })
+                        ctx.var.bk_app_code = "public"
+
+                        local status = plugin.rewrite(conf, ctx)
+                        local message = ctx.var.bk_apigw_error.error.message
+                        local www_auth = ngx.header["WWW-Authenticate"]
+
+                        assert.is_equal(401, status)
+                        assert.is_truthy(string.find(
+                            message,
+                            'reason="OAuth2 token app code is not allowed"',
+                            1,
+                            true
+                        ))
+                        assert.is_truthy(string.find(message, 'bk_app_code="public"', 1, true))
+                        assert.is_truthy(string.find(message, 'support_public="false"', 1, true))
+                        assert.is_truthy(string.find(message, 'support_personal="true"', 1, true))
+                        assert.is_truthy(string.find(message, 'gateway="demo"', 1, true))
+                        assert.is_truthy(string.find(message, 'resource="test-resource"', 1, true))
+                        assert.is_truthy(string.find(www_auth, 'error="invalid_token"', 1, true))
+                        assert.is_truthy(string.find(www_auth, "bk_app_code=public", 1, true))
+                        assert.is_truthy(string.find(www_auth, "support_public=false", 1, true))
+                        assert.is_truthy(string.find(www_auth, "support_personal=true", 1, true))
+                        assert.stub(core.log.info).was_called_with(
+                            "bk-oauth2-appcode-validate: validation failed",
+                            ", bk_app_code=", "public",
+                            ", support_public=", false,
+                            ", support_personal=", true,
+                            ", gateway=", "demo",
+                            ", resource=", "test-resource"
+                        )
+                    end
+                )
+            end
+        )
+    end
+)

--- a/src/apisix/tests/test-bk-oauth2-audience-validate.lua
+++ b/src/apisix/tests/test-bk-oauth2-audience-validate.lua
@@ -107,6 +107,15 @@ describe(
                 )
 
                 it(
+                    "should parse mcp wildcard format", function()
+                        local result = plugin._parse_audience("mcp:*")
+
+                        assert.is_equal("mcp_server", result.type)
+                        assert.is_equal("*", result.name)
+                    end
+                )
+
+                it(
                     "should parse gateway_api format correctly", function()
                         local result = plugin._parse_audience("gateway:demo/api:test-api")
 
@@ -122,6 +131,16 @@ describe(
 
                         assert.is_equal("gateway_api", result.type)
                         assert.is_equal("demo", result.gateway)
+                        assert.is_equal("*", result.api)
+                    end
+                )
+
+                it(
+                    "should normalize gateway wildcard format", function()
+                        local result = plugin._parse_audience("gateway:*")
+
+                        assert.is_equal("gateway_api", result.type)
+                        assert.is_equal("*", result.gateway)
                         assert.is_equal("*", result.api)
                     end
                 )
@@ -188,6 +207,19 @@ describe(
                 )
 
                 it(
+                    "should allow access with wildcard mcp_server", function()
+                        ctx.var.is_bk_oauth2 = true
+                        ctx.var.bk_gateway_name = "bk-apigateway"
+                        ctx.var.uri = "/api/v2/mcp-servers/any-server/resources"
+                        ctx.var.audience = {"mcp:*"}
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                    end
+                )
+
+                it(
                     "should deny access when mcp_server does not match", function()
                         ctx.var.is_bk_oauth2 = true
                         ctx.var.bk_gateway_name = "bk-apigateway"
@@ -240,6 +272,32 @@ describe(
                         local result = plugin.rewrite({}, ctx)
 
                         assert.is_nil(result)
+                    end
+                )
+
+                it(
+                    "should allow access with wildcard gateway", function()
+                        ctx.var.is_bk_oauth2 = true
+                        ctx.var.bk_gateway_name = "any-gateway"
+                        ctx.var.bk_resource_name = "any-api"
+                        ctx.var.audience = {"gateway:*"}
+
+                        local result = plugin.rewrite({}, ctx)
+
+                        assert.is_nil(result)
+                    end
+                )
+
+                it(
+                    "should deny wildcard gateway with a specific api", function()
+                        ctx.var.is_bk_oauth2 = true
+                        ctx.var.bk_gateway_name = "any-gateway"
+                        ctx.var.bk_resource_name = "test-api"
+                        ctx.var.audience = {"gateway:*/api:test-api"}
+
+                        local status = plugin.rewrite({}, ctx)
+
+                        assert.is_equal(403, status)
                     end
                 )
 

--- a/src/apisix/tests/test-bk-traffic-label.lua
+++ b/src/apisix/tests/test-bk-traffic-label.lua
@@ -1,3 +1,21 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+
 local plugin = require("apisix.plugins.bk-traffic-label")
 
 describe(


### PR DESCRIPTION
### Description

Forward-port the release/1.23 OAuth2 changes to master:

- support wildcard OAuth2 audience scopes from #172
- validate supported OAuth2 token app codes from #174
- add the missing standard license header to the existing traffic-label test so the repository license gate passes

Source PRs:

- https://github.com/TencentBlueKing/blueking-apigateway-apisix/pull/172
- https://github.com/TencentBlueKing/blueking-apigateway-apisix/pull/174

Cherry-picked commits:

- 1e2b5a578d8ada57dadd2d68702c0f0489d9ea3c
- 49f60307cf2d0c99a42be4f2a2303c3f998c860c

### Verification

- `make check-license`
- `RUN_WITH_IT= make lint`: 92 files, 0 warnings, 0 errors
- `RUN_WITH_IT= make test`: Busted 771 successes; test-nginx 30 files / 721 tests, PASS
- `git diff --check upstream/master...HEAD`

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [x] 本地开发联调环境验证通过 (local development environment verification passed)
