### PR TITLE
fix(build): avoid sentrylogs daemonization for release/1.23

### DIFF
--- a/src/build/bin/apisix-start.sh
+++ b/src/build/bin/apisix-start.sh
@@ -8,7 +8,7 @@ echo "starting......"
 if [ x"${BK_APIGW_NGINX_ERROR_LOG_SENTRY_DSN}" != x"" ]
 then
     echo "start sentrylogs to ship nginx error log to sentry"
-    SENTRY_DSN="${BK_APIGW_NGINX_ERROR_LOG_SENTRY_DSN}" NGINX_ERROR_PATH="/usr/local/apisix/logs/error.log" sentrylogs --daemonize
+    SENTRY_DSN="${BK_APIGW_NGINX_ERROR_LOG_SENTRY_DSN}" NGINX_ERROR_PATH="/usr/local/apisix/logs/error.log" sentrylogs >/dev/null 2>&1 &
 
     # start a daemon to check sentrylogs, the sentrylogs will only process the `tail` records, so it's safe to restart it
     sh /data/bkgateway/bin/sentrylogs-daemonize.sh &

--- a/src/build/bin/sentrylogs-daemonize.sh
+++ b/src/build/bin/sentrylogs-daemonize.sh
@@ -10,7 +10,7 @@ do
             echo "sentrylogs is running"
         else
             echo "sentrylogs is not running, restarting..."
-            SENTRY_DSN="${BK_APIGW_NGINX_ERROR_LOG_SENTRY_DSN}" NGINX_ERROR_PATH="/usr/local/apisix/logs/error.log" sentrylogs --daemonize
+            SENTRY_DSN="${BK_APIGW_NGINX_ERROR_LOG_SENTRY_DSN}" NGINX_ERROR_PATH="/usr/local/apisix/logs/error.log" sentrylogs >/dev/null 2>&1 &
         fi
     fi
     sleep 60


### PR DESCRIPTION
## Summary
- backport #177 to `release/1.23`
- source PR: https://github.com/TencentBlueKing/blueking-apigateway-apisix/pull/177
- run `sentrylogs` as a shell-managed background process to avoid CPU spinning with very large `RLIMIT_NOFILE` limits

## Cherry-picked commits
- `48d9a3083d47a17c351313178e4af7d631cd1b05` fix(build): avoid sentrylogs daemonization

## Verification
- `bash -n src/build/bin/apisix-start.sh`
- `bash -n src/build/bin/sentrylogs-daemonize.sh`
- `sh -n src/build/bin/apisix-start.sh`
- `RUN_WITH_IT= make lint` (92 files, 0 warnings / 0 errors)
- `RUN_WITH_IT= make test` (771 Busted tests and 721 test-nginx tests passed)