### PR TITLE
fix(auth): reject app_code with whitespace or angle brackets

### DIFF
--- a/src/apisix/plugins/bk-auth-verify/app-account-verifier.lua
+++ b/src/apisix/plugins/bk-auth-verify/app-account-verifier.lua
@@ -47,9 +47,13 @@ function _M.verify_app(self)
     end
 
     if not pl_types.is_empty(self.app_secret) then
-        -- check the length before call bkauth apis
+        -- check the length / characters before call bkauth apis
         if string.len(self.app_code) > 32 then
             return bk_app_define.new_anonymous_app("app code cannot be longer than 32 characters")
+        end
+        -- reject whitespace / <> which make resty-http path invalid (e.g. null tostring, placeholders)
+        if string.find(self.app_code, "[%s<>]", 1) then
+            return bk_app_define.new_anonymous_app("app code contains invalid characters")
         end
         if string.len(self.app_secret) > 128 then
             return bk_app_define.new_anonymous_app("app secret cannot be longer than 128 characters")

--- a/src/apisix/tests/bk-auth-verify/test-app-account-verifier.lua
+++ b/src/apisix/tests/bk-auth-verify/test-app-account-verifier.lua
@@ -100,12 +100,12 @@ describe(
 
                 it(
                     "app_code contains invalid characters", function()
-                        local cases = {
+                        local invalid_cases = {
                             "userdata: NULL",
                             "<bk_app_code>",
                             "<应用code>",
                         }
-                        for _, app_code in ipairs(cases) do
+                        for _, app_code in ipairs(invalid_cases) do
                             local auth_params = auth_params_mod.new({
                                 bk_app_code = app_code,
                                 bk_app_secret = "world",
@@ -119,6 +119,36 @@ describe(
                                 app.valid_error_message,
                                 "app code contains invalid characters"
                             )
+                        end
+
+                        -- normal gateway / app codes must pass the character check
+                        local valid_cases = {
+                            "bk_sops",
+                            "bk-cmdb",
+                            "bk_apigateway",
+                            "demo",
+                            "my_app",
+                        }
+                        for _, app_code in ipairs(valid_cases) do
+                            local auth_params = auth_params_mod.new({
+                                bk_app_code = app_code,
+                                bk_app_secret = "world",
+                            })
+                            local verifier = app_account_verifier_mod.new(auth_params)
+                            local mock_app = bk_app_define.new_app({
+                                app_code = app_code,
+                                verified = true,
+                                valid_error_message = "",
+                            })
+                            stub(verifier, "verify_by_app_secret", mock_app)
+
+                            local app = verifier:verify_app()
+                            assert.stub(verifier.verify_by_app_secret).was_called()
+                            assert.is_equal(app.app_code, app_code)
+                            assert.is_true(app.verified)
+                            assert.is_equal(app.valid_error_message, "")
+
+                            verifier.verify_by_app_secret:revert()
                         end
                     end
                 )

--- a/src/apisix/tests/bk-auth-verify/test-app-account-verifier.lua
+++ b/src/apisix/tests/bk-auth-verify/test-app-account-verifier.lua
@@ -99,6 +99,31 @@ describe(
                 )
 
                 it(
+                    "app_code contains invalid characters", function()
+                        local cases = {
+                            "userdata: NULL",
+                            "<bk_app_code>",
+                            "<应用code>",
+                        }
+                        for _, app_code in ipairs(cases) do
+                            local auth_params = auth_params_mod.new({
+                                bk_app_code = app_code,
+                                bk_app_secret = "world",
+                            })
+                            local verifier = app_account_verifier_mod.new(auth_params)
+
+                            local app = verifier:verify_app()
+                            assert.is_equal(app.app_code, "")
+                            assert.is_false(app.verified)
+                            assert.is_equal(
+                                app.valid_error_message,
+                                "app code contains invalid characters"
+                            )
+                        end
+                    end
+                )
+
+                it(
                     "app_secret length is greather 128", function()
                         local auth_params = auth_params_mod.new({
                             bk_app_code = "hello",


### PR DESCRIPTION
## Summary
- Reject `bk_app_code` containing whitespace or `<>` before calling bkauth, matching the existing length pre-check in `app-account-verifier`.
- Covers production error cases such as `userdata: NULL`, `<bk_app_code>`, and `<应用code>` that trigger `invalid characters found in path` after the APISIX 3.17 / resty-http 0.2.3 upgrade.

## Verification
- `RUN_WITH_IT= make test-busted` in `src/apisix` → `772 successes / 0 failures / 0 errors`
- `RUN_WITH_IT= make lint` in `src/apisix` → `0 warnings / 0 errors in 92 files`


Made with [Cursor](https://cursor.com)