### PR TITLE
feat(ai): add sensitive data redaction plugin

### DIFF
--- a/src/apisix/Makefile
+++ b/src/apisix/Makefile
@@ -27,6 +27,7 @@ test-nginx:
 	@docker run --rm ${RUN_WITH_IT} \
 	-v ${ROOT_DIR}/t:/bkgateway/t/ \
 	-v ${ROOT_DIR}/plugins:/bkgateway/apisix/plugins \
+	-v ${ROOT_DIR}/../build/patches:/bkgateway/patches:ro \
 	apisix-test-nginx-317 "/run-test-nginx.sh" $(if $(CASE_FILE),$(CASE_FILE))
 
 .PHONY: apisix-test-images

--- a/src/apisix/ci/run-test-nginx.sh
+++ b/src/apisix/ci/run-test-nginx.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+echo "apply the AI response filter EOF patch"
+if ! patch --batch --forward --fuzz=0 -p1 -d /usr/local/apisix \
+    < /bkgateway/patches/010_ai_response_filter_eof.patch; then
+    echo "failed to apply 010_ai_response_filter_eof.patch" >&2
+    exit 1
+fi
+
 echo "start etcd"
 nohup etcd >/tmp/etcd.log 2>&1 &
 

--- a/src/apisix/ci/run-test-nginx.sh
+++ b/src/apisix/ci/run-test-nginx.sh
@@ -7,6 +7,13 @@ if ! patch --batch --forward --fuzz=0 -p1 -d /usr/local/apisix \
     exit 1
 fi
 
+echo "apply the AI final request body filter patch"
+if ! patch --batch --forward --fuzz=0 -p1 -d /usr/local/apisix \
+    < /bkgateway/patches/011_ai_final_request_body_filter.patch; then
+    echo "failed to apply 011_ai_final_request_body_filter.patch" >&2
+    exit 1
+fi
+
 echo "start etcd"
 nohup etcd >/tmp/etcd.log 2>&1 &
 

--- a/src/apisix/plugins/README.md
+++ b/src/apisix/plugins/README.md
@@ -79,6 +79,13 @@ proxy 预处理：17000 ~ 17500
 - bk-resource-header-rewrite                # priority: 17420
 - bk-mock                                   # priority: 17150
 
+AI 执行与响应恢复：
+
+- ai-proxy-multi                           # priority: 1041
+- ai-proxy                                 # priority: 1040
+- bk-ai-sensitive-data-redaction           # priority: 1039 # APISIX 按优先级从高到低执行，因此在 ai-proxy/ai-proxy-multi 之后运行；[使用说明](bk-ai-sensitive-data-redaction/README.md)
+- ai-rate-limiting                         # priority: 1030
+
 官方插件：
 
 - fault-injection                           # priority: 11000

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
@@ -670,21 +670,15 @@ function _M.lua_body_filter(_, ctx, _, body, eof)
         return
     end
 
-    local decoded, decode_err = core.json.decode(body)
-    if not decoded then
+    local ok, restored, count = pcall(
+        restorer.restore_json_text,
+        body,
+        ctx._ai_redaction_mapping,
+        ctx._ai_redaction_namespace
+    )
+    if not ok or type(restored) ~= "string" or type(count) ~= "number" then
         core.log.error(
-            "failed to decode masked AI response: ", decode_err,
-            ", request_id: ", ctx._ai_redaction_request_id
-        )
-        clear_sensitive_state(ctx)
-        return
-    end
-
-    local restored, count = restorer.restore_json(decoded, ctx._ai_redaction_mapping)
-    local encoded, encode_err = core.json.encode(restored)
-    if not encoded then
-        core.log.error(
-            "failed to encode restored AI response: ", encode_err,
+            "failed to restore masked AI response",
             ", request_id: ", ctx._ai_redaction_request_id
         )
         clear_sensitive_state(ctx)
@@ -693,7 +687,7 @@ function _M.lua_body_filter(_, ctx, _, body, eof)
 
     ctx._ai_redaction_restored_count = count
     clear_sensitive_state(ctx)
-    return nil, encoded
+    return nil, restored
 end
 
 

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
@@ -70,6 +70,7 @@ local FORBIDDEN_AUTH_HEADERS = {
 --   27 + 6*max_request_body_bytes + 6*max_mapping_bytes + 33*max_mapping_entries
 -- The hard ceiling keeps a misconfigured limit from permitting an unbounded worker buffer.
 local MAX_RESPONSE_WIRE_BYTES = 64 * 1024 * 1024
+local MAX_RESPONSE_READ_BYTES = 8192
 local RESPONSE_ENVELOPE_BYTES = 27
 local JSON_ESCAPE_MULTIPLIER = 6
 local MAPPING_ENTRY_STRUCTURE_BYTES = 33
@@ -325,7 +326,11 @@ local function read_bounded_response(res, max_bytes)
     local chunks = {}
     local total = 0
     while true do
-        local chunk, read_err = res.body_reader()
+        local remaining = max_bytes - total
+        -- Read one byte past the remaining allowance to detect overflow without
+        -- letting lua-resty-http allocate an entire declared chunk or body.
+        local read_size = math_min(MAX_RESPONSE_READ_BYTES, remaining + 1)
+        local chunk, read_err = res.body_reader(read_size)
         if read_err then
             return nil, "redaction service read failed: " .. read_err
         end

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
@@ -502,6 +502,8 @@ end
 
 
 function _M.access(conf, ctx)
+    ctx.var.llm_request_body = {}
+
     if not ctx.picked_ai_instance or not ctx.ai_client_protocol then
         return 500,
                "bk-ai-sensitive-data-redaction must be used with ai-proxy or ai-proxy-multi"

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
@@ -1,0 +1,424 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+
+local core = require("apisix.core")
+local http = require("resty.http")
+local protocols = require("apisix.plugins.ai-protocols")
+local restorer = require("apisix.plugins.bk-ai-sensitive-data-redaction.restorer")
+local url = require("socket.url")
+local uuid = require("resty.jit-uuid")
+local getmetatable = getmetatable
+local pairs = pairs
+local require = require
+local setmetatable = setmetatable
+local tostring = tostring
+local type = type
+
+-- Load the streaming response helper now; response restoration is wired in a later task.
+require("apisix.plugins.bk-ai-sensitive-data-redaction.sse")
+
+local UUID_PATTERN =
+    [[^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-]] ..
+    [[[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z]]
+
+local SUPPORTED_STREAM_PROTOCOLS = {
+    ["openai-chat"] = true,
+    ["openai-responses"] = true,
+    ["anthropic-messages"] = true,
+}
+
+local schema = {
+    type = "object",
+    properties = {
+        endpoint = {
+            type = "string",
+            pattern = [[^https?://]],
+            minLength = 1,
+        },
+        auth_header = {
+            type = "string",
+            default = "Authorization",
+            minLength = 1,
+        },
+        auth_value = {
+            type = "string",
+            minLength = 1,
+        },
+        session_id_header = {
+            type = "string",
+            default = "X-AI-Session-Id",
+            minLength = 1,
+        },
+        timeout = {
+            type = "integer",
+            minimum = 1,
+            maximum = 60000,
+            default = 3000,
+        },
+        ssl_verify = {
+            type = "boolean",
+            default = true,
+        },
+        keepalive = {
+            type = "boolean",
+            default = true,
+        },
+        keepalive_pool = {
+            type = "integer",
+            minimum = 1,
+            default = 30,
+        },
+        keepalive_timeout = {
+            type = "integer",
+            minimum = 1000,
+            default = 60000,
+        },
+        max_request_body_bytes = {
+            type = "integer",
+            minimum = 1,
+            default = 1048576,
+        },
+        max_mapping_entries = {
+            type = "integer",
+            minimum = 1,
+            default = 1000,
+        },
+        max_mapping_bytes = {
+            type = "integer",
+            minimum = 1,
+            default = 1048576,
+        },
+    },
+    encrypt_fields = {"auth_value"},
+    required = {"endpoint"},
+}
+
+local _M = {
+    version = 0.1,
+    priority = 1039,
+    name = "bk-ai-sensitive-data-redaction",
+    schema = schema,
+}
+
+
+local function parse_endpoint(endpoint)
+    if type(endpoint) ~= "string" or endpoint:find("[%c%s]") then
+        return nil, "endpoint must be an absolute HTTP or HTTPS URL"
+    end
+
+    local parsed = url.parse(endpoint)
+    if type(parsed) ~= "table"
+            or (parsed.scheme ~= "http" and parsed.scheme ~= "https")
+            or type(parsed.host) ~= "string"
+            or parsed.host == ""
+            or parsed.host:find("[%c%s]") then
+        return nil, "endpoint must be an absolute HTTP or HTTPS URL"
+    end
+
+    return parsed
+end
+
+
+function _M.check_schema(conf)
+    local ok, err = core.schema.check(schema, conf)
+    if not ok then
+        return false, err
+    end
+
+    local _, endpoint_err = parse_endpoint(conf.endpoint)
+    if endpoint_err then
+        return false, endpoint_err
+    end
+
+    local auth_header = conf.auth_header or "Authorization"
+    if not core.utils.validate_header_field(auth_header) then
+        return false, "invalid auth_header"
+    end
+
+    local session_id_header = conf.session_id_header or "X-AI-Session-Id"
+    if not core.utils.validate_header_field(session_id_header) then
+        return false, "invalid session_id_header"
+    end
+
+    return true
+end
+
+
+local function is_uuid(value)
+    if type(value) ~= "string" then
+        return false
+    end
+
+    return ngx.re.match(value, UUID_PATTERN, "jo") ~= nil
+end
+
+
+local function resolve_request_id(ctx)
+    if is_uuid(ctx.var.apisix_request_id) then
+        return ctx.var.apisix_request_id
+    end
+
+    if is_uuid(ctx.var.bk_request_id) then
+        return ctx.var.bk_request_id
+    end
+
+    return uuid.generate_v4()
+end
+
+
+local function resolve_session_id(conf, ctx)
+    local header_name = conf.session_id_header or "X-AI-Session-Id"
+    local session_id = core.request.header(ctx, header_name)
+    if session_id == nil or session_id == "" then
+        return nil
+    end
+
+    if not is_uuid(session_id) then
+        return nil, "invalid AI session ID"
+    end
+
+    return session_id
+end
+
+
+local function namespace_for(request_id)
+    return "__BK_REDACT_" .. request_id:gsub("-", ""):lower() .. "_"
+end
+
+
+local function body_status(err)
+    local message = err
+    if type(err) == "table" then
+        message = err.message
+    end
+
+    if type(message) == "string"
+            and message:find("greater than the maximum size", 1, true) then
+        return 413
+    end
+
+    return 400
+end
+
+
+local function close_connection(httpc)
+    httpc:close()
+end
+
+
+local function call_redaction_service(conf, request_id, session_id, namespace, body)
+    local parsed, endpoint_err = parse_endpoint(conf.endpoint)
+    if not parsed then
+        return nil, endpoint_err
+    end
+
+    local httpc = http.new()
+    httpc:set_timeout(conf.timeout)
+    local ok, err = httpc:connect({
+        scheme = parsed.scheme,
+        host = parsed.host,
+        port = parsed.port,
+        ssl_verify = conf.ssl_verify,
+        ssl_server_name = parsed.host,
+        pool_size = conf.keepalive and conf.keepalive_pool,
+    })
+    if not ok then
+        return nil, "redaction service connect failed: " .. (err or "unknown")
+    end
+
+    local payload = {
+        request_id = request_id,
+        placeholder_namespace = namespace,
+        body = body,
+    }
+    if session_id then
+        payload.session_id = session_id
+    end
+
+    local encoded_payload, encode_err = core.json.encode(payload)
+    if not encoded_payload then
+        close_connection(httpc)
+        return nil, "failed to encode redaction request: " .. (encode_err or "unknown")
+    end
+
+    local headers = {
+        ["Content-Type"] = "application/json",
+    }
+    if conf.auth_value then
+        headers[conf.auth_header or "Authorization"] = conf.auth_value
+    end
+
+    local path = parsed.path
+    if not path or path == "" then
+        path = "/"
+    end
+    if parsed.query then
+        path = path .. "?" .. parsed.query
+    end
+
+    local res, request_err = httpc:request({
+        method = "POST",
+        path = path,
+        headers = headers,
+        body = encoded_payload,
+    })
+    if not res then
+        close_connection(httpc)
+        return nil, "redaction service request failed: " .. (request_err or "unknown")
+    end
+
+    local raw, read_err = res:read_body()
+    if not raw then
+        close_connection(httpc)
+        return nil, "redaction service read failed: " .. (read_err or "unknown")
+    end
+
+    if conf.keepalive then
+        httpc:set_keepalive(conf.keepalive_timeout, conf.keepalive_pool)
+    else
+        close_connection(httpc)
+    end
+
+    if res.status ~= 200 then
+        return nil, "redaction service returned status " .. tostring(res.status)
+    end
+
+    local decoded = core.json.decode(raw)
+    if not decoded then
+        return nil, "redaction service returned invalid JSON"
+    end
+
+    if type(decoded) ~= "table" or getmetatable(decoded) == core.json.array_mt then
+        return nil, "redaction service response must be an object"
+    end
+
+    return decoded
+end
+
+
+local function validate_control_fields(ctx, original, masked)
+    if type(masked) ~= "table" or getmetatable(masked) == core.json.array_mt then
+        return "redaction service body must be an object"
+    end
+
+    local masked_protocol = protocols.detect(masked, ctx)
+    if masked_protocol ~= ctx.ai_client_protocol then
+        return "redaction service changed the AI protocol"
+    end
+
+    if masked.model ~= original.model then
+        return "redaction service changed model"
+    end
+
+    if masked.stream ~= original.stream then
+        return "redaction service changed stream"
+    end
+end
+
+
+local function replace_table(target, source)
+    for key in pairs(target) do
+        target[key] = nil
+    end
+    for key, value in pairs(source) do
+        target[key] = value
+    end
+    setmetatable(target, getmetatable(source))
+end
+
+
+function _M.access(conf, ctx)
+    if not ctx.picked_ai_instance or not ctx.ai_client_protocol then
+        return 500,
+               "bk-ai-sensitive-data-redaction must be used with ai-proxy or ai-proxy-multi"
+    end
+
+    if ctx.var.request_type == "ai_stream"
+            and not SUPPORTED_STREAM_PROTOCOLS[ctx.ai_client_protocol] then
+        return 400, "streaming protocol " .. ctx.ai_client_protocol ..
+                    " is not supported for response restoration"
+    end
+
+    local body, body_err = core.request.get_json_request_body_table(
+        conf.max_request_body_bytes
+    )
+    if not body then
+        return body_status(body_err), body_err
+    end
+
+    local encoded_body, encode_err = core.json.encode(body)
+    if not encoded_body then
+        return 400, {message = "failed to encode request body: " .. (encode_err or "unknown")}
+    end
+    if #encoded_body > conf.max_request_body_bytes then
+        return 413, {message = "request body is greater than the maximum size"}
+    end
+
+    local request_id = resolve_request_id(ctx)
+    local session_id, session_err = resolve_session_id(conf, ctx)
+    if session_err then
+        return 400, session_err
+    end
+
+    local namespace = namespace_for(request_id)
+    local result, redact_err = call_redaction_service(
+        conf, request_id, session_id, namespace, body
+    )
+    if not result then
+        return 502, {message = redact_err}
+    end
+
+    local control_err = validate_control_fields(ctx, body, result.body)
+    if control_err then
+        return 502, {message = control_err}
+    end
+
+    if type(result.replacements) ~= "table"
+            or getmetatable(result.replacements) ~= core.json.array_mt then
+        return 502, {message = "replacements must be a JSON array"}
+    end
+
+    local mapping, mapping_err = restorer.validate_mapping(
+        namespace,
+        result.body,
+        result.replacements,
+        conf.max_mapping_entries,
+        conf.max_mapping_bytes
+    )
+    if not mapping then
+        return 502, {message = mapping_err}
+    end
+
+    local masked_body, masked_encode_err = core.json.encode(result.body)
+    if not masked_body then
+        return 502, {
+            message = "failed to encode masked body: " .. (masked_encode_err or "unknown"),
+        }
+    end
+
+    replace_table(body, result.body)
+    ngx.req.set_body_data(masked_body)
+    ctx._ai_redaction_request_id = request_id
+    ctx._ai_redaction_session_id = session_id
+    ctx._ai_redaction_namespace = namespace
+    ctx._ai_redaction_mapping = mapping
+    ctx.ai_request_body_changed = true
+end
+
+
+return _M

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
@@ -490,6 +490,26 @@ local function clear_sensitive_state(ctx)
 end
 
 
+local function ensure_stream_counts(ctx)
+    if type(ctx._ai_redaction_restored_count) ~= "number" then
+        ctx._ai_redaction_restored_count = 0
+    end
+    if type(ctx._ai_redaction_unresolved_count) ~= "number" then
+        ctx._ai_redaction_unresolved_count = 0
+    end
+end
+
+
+local function latch_stream_passthrough(ctx)
+    if ctx._ai_redaction_stream_passthrough then
+        return
+    end
+
+    ctx._ai_redaction_stream_passthrough = true
+    clear_sensitive_state(ctx)
+end
+
+
 function _M.access(conf, ctx)
     if not ctx.picked_ai_instance or not ctx.ai_client_protocol then
         return 500,
@@ -578,28 +598,67 @@ end
 
 function _M.lua_body_filter(_, ctx, _, body, eof)
     if ctx.var.request_type == "ai_stream" then
+        local chunk = body or ""
+        ensure_stream_counts(ctx)
+        if ctx._ai_redaction_stream_passthrough then
+            return nil, chunk
+        end
+
         if not ctx._ai_redaction_sse_restorer then
-            local processor, err = sse_restorer.new(
+            local ok, processor = pcall(
+                sse_restorer.new,
                 ctx.ai_client_protocol,
                 ctx._ai_redaction_mapping,
                 ctx._ai_redaction_namespace
             )
-            if not processor then
+            if not ok or type(processor) ~= "table"
+                    or type(processor.feed) ~= "function" then
                 core.log.error(
-                    "failed to create SSE restorer: ", err,
+                    "failed to create SSE restorer",
                     ", request_id: ", ctx._ai_redaction_request_id
                 )
-                return
+                latch_stream_passthrough(ctx)
+                return nil, chunk
             end
             ctx._ai_redaction_sse_restorer = processor
         end
 
-        local output, restored_count, unresolved_count =
-            ctx._ai_redaction_sse_restorer:feed(body or "", eof == true)
+        local processor = ctx._ai_redaction_sse_restorer
+        local buffered = type(processor.remainder) == "string"
+                         and processor.remainder or ""
+        local ok, output, restored_count, unresolved_count = pcall(
+            processor.feed, processor, chunk, eof == true
+        )
+        if not ok or type(output) ~= "string"
+                or type(restored_count) ~= "number"
+                or type(unresolved_count) ~= "number" then
+            local prefix = buffered
+            local fallback = processor.fail_closed
+            if type(fallback) == "function" then
+                local fallback_ok, fallback_output, fallback_unresolved = pcall(
+                    fallback, processor, buffered
+                )
+                if fallback_ok and type(fallback_output) == "string" then
+                    prefix = fallback_output
+                    if type(fallback_unresolved) == "number" then
+                        ctx._ai_redaction_unresolved_count =
+                            ctx._ai_redaction_unresolved_count + fallback_unresolved
+                    end
+                end
+            end
+
+            core.log.error(
+                "failed to restore masked SSE response",
+                ", request_id: ", ctx._ai_redaction_request_id
+            )
+            latch_stream_passthrough(ctx)
+            return nil, prefix .. chunk
+        end
+
         ctx._ai_redaction_restored_count =
-            (ctx._ai_redaction_restored_count or 0) + restored_count
+            ctx._ai_redaction_restored_count + restored_count
         ctx._ai_redaction_unresolved_count =
-            (ctx._ai_redaction_unresolved_count or 0) + unresolved_count
+            ctx._ai_redaction_unresolved_count + unresolved_count
 
         if eof then
             clear_sensitive_state(ctx)

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
@@ -20,6 +20,7 @@ local core = require("apisix.core")
 local http = require("resty.http")
 local protocols = require("apisix.plugins.ai-protocols")
 local restorer = require("apisix.plugins.bk-ai-sensitive-data-redaction.restorer")
+local sse_restorer = require("apisix.plugins.bk-ai-sensitive-data-redaction.sse")
 local secret = require("apisix.secret")
 local url = require("socket.url")
 local uuid = require("resty.jit-uuid")
@@ -27,7 +28,6 @@ local getmetatable = getmetatable
 local math_min = math.min
 local pairs = pairs
 local pcall = pcall
-local require = require
 local setmetatable = setmetatable
 local string_byte = string.byte
 local string_lower = string.lower
@@ -35,9 +35,6 @@ local table_concat = table.concat
 local tonumber = tonumber
 local tostring = tostring
 local type = type
-
--- Load the streaming response helper now; response restoration is wired in a later task.
-require("apisix.plugins.bk-ai-sensitive-data-redaction.sse")
 
 local UUID_PATTERN =
     [[^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-]] ..
@@ -579,7 +576,37 @@ function _M.access(conf, ctx)
 end
 
 
-function _M.lua_body_filter(_, ctx, _, body)
+function _M.lua_body_filter(_, ctx, _, body, eof)
+    if ctx.var.request_type == "ai_stream" then
+        if not ctx._ai_redaction_sse_restorer then
+            local processor, err = sse_restorer.new(
+                ctx.ai_client_protocol,
+                ctx._ai_redaction_mapping,
+                ctx._ai_redaction_namespace
+            )
+            if not processor then
+                core.log.error(
+                    "failed to create SSE restorer: ", err,
+                    ", request_id: ", ctx._ai_redaction_request_id
+                )
+                return
+            end
+            ctx._ai_redaction_sse_restorer = processor
+        end
+
+        local output, restored_count, unresolved_count =
+            ctx._ai_redaction_sse_restorer:feed(body or "", eof == true)
+        ctx._ai_redaction_restored_count =
+            (ctx._ai_redaction_restored_count or 0) + restored_count
+        ctx._ai_redaction_unresolved_count =
+            (ctx._ai_redaction_unresolved_count or 0) + unresolved_count
+
+        if eof then
+            clear_sensitive_state(ctx)
+        end
+        return nil, output
+    end
+
     if ctx.var.request_type ~= "ai_chat" then
         return
     end

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
@@ -26,9 +26,7 @@ local url = require("socket.url")
 local uuid = require("resty.jit-uuid")
 local getmetatable = getmetatable
 local math_min = math.min
-local pairs = pairs
 local pcall = pcall
-local setmetatable = setmetatable
 local string_byte = string.byte
 local string_lower = string.lower
 local table_concat = table.concat
@@ -61,14 +59,15 @@ local FORBIDDEN_AUTH_HEADERS = {
     ["upgrade"] = true,
 }
 
--- A response contains the masked body plus replacement strings. Any decoded JSON byte can
--- occupy at most six wire bytes as a \u00XX escape. The fixed compact envelope is 27 bytes,
+-- A response contains the masked raw JSON string plus replacement strings. Any raw body or
+-- decoded mapping byte can occupy at most six wire bytes as a \u00XX escape. The fixed compact
+-- envelope is 29 bytes,
 -- and each mapping entry adds at most 33 structural bytes including its separator:
---   27 + 6*max_request_body_bytes + 6*max_mapping_bytes + 33*max_mapping_entries
+--   29 + 6*max_request_body_bytes + 6*max_mapping_bytes + 33*max_mapping_entries
 -- The hard ceiling keeps a misconfigured limit from permitting an unbounded worker buffer.
 local MAX_RESPONSE_WIRE_BYTES = 64 * 1024 * 1024
 local MAX_RESPONSE_READ_BYTES = 8192
-local RESPONSE_ENVELOPE_BYTES = 27
+local RESPONSE_ENVELOPE_BYTES = 29
 local JSON_ESCAPE_MULTIPLIER = 6
 local MAPPING_ENTRY_STRUCTURE_BYTES = 33
 
@@ -452,12 +451,8 @@ end
 
 
 local function validate_control_fields(ctx, original, masked)
-    if type(masked) ~= "table" or getmetatable(masked) == core.json.array_mt then
-        return "redaction service body must be an object"
-    end
-
     local masked_protocol = protocols.detect(masked, ctx)
-    if masked_protocol ~= ctx.ai_client_protocol then
+    if masked_protocol ~= ctx.ai_target_protocol then
         return "redaction service changed the AI protocol"
     end
 
@@ -471,14 +466,10 @@ local function validate_control_fields(ctx, original, masked)
 end
 
 
-local function replace_table(target, source)
-    for key in pairs(target) do
-        target[key] = nil
-    end
-    for key, value in pairs(source) do
-        target[key] = value
-    end
-    setmetatable(target, getmetatable(source))
+local function clear_attempt_state(ctx)
+    ctx._ai_redaction_mapping = nil
+    ctx._ai_redaction_sse_restorer = nil
+    ctx._ai_redaction_stream_passthrough = nil
 end
 
 
@@ -522,19 +513,9 @@ function _M.access(conf, ctx)
                     " is not supported for response restoration"
     end
 
-    local body, body_err = core.request.get_json_request_body_table(
-        conf.max_request_body_bytes
-    )
-    if not body then
-        return body_status(body_err), body_err
-    end
-
-    local encoded_body, encode_err = core.json.encode(body)
-    if not encoded_body then
-        return 400, {message = "failed to encode request body: " .. (encode_err or "unknown")}
-    end
-    if #encoded_body > conf.max_request_body_bytes then
-        return 413, {message = "request body is greater than the maximum size"}
+    local raw_body, body_err = core.request.get_body(conf.max_request_body_bytes, ctx)
+    if not raw_body then
+        return body_status(body_err), {message = body_err}
     end
 
     local request_id = resolve_request_id(ctx)
@@ -547,52 +528,83 @@ function _M.access(conf, ctx)
         return 500, "invalid redaction service authentication configuration"
     end
 
+    if ctx.ai_final_request_body_filter ~= nil then
+        return 500, "AI final request body filter is already registered"
+    end
+
     local namespace = namespace_for(request_id)
-    local result, redact_err = call_redaction_service(
-        conf, request_id, session_id, namespace, body
-    )
-    if not result then
-        return 502, {message = redact_err}
-    end
-
-    local control_err = validate_control_fields(ctx, body, result.body)
-    if control_err then
-        return 502, {message = control_err}
-    end
-
-    if type(result.replacements) ~= "table"
-            or getmetatable(result.replacements) ~= core.json.array_mt then
-        return 502, {message = "replacements must be a JSON array"}
-    end
-
-    local mapping, mapping_err = restorer.validate_mapping(
-        namespace,
-        result.body,
-        result.replacements,
-        conf.max_mapping_entries,
-        conf.max_mapping_bytes
-    )
-    if not mapping then
-        return 502, {message = mapping_err}
-    end
-
-    local masked_body, masked_encode_err = core.json.encode(result.body)
-    if not masked_body then
-        return 502, {
-            message = "failed to encode masked body: " .. (masked_encode_err or "unknown"),
-        }
-    end
-    if #masked_body > conf.max_request_body_bytes then
-        return 502, {message = "masked body size limit exceeded"}
-    end
-
-    replace_table(body, result.body)
-    ngx.req.set_body_data(masked_body)
     ctx._ai_redaction_request_id = request_id
     ctx._ai_redaction_session_id = session_id
     ctx._ai_redaction_namespace = namespace
-    ctx._ai_redaction_mapping = mapping
-    ctx.ai_request_body_changed = true
+    ctx.ai_final_request_body_filter = function(final_raw_body)
+        if type(final_raw_body) ~= "string" then
+            return nil, {
+                message = "final AI request body must be a JSON object string",
+            }, 400
+        end
+        if #final_raw_body > conf.max_request_body_bytes then
+            return nil, {message = "request body is greater than the maximum size"}, 413
+        end
+
+        local original = core.json.decode(final_raw_body)
+        if not original then
+            return nil, {message = "final AI request body must be valid JSON"}, 400
+        end
+        if type(original) ~= "table"
+                or getmetatable(original) == core.json.array_mt then
+            return nil, {
+                message = "final AI request body must be a JSON object string",
+            }, 400
+        end
+
+        clear_attempt_state(ctx)
+        local result, redact_err = call_redaction_service(
+            conf, request_id, session_id, namespace, final_raw_body
+        )
+        if not result then
+            return nil, {message = redact_err}, 502
+        end
+
+        if type(result.body) ~= "string" then
+            return nil, {message = "redaction service body must be a raw JSON string"}, 502
+        end
+        local masked = core.json.decode(result.body)
+        if not masked then
+            return nil, {message = "redaction service body must be valid JSON"}, 502
+        end
+        if type(masked) ~= "table"
+                or getmetatable(masked) == core.json.array_mt then
+            return nil, {message = "redaction service body must be an object"}, 502
+        end
+
+        local control_err = validate_control_fields(ctx, original, masked)
+        if control_err then
+            return nil, {message = control_err}, 502
+        end
+
+        if type(result.replacements) ~= "table"
+                or getmetatable(result.replacements) ~= core.json.array_mt then
+            return nil, {message = "replacements must be a JSON array"}, 502
+        end
+
+        local mapping, mapping_err = restorer.validate_mapping(
+            namespace,
+            result.body,
+            result.replacements,
+            conf.max_mapping_entries,
+            conf.max_mapping_bytes
+        )
+        if not mapping then
+            return nil, {message = mapping_err}, 502
+        end
+
+        if #result.body > conf.max_request_body_bytes then
+            return nil, {message = "masked body size limit exceeded"}, 502
+        end
+
+        ctx._ai_redaction_mapping = mapping
+        return result.body
+    end
 end
 
 

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
@@ -537,6 +537,9 @@ function _M.access(conf, ctx)
     ctx._ai_redaction_session_id = session_id
     ctx._ai_redaction_namespace = namespace
     ctx.ai_final_request_body_filter = function(final_raw_body)
+        clear_attempt_state(ctx)
+        ctx.var.llm_request_body = {}
+
         if type(final_raw_body) ~= "string" then
             return nil, {
                 message = "final AI request body must be a JSON object string",
@@ -557,7 +560,6 @@ function _M.access(conf, ctx)
             }, 400
         end
 
-        clear_attempt_state(ctx)
         local result, redact_err = call_redaction_service(
             conf, request_id, session_id, namespace, final_raw_body
         )
@@ -568,6 +570,10 @@ function _M.access(conf, ctx)
         if type(result.body) ~= "string" then
             return nil, {message = "redaction service body must be a raw JSON string"}, 502
         end
+        if #result.body > conf.max_request_body_bytes then
+            return nil, {message = "masked body size limit exceeded"}, 502
+        end
+
         local masked = core.json.decode(result.body)
         if not masked then
             return nil, {message = "redaction service body must be valid JSON"}, 502
@@ -598,11 +604,15 @@ function _M.access(conf, ctx)
             return nil, {message = mapping_err}, 502
         end
 
-        if #result.body > conf.max_request_body_bytes then
-            return nil, {message = "masked body size limit exceeded"}, 502
+        local integrity_ok, integrity_err = restorer.verify_redaction(
+            final_raw_body, result.body, mapping, namespace
+        )
+        if not integrity_ok then
+            return nil, {message = integrity_err}, 502
         end
 
         ctx._ai_redaction_mapping = mapping
+        ctx.var.llm_request_body = masked
         return result.body
     end
 end

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
@@ -20,12 +20,19 @@ local core = require("apisix.core")
 local http = require("resty.http")
 local protocols = require("apisix.plugins.ai-protocols")
 local restorer = require("apisix.plugins.bk-ai-sensitive-data-redaction.restorer")
+local secret = require("apisix.secret")
 local url = require("socket.url")
 local uuid = require("resty.jit-uuid")
 local getmetatable = getmetatable
+local math_min = math.min
 local pairs = pairs
+local pcall = pcall
 local require = require
 local setmetatable = setmetatable
+local string_byte = string.byte
+local string_lower = string.lower
+local table_concat = table.concat
+local tonumber = tonumber
 local tostring = tostring
 local type = type
 
@@ -41,6 +48,31 @@ local SUPPORTED_STREAM_PROTOCOLS = {
     ["openai-responses"] = true,
     ["anthropic-messages"] = true,
 }
+
+local FORBIDDEN_AUTH_HEADERS = {
+    ["connection"] = true,
+    ["content-length"] = true,
+    ["content-type"] = true,
+    ["host"] = true,
+    ["keep-alive"] = true,
+    ["proxy-authenticate"] = true,
+    ["proxy-authorization"] = true,
+    ["te"] = true,
+    ["trailer"] = true,
+    ["trailers"] = true,
+    ["transfer-encoding"] = true,
+    ["upgrade"] = true,
+}
+
+-- A response contains the masked body plus replacement strings. Any decoded JSON byte can
+-- occupy at most six wire bytes as a \u00XX escape. The fixed compact envelope is 27 bytes,
+-- and each mapping entry adds at most 33 structural bytes including its separator:
+--   27 + 6*max_request_body_bytes + 6*max_mapping_bytes + 33*max_mapping_entries
+-- The hard ceiling keeps a misconfigured limit from permitting an unbounded worker buffer.
+local MAX_RESPONSE_WIRE_BYTES = 64 * 1024 * 1024
+local RESPONSE_ENVELOPE_BYTES = 27
+local JSON_ESCAPE_MULTIPLIER = 6
+local MAPPING_ENTRY_STRUCTURE_BYTES = 33
 
 local schema = {
     type = "object",
@@ -134,6 +166,44 @@ local function parse_endpoint(endpoint)
 end
 
 
+local function is_safe_auth_header(header_name)
+    return type(header_name) == "string"
+           and core.utils.validate_header_field(header_name)
+           and not FORBIDDEN_AUTH_HEADERS[string_lower(header_name)]
+end
+
+
+local function is_safe_auth_value(value)
+    if type(value) ~= "string" or value == "" then
+        return false
+    end
+
+    for index = 1, #value do
+        local byte = string_byte(value, index)
+        if byte < 32 or byte == 127 then
+            return false
+        end
+    end
+
+    return true
+end
+
+
+local function has_safe_runtime_auth(conf)
+    local header_name = conf.auth_header or "Authorization"
+    if not is_safe_auth_header(header_name) then
+        return false
+    end
+
+    if conf.auth_value == nil then
+        return true
+    end
+
+    return not secret.is_secret_ref(conf.auth_value)
+           and is_safe_auth_value(conf.auth_value)
+end
+
+
 function _M.check_schema(conf)
     local ok, err = core.schema.check(schema, conf)
     if not ok then
@@ -146,8 +216,14 @@ function _M.check_schema(conf)
     end
 
     local auth_header = conf.auth_header or "Authorization"
-    if not core.utils.validate_header_field(auth_header) then
+    if not is_safe_auth_header(auth_header) then
         return false, "invalid auth_header"
+    end
+
+    if conf.auth_value ~= nil
+            and not secret.is_secret_ref(conf.auth_value)
+            and not is_safe_auth_value(conf.auth_value) then
+        return false, "invalid auth_value"
     end
 
     local session_id_header = conf.session_id_header or "X-AI-Session-Id"
@@ -217,7 +293,57 @@ end
 
 
 local function close_connection(httpc)
-    httpc:close()
+    local ok = pcall(httpc.close, httpc)
+    if not ok then
+        core.log.warn("failed to close redaction service connection")
+    end
+end
+
+
+local function response_wire_limit(conf)
+    local derived = RESPONSE_ENVELOPE_BYTES
+                    + JSON_ESCAPE_MULTIPLIER * conf.max_request_body_bytes
+                    + JSON_ESCAPE_MULTIPLIER * conf.max_mapping_bytes
+                    + MAPPING_ENTRY_STRUCTURE_BYTES * conf.max_mapping_entries
+    return math_min(derived, MAX_RESPONSE_WIRE_BYTES)
+end
+
+
+local function read_bounded_response(res, max_bytes)
+    local headers = res.headers or {}
+    local content_length = tonumber(
+        headers["Content-Length"] or headers["content-length"]
+    )
+    if content_length and content_length > max_bytes then
+        return nil, "redaction service response size limit exceeded"
+    end
+
+    if type(res.body_reader) ~= "function" then
+        return nil, "redaction service read failed: response body is unavailable"
+    end
+
+    local chunks = {}
+    local total = 0
+    while true do
+        local chunk, read_err = res.body_reader()
+        if read_err then
+            return nil, "redaction service read failed: " .. read_err
+        end
+        if chunk == nil then
+            break
+        end
+        if type(chunk) ~= "string" then
+            return nil, "redaction service read failed: invalid response chunk"
+        end
+
+        total = total + #chunk
+        if total > max_bytes then
+            return nil, "redaction service response size limit exceeded"
+        end
+        chunks[#chunks + 1] = chunk
+    end
+
+    return table_concat(chunks)
 end
 
 
@@ -229,14 +355,18 @@ local function call_redaction_service(conf, request_id, session_id, namespace, b
 
     local httpc = http.new()
     httpc:set_timeout(conf.timeout)
-    local ok, err = httpc:connect({
+    local connect_options = {
         scheme = parsed.scheme,
         host = parsed.host,
         port = parsed.port,
         ssl_verify = conf.ssl_verify,
         ssl_server_name = parsed.host,
-        pool_size = conf.keepalive and conf.keepalive_pool,
-    })
+    }
+    if conf.keepalive then
+        connect_options.pool_size = conf.keepalive_pool
+    end
+
+    local ok, err = httpc:connect(connect_options)
     if not ok then
         return nil, "redaction service connect failed: " .. (err or "unknown")
     end
@@ -282,20 +412,28 @@ local function call_redaction_service(conf, request_id, session_id, namespace, b
         return nil, "redaction service request failed: " .. (request_err or "unknown")
     end
 
-    local raw, read_err = res:read_body()
+    if res.status ~= 200 then
+        close_connection(httpc)
+        return nil, "redaction service returned status " .. tostring(res.status)
+    end
+
+    local raw, read_err = read_bounded_response(res, response_wire_limit(conf))
     if not raw then
         close_connection(httpc)
-        return nil, "redaction service read failed: " .. (read_err or "unknown")
+        return nil, read_err
     end
 
     if conf.keepalive then
-        httpc:set_keepalive(conf.keepalive_timeout, conf.keepalive_pool)
+        local kept = httpc:set_keepalive(conf.keepalive_timeout, conf.keepalive_pool)
+        if not kept then
+            close_connection(httpc)
+            core.log.warn(
+                "failed to keep redaction service connection alive, request_id: ",
+                request_id
+            )
+        end
     else
         close_connection(httpc)
-    end
-
-    if res.status ~= 200 then
-        return nil, "redaction service returned status " .. tostring(res.status)
     end
 
     local decoded = core.json.decode(raw)
@@ -375,6 +513,10 @@ function _M.access(conf, ctx)
         return 400, session_err
     end
 
+    if not has_safe_runtime_auth(conf) then
+        return 500, "invalid redaction service authentication configuration"
+    end
+
     local namespace = namespace_for(request_id)
     local result, redact_err = call_redaction_service(
         conf, request_id, session_id, namespace, body
@@ -409,6 +551,9 @@ function _M.access(conf, ctx)
         return 502, {
             message = "failed to encode masked body: " .. (masked_encode_err or "unknown"),
         }
+    end
+    if #masked_body > conf.max_request_body_bytes then
+        return 502, {message = "masked body size limit exceeded"}
     end
 
     replace_table(body, result.body)

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
@@ -25,6 +25,7 @@ local secret = require("apisix.secret")
 local url = require("socket.url")
 local uuid = require("resty.jit-uuid")
 local getmetatable = getmetatable
+local ipairs = ipairs
 local math_min = math.min
 local pcall = pcall
 local string_byte = string.byte
@@ -67,6 +68,7 @@ local FORBIDDEN_AUTH_HEADERS = {
 -- The hard ceiling keeps a misconfigured limit from permitting an unbounded worker buffer.
 local MAX_RESPONSE_WIRE_BYTES = 64 * 1024 * 1024
 local MAX_RESPONSE_READ_BYTES = 8192
+local MAX_RESPONSE_CHUNK_PARTS = 8192
 local RESPONSE_ENVELOPE_BYTES = 29
 local JSON_ESCAPE_MULTIPLIER = 6
 local MAPPING_ENTRY_STRUCTURE_BYTES = 33
@@ -298,10 +300,22 @@ end
 
 
 local function response_wire_limit(conf)
+    -- The same hard/config-derived ceiling bounds response restoration so a
+    -- small masked payload cannot expand into an unbounded worker allocation.
+    conf = conf or {}
     local derived = RESPONSE_ENVELOPE_BYTES
-                    + JSON_ESCAPE_MULTIPLIER * conf.max_request_body_bytes
-                    + JSON_ESCAPE_MULTIPLIER * conf.max_mapping_bytes
-                    + MAPPING_ENTRY_STRUCTURE_BYTES * conf.max_mapping_entries
+                    + JSON_ESCAPE_MULTIPLIER * (
+                        conf.max_request_body_bytes
+                        or schema.properties.max_request_body_bytes.default
+                    )
+                    + JSON_ESCAPE_MULTIPLIER * (
+                        conf.max_mapping_bytes
+                        or schema.properties.max_mapping_bytes.default
+                    )
+                    + MAPPING_ENTRY_STRUCTURE_BYTES * (
+                        conf.max_mapping_entries
+                        or schema.properties.max_mapping_entries.default
+                    )
     return math_min(derived, MAX_RESPONSE_WIRE_BYTES)
 end
 
@@ -320,6 +334,7 @@ local function read_bounded_response(res, max_bytes)
     end
 
     local chunks = {}
+    local chunk_parts = {}
     local total = 0
     while true do
         local remaining = max_bytes - total
@@ -341,9 +356,16 @@ local function read_bounded_response(res, max_bytes)
         if total > max_bytes then
             return nil, "redaction service response size limit exceeded"
         end
-        chunks[#chunks + 1] = chunk
+        chunk_parts[#chunk_parts + 1] = chunk
+        if #chunk_parts >= MAX_RESPONSE_CHUNK_PARTS then
+            chunks[#chunks + 1] = table_concat(chunk_parts)
+            chunk_parts = {}
+        end
     end
 
+    if #chunk_parts > 0 then
+        chunks[#chunks + 1] = table_concat(chunk_parts)
+    end
     return table_concat(chunks)
 end
 
@@ -451,8 +473,24 @@ end
 
 
 local function validate_control_fields(ctx, original, masked)
-    local masked_protocol = protocols.detect(masked, ctx)
-    if masked_protocol ~= ctx.ai_target_protocol then
+    local target_protocol = ctx.ai_target_protocol
+    local protocol = protocols.get(target_protocol)
+    local matches_target = protocol and protocol.matches(masked, ctx)
+    if target_protocol == "vertex-predict" then
+        matches_target = type(masked.instances) == "table"
+                         and getmetatable(masked.instances) == core.json.array_mt
+                         and #masked.instances > 0
+        if matches_target then
+            for _, instance in ipairs(masked.instances) do
+                if type(instance) ~= "table"
+                        or type(instance.content) ~= "string" then
+                    matches_target = false
+                    break
+                end
+            end
+        end
+    end
+    if not matches_target then
         return "redaction service changed the AI protocol"
     end
 
@@ -600,27 +638,31 @@ function _M.access(conf, ctx)
             result.body,
             result.replacements,
             conf.max_mapping_entries,
-            conf.max_mapping_bytes
+            conf.max_mapping_bytes,
+            response_wire_limit(conf)
         )
         if not mapping then
             return nil, {message = mapping_err}, 502
         end
 
         local integrity_ok, integrity_err = restorer.verify_redaction(
-            final_raw_body, result.body, mapping, namespace
+            final_raw_body,
+            result.body,
+            mapping,
+            namespace,
+            response_wire_limit(conf)
         )
         if not integrity_ok then
             return nil, {message = integrity_err}, 502
         end
 
         ctx._ai_redaction_mapping = mapping
-        ctx.var.llm_request_body = masked
         return result.body
     end
 end
 
 
-function _M.lua_body_filter(_, ctx, _, body, eof)
+function _M.lua_body_filter(conf, ctx, _, body, eof)
     if ctx.var.request_type == "ai_stream" then
         local chunk = body or ""
         ensure_stream_counts(ctx)
@@ -633,7 +675,8 @@ function _M.lua_body_filter(_, ctx, _, body, eof)
                 sse_restorer.new,
                 ctx.ai_client_protocol,
                 ctx._ai_redaction_mapping,
-                ctx._ai_redaction_namespace
+                ctx._ai_redaction_namespace,
+                response_wire_limit(conf)
             )
             if not ok or type(processor) ~= "table"
                     or type(processor.feed) ~= "function" then
@@ -698,7 +741,8 @@ function _M.lua_body_filter(_, ctx, _, body, eof)
         restorer.restore_json_text,
         body,
         ctx._ai_redaction_mapping,
-        ctx._ai_redaction_namespace
+        ctx._ai_redaction_namespace,
+        response_wire_limit(conf)
     )
     if not ok or type(restored) ~= "string" or type(count) ~= "number" then
         core.log.error(

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction.lua
@@ -485,6 +485,14 @@ local function replace_table(target, source)
 end
 
 
+local function clear_sensitive_state(ctx)
+    ctx._ai_redaction_session_id = nil
+    ctx._ai_redaction_namespace = nil
+    ctx._ai_redaction_mapping = nil
+    ctx._ai_redaction_sse_restorer = nil
+end
+
+
 function _M.access(conf, ctx)
     if not ctx.picked_ai_instance or not ctx.ai_client_protocol then
         return 500,
@@ -568,6 +576,38 @@ function _M.access(conf, ctx)
     ctx._ai_redaction_namespace = namespace
     ctx._ai_redaction_mapping = mapping
     ctx.ai_request_body_changed = true
+end
+
+
+function _M.lua_body_filter(_, ctx, _, body)
+    if ctx.var.request_type ~= "ai_chat" then
+        return
+    end
+
+    local decoded, decode_err = core.json.decode(body)
+    if not decoded then
+        core.log.error(
+            "failed to decode masked AI response: ", decode_err,
+            ", request_id: ", ctx._ai_redaction_request_id
+        )
+        clear_sensitive_state(ctx)
+        return
+    end
+
+    local restored, count = restorer.restore_json(decoded, ctx._ai_redaction_mapping)
+    local encoded, encode_err = core.json.encode(restored)
+    if not encoded then
+        core.log.error(
+            "failed to encode restored AI response: ", encode_err,
+            ", request_id: ", ctx._ai_redaction_request_id
+        )
+        clear_sensitive_state(ctx)
+        return
+    end
+
+    ctx._ai_redaction_restored_count = count
+    clear_sensitive_state(ctx)
+    return nil, encoded
 end
 
 

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/README.md
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/README.md
@@ -1,0 +1,527 @@
+# bk-ai-sensitive-data-redaction
+
+## English
+
+### Overview and ordering
+
+`bk-ai-sensitive-data-redaction` masks sensitive values in the final AI JSON
+request, sends only the masked request to the LLM, and restores exact known
+placeholders in the client response. The redaction service is the only external
+component that receives the original request values as part of this flow.
+
+The plugin name is `bk-ai-sensitive-data-redaction` and its priority is `1039`.
+APISIX executes higher priorities first, so it runs after `ai-proxy-multi`
+(`1041`) or `ai-proxy` (`1040`) has selected an AI instance and detected the
+client protocol, and before `ai-rate-limiting` (`1030`). Bind this plugin only
+to a route that also uses `ai-proxy` or `ai-proxy-multi`.
+
+### Configuration
+
+| Field | Type | Required | Default | Validation and behavior |
+| --- | --- | --- | --- | --- |
+| `endpoint` | string | yes | none | Absolute `http://` or `https://` URL with a non-empty host. Control characters and whitespace are rejected. |
+| `auth_header` | string | no | `Authorization` | Non-empty valid HTTP header name. `connection`, `content-length`, `content-type`, `host`, `keep-alive`, `proxy-authenticate`, `proxy-authorization`, `te`, `trailer`, `trailers`, `transfer-encoding`, and `upgrade` are forbidden, case-insensitively. |
+| `auth_value` | string | no | none | Non-empty credential placed in `auth_header`. It is in `encrypt_fields` and may be a resolvable APISIX secret reference. The runtime value must contain no control bytes. No authentication header is sent when omitted. |
+| `session_id_header` | string | no | `X-AI-Session-Id` | Non-empty valid HTTP header name used to read the optional session UUID. |
+| `timeout` | integer | no | `3000` | Redaction-service connect/request/read timeout in milliseconds, from `1` through `60000`. |
+| `ssl_verify` | boolean | no | `true` | Verifies the redaction-service TLS certificate. |
+| `keepalive` | boolean | no | `true` | Reuses the redaction-service connection. |
+| `keepalive_pool` | integer | no | `30` | Connection pool size; minimum `1`. |
+| `keepalive_timeout` | integer | no | `60000` | Keepalive timeout in milliseconds; minimum `1000`. |
+| `max_request_body_bytes` | integer | no | `1048576` | Maximum encoded original request body and maximum encoded masked body; minimum `1`. |
+| `max_mapping_entries` | integer | no | `1000` | Maximum number of replacement entries; minimum `1`. |
+| `max_mapping_bytes` | integer | no | `1048576` | Maximum sum, in bytes, of every placeholder and original value; minimum `1`. |
+
+There is no fail-open option.
+
+### Route and request example
+
+The following is an executable Admin API template. Replace the example LLM and
+redaction endpoints and the test LLM token for the target environment. It
+contains no production credential.
+
+```bash
+export APISIX_ADMIN_KEY='replace-with-local-admin-key'
+
+curl --fail-with-body -X PUT \
+  'http://127.0.0.1:9180/apisix/admin/routes/ai-redaction-demo' \
+  -H "X-API-KEY: ${APISIX_ADMIN_KEY}" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "uri": "/ai/redacted-chat",
+    "methods": ["POST"],
+    "plugins": {
+      "request-id": {
+        "header_name": "X-Request-ID",
+        "include_in_response": false,
+        "algorithm": "uuid"
+      },
+      "ai-proxy": {
+        "provider": "openai",
+        "auth": {
+          "header": {"Authorization": "Bearer replace-with-llm-token"}
+        },
+        "options": {"model": "gpt-4o"},
+        "override": {"endpoint": "https://llm.example.internal/v1/chat/completions"}
+      },
+      "bk-ai-sensitive-data-redaction": {
+        "endpoint": "https://redactor.example.internal/v1/redact",
+        "session_id_header": "X-AI-Session-Id"
+      }
+    }
+  }'
+```
+
+Call the configured route with a canonical UUID session ID when conversation
+correlation is required. The session header is optional.
+
+```bash
+curl --fail-with-body -X POST \
+  'http://127.0.0.1:9080/ai/redacted-chat' \
+  -H 'Content-Type: application/json' \
+  -H 'X-AI-Session-Id: 24395b38-bf3f-426c-a632-10df20ec69c8' \
+  -d '{
+    "model": "gpt-4o",
+    "stream": false,
+    "messages": [
+      {"role": "user", "content": "phone: 13800138000"}
+    ]
+  }'
+```
+
+### Request identity and third-party contract
+
+`request_id` is mandatory in the third-party payload and is scoped to one HTTP
+request. The plugin uses the first value with the canonical UUID shape
+`8-4-4-4-12` hexadecimal digits, case-insensitively, in this order:
+
+1. `ctx.var.apisix_request_id`;
+2. `ctx.var.bk_request_id`;
+3. a newly generated UUID v4.
+
+The selected value must be unique for every HTTP request. The plugin validates
+its shape but cannot detect a UUID that an upstream request-ID source wrongly
+reuses across requests.
+
+The placeholder namespace is derived only from that request ID: remove its
+hyphens, lowercase its 32 hexadecimal digits, and wrap them as
+`__BK_REDACT_<32-hex>_`. For example,
+`da584df5-7bd5-4590-98e0-8f92a89f9494` produces
+`__BK_REDACT_da584df57bd5459098e08f92a89f9494_`.
+
+`session_id` is optional. A non-empty value from `session_id_header` must have
+the same canonical UUID shape or the request is rejected with HTTP 400. It is
+forwarded only for third-party/Agent conversation correlation. It is never an
+APISIX storage key and never selects a mapping. Reusing one session ID across
+multiple turns does not persist or reuse replacements: every HTTP request has
+an independent mapping and stream state keyed by its unique `request_id`, and
+conversation history sent on a later turn is redacted again.
+
+After request validation, APISIX makes one `POST` to the configured endpoint
+with `Content-Type: application/json` (or makes one such attempt if connection
+or request I/O fails). It adds `auth_header: auth_value` only when `auth_value`
+is configured. `session_id` is omitted when the caller did not supply it.
+
+```json
+{
+  "request_id": "da584df5-7bd5-4590-98e0-8f92a89f9494",
+  "session_id": "24395b38-bf3f-426c-a632-10df20ec69c8",
+  "placeholder_namespace": "__BK_REDACT_da584df57bd5459098e08f92a89f9494_",
+  "body": {
+    "model": "gpt-4o",
+    "stream": true,
+    "messages": [
+      {"role": "user", "content": "phone: 13800138000"}
+    ]
+  }
+}
+```
+
+The service must return HTTP 200 with one JSON object in this form:
+
+```json
+{
+  "body": {
+    "model": "gpt-4o",
+    "stream": true,
+    "messages": [
+      {
+        "role": "user",
+        "content": "phone: __BK_REDACT_da584df57bd5459098e08f92a89f9494_1__"
+      }
+    ]
+  },
+  "replacements": [
+    {
+      "placeholder": "__BK_REDACT_da584df57bd5459098e08f92a89f9494_1__",
+      "original": "13800138000"
+    }
+  ]
+}
+```
+
+Before changing the LLM request, the plugin verifies all of these conditions:
+
+- the top-level response and `body` are JSON objects, not arrays;
+- `body` is detected as the same AI client protocol as the original body;
+- `model` and `stream` are unchanged;
+- `replacements` is a JSON array with at most `max_mapping_entries` entries;
+- every entry is an object containing string `placeholder` and `original`
+  values;
+- every placeholder is unique and exactly matches
+  `^<placeholder_namespace>[1-9][0-9]*__$`;
+- every declared placeholder occurs in the compact JSON encoding of the masked
+  body;
+- the sum of placeholder and original string bytes is no greater than
+  `max_mapping_bytes`; and
+- the compact encoded masked body is no greater than
+  `max_request_body_bytes`.
+
+The original and masked encoded AI bodies are each limited by
+`max_request_body_bytes`; an oversized original is HTTP 413, while an oversized
+masked body is a third-party contract failure (HTTP 502). The full outbound
+third-party request envelope has no separate schema limit. The third-party
+response wire body is read with this implementation limit:
+
+```text
+min(27 + 6 * max_request_body_bytes
+       + 6 * max_mapping_bytes
+       + 33 * max_mapping_entries,
+    64 MiB)
+```
+
+An over-limit `Content-Length` is rejected before reading, and chunked or
+undeclared bodies are bounded while reading. These multipliers cover the
+worst-case JSON escaping and mapping envelope; the decoded mapping limits above
+are still validated separately.
+
+### Response protocols and restoration
+
+Non-streaming `ai_chat` responses are restored as complete client-format JSON.
+Known placeholders are replaced in every string leaf. A string leaf that is
+itself a complete JSON object or array is decoded, restored recursively, and
+re-encoded, which supports tool/function argument JSON.
+
+Streaming restoration supports only client-visible SSE for these client
+protocols:
+
+- `openai-chat`: `choices[*].delta.content`, `reasoning_content`, `refusal`,
+  `function_call.arguments`, and `tool_calls[*].function.arguments`;
+- `openai-responses`: `response.output_text.delta`,
+  `response.reasoning_summary_text.delta`, and
+  `response.function_call_arguments.delta`; and
+- `anthropic-messages`: `text_delta.text` and
+  `input_json_delta.partial_json` in content-block delta events.
+
+The processor preserves incomplete SSE frames and placeholder prefixes across
+transport chunks. Text fields receive raw originals; JSON-fragment fields
+receive JSON-escaped originals. Comment/keepalive frames, malformed events,
+unknown event shapes, and fields outside the list above pass through unchanged
+and therefore remain masked. An unterminated SSE remainder is bounded at 1 MiB;
+if it grows past that size before EOF, it is emitted unchanged and the remainder
+buffer is reset rather than rejecting the response.
+
+Raw client-visible Bedrock `bedrock-converse` AWS EventStream and arbitrary
+passthrough streaming protocols are rejected with HTTP 400 before the redaction
+service or LLM is called. A Bedrock upstream is supported when `ai-proxy`
+converts it to one of the supported OpenAI or Anthropic client-visible SSE
+protocols, because this plugin sees and restores the converted SSE.
+
+At a protocol terminal event or transport EOF, pending state is flushed and
+the sensitive request mapping is cleared. If the client disconnects first, the
+AI streaming loop may stop before its EOF callback; no remaining buffered
+response can be delivered, and the request-local state is reclaimed with the
+request rather than persisted.
+
+### Failure, security, and observability
+
+Request processing is fail closed. No LLM upstream call occurs on any of these
+plugin failures:
+
+- HTTP 400: invalid non-empty session UUID, unsupported streaming protocol, or
+  invalid/unencodable request JSON;
+- HTTP 413: original body exceeds `max_request_body_bytes`;
+- HTTP 500: the required AI-proxy context is absent, or the runtime
+  authentication configuration remains unresolved/unsafe; and
+- HTTP 502: redaction-service connection/request/read failure, non-200 status,
+  malformed or oversized response, changed protocol/model/stream, invalid
+  mapping, or oversized masked body.
+
+Response-side restoration never substitutes an unmasked fallback. If complete
+JSON cannot be decoded or encoded, or the SSE restorer fails, the response
+continues with the still-masked data. After an SSE restorer failure, remaining
+chunks stay in masked passthrough mode. Unknown, altered, or incomplete
+placeholders are never restored; a pending incomplete placeholder is emitted
+still masked at a terminal event or EOF and counted as unresolved.
+
+All mappings, namespaces, session IDs, and SSE buffers live only in the current
+request context. The plugin does not use an Nginx shared dictionary, etcd,
+Redis, files, or another cross-request store. Never log request/response bodies,
+original values, placeholders/tokens, mappings, credentials, or `session_id`.
+The implementation logs only operational restoration/connection failures and
+may include the non-secret `request_id` for correlation.
+
+The implementation maintains request-context-only numeric counters
+`ctx._ai_redaction_restored_count` and
+`ctx._ai_redaction_unresolved_count`. They are not public metrics. The plugin
+does not create a public response header for `request_id`; any such header is
+owned by a separately configured request-ID plugin. The redaction request's
+`request_id` is also retained in `ctx._ai_redaction_request_id` for local
+correlation after sensitive mapping state is cleared.
+
+Use HTTPS with `ssl_verify=true` in production, authenticate the redaction
+service with a resolved secret rather than a literal credential, and authorize
+it for the minimum required caller/tenant scope. The redaction service sees the
+original sensitive values by design and must be operated as a trusted data
+processor. If `ai-request-rewrite`, `ai-rag`, or external moderation plugins
+are also bound, their services may receive or inspect raw data; do not bind
+them when the redaction service must be the only external raw-data recipient
+unless those services are explicitly trusted.
+
+## 中文
+
+### 概述与执行顺序
+
+`bk-ai-sensitive-data-redaction` 对最终 AI JSON 请求中的敏感值进行脱敏，只把
+脱敏后的请求发送给 LLM，并在客户端响应中精确还原已知占位符。在这条处理链路中，
+脱敏服务是唯一会接收原始请求值的外部组件。
+
+插件名为 `bk-ai-sensitive-data-redaction`，优先级为 `1039`。APISIX 按优先级
+从高到低执行，因此本插件会在 `ai-proxy-multi`（`1041`）或 `ai-proxy`
+（`1040`）完成 AI 实例选择和客户端协议识别后执行，并在
+`ai-rate-limiting`（`1030`）之前执行。只能把本插件绑定到同时配置了
+`ai-proxy` 或 `ai-proxy-multi` 的路由。
+
+### 配置
+
+| 字段 | 类型 | 必填 | 默认值 | 校验与行为 |
+| --- | --- | --- | --- | --- |
+| `endpoint` | string | 是 | 无 | 带非空主机名的绝对 `http://` 或 `https://` URL；拒绝控制字符和空白字符。 |
+| `auth_header` | string | 否 | `Authorization` | 非空且合法的 HTTP 请求头名。不区分大小写禁止 `connection`、`content-length`、`content-type`、`host`、`keep-alive`、`proxy-authenticate`、`proxy-authorization`、`te`、`trailer`、`trailers`、`transfer-encoding` 和 `upgrade`。 |
+| `auth_value` | string | 否 | 无 | 写入 `auth_header` 的非空凭据。该字段位于 `encrypt_fields` 中，可使用能被 APISIX 解析的 secret 引用；运行时值不能包含控制字节。省略时不发送认证请求头。 |
+| `session_id_header` | string | 否 | `X-AI-Session-Id` | 用于读取可选会话 UUID 的非空合法 HTTP 请求头名。 |
+| `timeout` | integer | 否 | `3000` | 脱敏服务连接、请求和读取超时，单位毫秒，范围 `1` 到 `60000`。 |
+| `ssl_verify` | boolean | 否 | `true` | 是否校验脱敏服务的 TLS 证书。 |
+| `keepalive` | boolean | 否 | `true` | 是否复用脱敏服务连接。 |
+| `keepalive_pool` | integer | 否 | `30` | 连接池大小，最小值 `1`。 |
+| `keepalive_timeout` | integer | 否 | `60000` | 长连接超时时间，单位毫秒，最小值 `1000`。 |
+| `max_request_body_bytes` | integer | 否 | `1048576` | 原始请求体编码后以及脱敏请求体编码后的最大字节数，最小值 `1`。 |
+| `max_mapping_entries` | integer | 否 | `1000` | replacement 条目的最大数量，最小值 `1`。 |
+| `max_mapping_bytes` | integer | 否 | `1048576` | 所有占位符与原始值的总字节数上限，最小值 `1`。 |
+
+插件没有 fail-open 选项。
+
+### 路由与请求示例
+
+下面是可执行的 Admin API 模板。请把示例 LLM、脱敏服务地址和测试 LLM token
+替换为目标环境的值；示例不包含生产凭据。
+
+```bash
+export APISIX_ADMIN_KEY='replace-with-local-admin-key'
+
+curl --fail-with-body -X PUT \
+  'http://127.0.0.1:9180/apisix/admin/routes/ai-redaction-demo' \
+  -H "X-API-KEY: ${APISIX_ADMIN_KEY}" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "uri": "/ai/redacted-chat",
+    "methods": ["POST"],
+    "plugins": {
+      "request-id": {
+        "header_name": "X-Request-ID",
+        "include_in_response": false,
+        "algorithm": "uuid"
+      },
+      "ai-proxy": {
+        "provider": "openai",
+        "auth": {
+          "header": {"Authorization": "Bearer replace-with-llm-token"}
+        },
+        "options": {"model": "gpt-4o"},
+        "override": {"endpoint": "https://llm.example.internal/v1/chat/completions"}
+      },
+      "bk-ai-sensitive-data-redaction": {
+        "endpoint": "https://redactor.example.internal/v1/redact",
+        "session_id_header": "X-AI-Session-Id"
+      }
+    }
+  }'
+```
+
+需要关联 Agent 多轮会话时，请使用符合规范格式的 UUID 作为会话 ID 调用路由；
+会话请求头是可选的。
+
+```bash
+curl --fail-with-body -X POST \
+  'http://127.0.0.1:9080/ai/redacted-chat' \
+  -H 'Content-Type: application/json' \
+  -H 'X-AI-Session-Id: 24395b38-bf3f-426c-a632-10df20ec69c8' \
+  -d '{
+    "model": "gpt-4o",
+    "stream": false,
+    "messages": [
+      {"role": "user", "content": "phone: 13800138000"}
+    ]
+  }'
+```
+
+### 请求身份与第三方协议
+
+第三方请求中的 `request_id` 必填，其作用域是单个 HTTP 请求。插件会按以下顺序
+选择第一个符合 `8-4-4-4-12` 十六进制格式（不区分大小写）的 UUID：
+
+1. `ctx.var.apisix_request_id`；
+2. `ctx.var.bk_request_id`；
+3. 新生成的 UUID v4。
+
+选中的值必须在每个 HTTP 请求中唯一。插件只校验 UUID 格式，无法识别上游
+request-ID 来源是否错误地在多个请求间复用了同一个 UUID。
+
+占位符命名空间只从该 request ID 派生：删除连字符，将 32 个十六进制字符转为
+小写，再组成 `__BK_REDACT_<32-hex>_`。例如
+`da584df5-7bd5-4590-98e0-8f92a89f9494` 会生成
+`__BK_REDACT_da584df57bd5459098e08f92a89f9494_`。
+
+`session_id` 可选。`session_id_header` 中的非空值必须符合相同 UUID 格式，否则
+返回 HTTP 400。它只用于第三方服务或 Agent 多轮会话的关联，不会成为 APISIX
+存储键，也不会用于选择 mapping。多轮复用同一个 session ID 不会让 APISIX 持久化
+或复用 replacement：每个 HTTP 请求都按其唯一 `request_id` 持有独立的 mapping
+和流状态；后续轮次再次携带的会话历史会重新脱敏。占位符还原始终绑定当前 HTTP
+请求的 `request_id`，而不是 `session_id`。
+
+请求校验通过后，APISIX 使用 `Content-Type: application/json` 向配置的 endpoint
+发起一次 `POST`（若连接或请求 I/O 失败，则只尝试一次）。只有配置 `auth_value`
+时才会增加 `auth_header: auth_value`。调用方没有提供会话 ID 时会省略
+`session_id`。
+
+```json
+{
+  "request_id": "da584df5-7bd5-4590-98e0-8f92a89f9494",
+  "session_id": "24395b38-bf3f-426c-a632-10df20ec69c8",
+  "placeholder_namespace": "__BK_REDACT_da584df57bd5459098e08f92a89f9494_",
+  "body": {
+    "model": "gpt-4o",
+    "stream": true,
+    "messages": [
+      {"role": "user", "content": "phone: 13800138000"}
+    ]
+  }
+}
+```
+
+服务必须返回 HTTP 200，响应体为以下 JSON 对象：
+
+```json
+{
+  "body": {
+    "model": "gpt-4o",
+    "stream": true,
+    "messages": [
+      {
+        "role": "user",
+        "content": "phone: __BK_REDACT_da584df57bd5459098e08f92a89f9494_1__"
+      }
+    ]
+  },
+  "replacements": [
+    {
+      "placeholder": "__BK_REDACT_da584df57bd5459098e08f92a89f9494_1__",
+      "original": "13800138000"
+    }
+  ]
+}
+```
+
+修改 LLM 请求前，插件会校验以下全部条件：
+
+- 顶层响应和 `body` 都是 JSON 对象，而不是数组；
+- `body` 被识别为与原始 body 相同的 AI 客户端协议；
+- `model` 和 `stream` 未改变；
+- `replacements` 是 JSON 数组，条目数不超过 `max_mapping_entries`；
+- 每个条目都是包含字符串 `placeholder` 和 `original` 的对象；
+- 每个占位符唯一，并严格匹配
+  `^<placeholder_namespace>[1-9][0-9]*__$`；
+- 每个声明的占位符都出现在脱敏 body 的紧凑 JSON 编码中；
+- 占位符与原始值的字符串字节总数不超过 `max_mapping_bytes`；以及
+- 脱敏 body 的紧凑编码不超过 `max_request_body_bytes`。
+
+原始和脱敏 AI body 编码后都受 `max_request_body_bytes` 限制；原始 body 超限
+返回 HTTP 413，脱敏 body 超限属于第三方协议错误，返回 HTTP 502。完整的第三方
+出站请求 envelope 没有独立的 schema 限制。第三方响应的 wire body 按以下实现上限
+读取：
+
+```text
+min(27 + 6 * max_request_body_bytes
+       + 6 * max_mapping_bytes
+       + 33 * max_mapping_entries,
+    64 MiB)
+```
+
+超限的 `Content-Length` 会在读取前被拒绝；chunked 或未声明长度的响应则在读取
+过程中受限。这些倍数覆盖最坏情况的 JSON 转义和 mapping envelope；解码后仍会
+单独执行上述 mapping 限制校验。
+
+### 响应协议与还原
+
+非流式 `ai_chat` 响应按完整客户端格式 JSON 还原。插件会替换每个字符串叶子中的
+已知占位符。若某个字符串叶子本身是完整 JSON 对象或数组，则会解码、递归还原并
+重新编码，从而支持 tool/function 参数 JSON。
+
+流式还原只支持以下客户端可见 SSE 协议：
+
+- `openai-chat`：`choices[*].delta.content`、`reasoning_content`、`refusal`、
+  `function_call.arguments` 和 `tool_calls[*].function.arguments`；
+- `openai-responses`：`response.output_text.delta`、
+  `response.reasoning_summary_text.delta` 和
+  `response.function_call_arguments.delta`；以及
+- `anthropic-messages`：content-block delta 事件中的 `text_delta.text` 和
+  `input_json_delta.partial_json`。
+
+处理器会跨传输 chunk 保留不完整 SSE frame 和占位符前缀。文本字段写入原始值，
+JSON fragment 字段写入经过 JSON 转义的原始值。注释/keepalive frame、格式错误的
+事件、未知事件结构以及上述列表以外的字段均原样透传，因此保持脱敏状态。未终止
+SSE remainder 的上限为 1 MiB；若它在 EOF 前超过该大小，插件会将其原样输出并重置
+remainder buffer，而不是拒绝响应。
+
+客户端直接可见的 Bedrock `bedrock-converse` 原始 AWS EventStream 以及任意
+passthrough 流式协议，会在调用脱敏服务和 LLM 之前以 HTTP 400 拒绝。若 Bedrock
+上游被 `ai-proxy` 转换成上述受支持的 OpenAI 或 Anthropic 客户端可见 SSE 协议，
+则仍受支持，因为本插件看到并还原的是转换后的 SSE。
+
+遇到协议终止事件或传输 EOF 时，插件会 flush 待处理状态并清除敏感请求 mapping。
+若客户端提前断开，AI 流式循环可能在执行 EOF 回调前停止；此时剩余缓冲响应已无法
+发送，请求局部状态会随请求回收，而不会被持久化。
+
+### 失败、安全与可观测性
+
+请求处理采用 fail closed。发生以下任一本插件错误时都不会调用 LLM 上游：
+
+- HTTP 400：非空 session UUID 无效、流式协议不受支持，或请求 JSON
+  无效/无法编码；
+- HTTP 413：原始 body 超过 `max_request_body_bytes`；
+- HTTP 500：缺少必需的 AI proxy 上下文，或运行时认证配置仍未解析/不安全；以及
+- HTTP 502：脱敏服务连接/请求/读取失败、返回非 200、响应格式错误或超限、修改了
+  协议/model/stream、mapping 无效，或脱敏 body 超限。
+
+响应侧还原绝不会用未脱敏数据作为 fallback。完整 JSON 无法解码或编码，或 SSE
+还原器失败时，响应继续使用仍处于脱敏状态的数据；SSE 还原器失败后，后续 chunk
+保持脱敏 passthrough。未知、被修改或不完整的占位符永远不会被还原；协议终止事件
+或 EOF 到达时，待处理的不完整占位符会仍以脱敏形式输出，并计入 unresolved 数量。
+
+所有 mapping、命名空间、session ID 和 SSE buffer 只存在于当前请求上下文中。
+插件不使用 Nginx shared dictionary、etcd、Redis、文件或其他跨请求存储。禁止记录
+请求/响应 body、原始值、占位符/token、mapping、凭据或 `session_id`。当前实现只
+记录还原/连接相关的运行错误，并可能携带非秘密的 `request_id` 用于关联。
+
+当前实现只在请求上下文内维护数值计数器
+`ctx._ai_redaction_restored_count` 和
+`ctx._ai_redaction_unresolved_count`，它们不是公开 metrics。本插件不会为
+`request_id` 创建公开响应头；此类响应头由另行配置的 request-ID 插件负责。脱敏
+请求使用的 `request_id` 也保留在 `ctx._ai_redaction_request_id` 中，使敏感 mapping
+状态清理后仍可在本地关联。
+
+生产环境应使用 HTTPS 和 `ssl_verify=true`，通过已解析的 secret 而不是字面量凭据
+认证脱敏服务，并按调用方/租户授予最小权限。脱敏服务按设计会看到原始敏感值，必须
+作为受信任的数据处理方运行。如果路由还绑定了 `ai-request-rewrite`、`ai-rag` 或
+外部 moderation 插件，它们的服务也可能接收或检查原始数据；当脱敏服务必须是唯一
+接收原始数据的外部组件时，不要绑定这些插件，除非明确信任相应服务。

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/README.md
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/README.md
@@ -205,7 +205,11 @@ min(29 + 6 * max_request_body_bytes
 An over-limit `Content-Length` is rejected before reading, and chunked or
 undeclared bodies are bounded while reading. These multipliers cover the
 worst-case JSON escaping and mapping envelope; the decoded mapping limits above
-are still validated separately.
+are still validated separately. The same ceiling limits each non-streaming
+restored body. For each streaming filter invocation, it limits aggregate
+restored-field bytes and each reconstructed JSON event. This bounds
+placeholder-driven expansion, not unchanged SSE frames or framing overhead. If
+the restoration limit is exceeded, the affected bytes remain masked.
 
 ### Response protocols and restoration
 
@@ -294,10 +298,11 @@ request context. The plugin does not use an Nginx shared dictionary, etcd,
 Redis, files, or another cross-request store. On entry to the plugin's access
 phase, request-payload logging is set to `{}` and remains empty through plugin
 validation, lower-priority access, provider routing, and request-build failures.
-Only a contract-verified masked body replaces it. While the final-body filter is
-active, body-bearing model options, LLM/request-body overrides, and
-authentication values are suppressed from the relevant AI-proxy logs; the
-original body, mapping, and session ID are not logged by this path.
+It also remains empty after a contract-verified masked body is accepted. While
+the final-body filter is active, body-bearing model options, LLM/request-body
+overrides, and authentication values are suppressed from the relevant AI-proxy
+logs; the original body, masked body, mapping, and session ID are not logged by
+this path.
 
 This is not a blanket promise that every provider option or override-derived
 value is absent from logs. Standard AI-proxy transport logs may retain
@@ -513,7 +518,10 @@ min(29 + 6 * max_request_body_bytes
 
 超限的 `Content-Length` 会在读取前被拒绝；chunked 或未声明长度的响应则在读取
 过程中受限。这些倍数覆盖最坏情况的 JSON 转义和 mapping envelope；解码后仍会
-单独执行上述 mapping 限制校验。
+单独执行上述 mapping 限制校验。同一上限也用于限制每次非流式 body 还原；对每次流式
+filter 调用，它限制聚合的已还原字段字节数，并逐个限制重建后的 JSON 事件。这限制的
+是占位符引起的扩张，不包括未修改的 SSE frame 或 framing 开销。还原超过该上限时，
+受影响的字节保持脱敏状态。
 
 ### 响应协议与还原
 
@@ -580,10 +588,10 @@ chunk 保持 passthrough。如果上游遵守协议，这会保留占位符；�
 所有 mapping、命名空间、session ID 和 SSE buffer 只存在于当前请求上下文中。
 插件不使用 Nginx shared dictionary、etcd、Redis、文件或其他跨请求存储。进入本
 插件 access 阶段时，请求 payload 日志即被设置为 `{}`；在插件校验、较低优先级
-access、provider 路由和请求构建失败期间均保持为空，只有通过协议校验的脱敏 body
-会替换它。最终 body filter 生效时，相关 AI-proxy 日志会抑制包含 body 的 model
-options、LLM/request-body override 和认证值；该路径不会记录原始 body、mapping 或
-session ID。
+access、provider 路由和请求构建失败期间均保持为空；通过协议校验的脱敏 body 被接受
+后也继续保持为空。最终 body filter 生效时，相关 AI-proxy 日志会抑制包含 body 的 model
+options、LLM/request-body override 和认证值；该路径不会记录原始 body、脱敏 body、
+mapping 或 session ID。
 
 这不代表日志中绝不会出现任何 provider option 或由 override 派生的值。标准
 AI-proxy 传输日志仍可能保留 endpoint 派生的非 body 元数据，例如 `scheme`、`host`、

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/README.md
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/README.md
@@ -291,12 +291,20 @@ and counted as unresolved.
 
 All mappings, namespaces, session IDs, and SSE buffers live only in the current
 request context. The plugin does not use an Nginx shared dictionary, etcd,
-Redis, files, or another cross-request store. While the final-body filter is
-active, body-bearing provider option and override values are not logged, and
-request-payload logging receives only the contract-verified masked body. This
-plugin path logs no original body, mapping, session, authentication, provider-
-option, or override value. Operational restoration/connection failures may be
-logged with the non-secret `request_id` for correlation.
+Redis, files, or another cross-request store. On entry to the plugin's access
+phase, request-payload logging is set to `{}` and remains empty through plugin
+validation, lower-priority access, provider routing, and request-build failures.
+Only a contract-verified masked body replaces it. While the final-body filter is
+active, body-bearing model options, LLM/request-body overrides, and
+authentication values are suppressed from the relevant AI-proxy logs; the
+original body, mapping, and session ID are not logged by this path.
+
+This is not a blanket promise that every provider option or override-derived
+value is absent from logs. Standard AI-proxy transport logs may retain
+endpoint-derived non-body metadata such as `scheme`, `host`, `port`, `path`, and
+`ssl_server_name`. Operators must treat endpoint metadata as log-visible and
+restrict log access accordingly. Operational restoration/connection failures
+may also be logged with the non-secret `request_id` for correlation.
 
 The implementation maintains request-context-only numeric counters
 `ctx._ai_redaction_restored_count` and
@@ -570,11 +578,18 @@ chunk 保持 passthrough。如果上游遵守协议，这会保留占位符；�
 事件或 EOF 到达时，待处理的不完整占位符会原样输出，并计入 unresolved 数量。
 
 所有 mapping、命名空间、session ID 和 SSE buffer 只存在于当前请求上下文中。
-插件不使用 Nginx shared dictionary、etcd、Redis、文件或其他跨请求存储。最终
-body filter 生效时，不记录包含 body 的 provider option/override 值，请求 payload
-日志只接收通过协议校验的脱敏 body。该插件路径不会记录原始 body、mapping、session、
-认证、provider option 或 override 值；还原/连接相关的运行错误可能携带非秘密的
-`request_id` 用于关联。
+插件不使用 Nginx shared dictionary、etcd、Redis、文件或其他跨请求存储。进入本
+插件 access 阶段时，请求 payload 日志即被设置为 `{}`；在插件校验、较低优先级
+access、provider 路由和请求构建失败期间均保持为空，只有通过协议校验的脱敏 body
+会替换它。最终 body filter 生效时，相关 AI-proxy 日志会抑制包含 body 的 model
+options、LLM/request-body override 和认证值；该路径不会记录原始 body、mapping 或
+session ID。
+
+这不代表日志中绝不会出现任何 provider option 或由 override 派生的值。标准
+AI-proxy 传输日志仍可能保留 endpoint 派生的非 body 元数据，例如 `scheme`、`host`、
+`port`、`path` 和 `ssl_server_name`。运维方必须把 endpoint 元数据视为日志可见信息，
+并相应限制日志访问权限。还原/连接相关的运行错误也可能携带非秘密的 `request_id`
+用于关联。
 
 当前实现只在请求上下文内维护数值计数器
 `ctx._ai_redaction_restored_count` 和

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/README.md
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/README.md
@@ -4,9 +4,13 @@
 
 ### Overview and ordering
 
-`bk-ai-sensitive-data-redaction` sends the final AI JSON request to a redaction
-service, installs the service-returned body as the LLM request after contract
-validation, and restores exact known placeholders in the client response. The
+`bk-ai-sensitive-data-redaction` sends the finalized provider-specific AI JSON
+request to a redaction service, installs the service-returned body as the LLM
+request after contract validation, and restores exact known placeholders in the
+client response. Its access phase only validates configuration and request
+metadata and registers a request-local final-body filter; it performs no
+third-party I/O. The filter runs after protocol conversion, provider options,
+overrides, and model removal, immediately before signing and transport. The
 redaction service receives the original request values. The plugin relies on
 that trusted service to identify and replace every sensitive value; it cannot
 prove that the returned body is completely redacted.
@@ -21,7 +25,7 @@ to a route that also uses `ai-proxy` or `ai-proxy-multi`.
 
 | Field | Type | Required | Default | Validation and behavior |
 | --- | --- | --- | --- | --- |
-| `endpoint` | string | yes | none | Absolute `http://` or `https://` URL with a non-empty host. Control characters and whitespace are rejected. |
+| `endpoint` | string | yes | none | Absolute `http://` or `https://` URL with a non-empty host. Control characters and whitespace are rejected. This is trusted administrator configuration; no SSRF or private-address deny list is applied. |
 | `auth_header` | string | no | `Authorization` | Non-empty valid HTTP header name. `connection`, `content-length`, `content-type`, `host`, `keep-alive`, `proxy-authenticate`, `proxy-authorization`, `te`, `trailer`, `trailers`, `transfer-encoding`, and `upgrade` are forbidden, case-insensitively. |
 | `auth_value` | string | no | none | Non-empty credential placed in `auth_header`. It is in `encrypt_fields` and may be a resolvable APISIX secret reference. The runtime value must contain no control bytes. No authentication header is sent when omitted. |
 | `session_id_header` | string | no | `X-AI-Session-Id` | Non-empty valid HTTP header name used to read the optional session UUID. |
@@ -112,32 +116,35 @@ hyphens, lowercase its 32 hexadecimal digits, and wrap them as
 `__BK_REDACT_da584df57bd5459098e08f92a89f9494_`.
 
 `session_id` is optional. A non-empty value from `session_id_header` must have
-the same canonical UUID shape or the request is rejected with HTTP 400. It is
-forwarded only for third-party/Agent conversation correlation. It is never an
-APISIX storage key and never selects a mapping. Reusing one session ID across
-multiple turns does not persist or reuse replacements: every HTTP request has
-an independent mapping and stream state stored only in its current request
-context, while its placeholders are namespaced by the unique `request_id`.
-There is no request-ID-keyed mapping lookup table. Conversation history sent on
-a later turn is redacted again.
+the same canonical UUID shape or the request is rejected with HTTP 400. If the
+header occurs multiple times, its first value is used. It is forwarded only for
+third-party/Agent conversation correlation. It is never an APISIX storage key
+and never selects or persists a mapping. Reusing one session ID across multiple
+turns does not persist or reuse replacements: every HTTP request has independent
+stream state, while its placeholders are namespaced by the unique `request_id`.
+There is no request-ID- or session-ID-keyed mapping lookup table. Conversation
+history sent on a later turn is redacted again.
 
-After request validation, APISIX makes one `POST` to the configured endpoint
-with `Content-Type: application/json` (or makes one such attempt if connection
-or request I/O fails). It adds `auth_header: auth_value` only when `auth_value`
-is configured. `session_id` is omitted when the caller did not supply it.
+For each finalized provider attempt, APISIX makes one `POST` to the configured
+endpoint with `Content-Type: application/json`. It does not retry a failed
+redaction-service connection or request. An `ai-proxy-multi` fallback attempt
+finalizes and redacts its own provider body; before every attempt the previous
+attempt's mapping is cleared, and only the successful final attempt's mapping
+can restore that attempt's response. A redaction failure is non-retryable: it
+prevents the current LLM call and does not fall back to another LLM provider.
+APISIX adds `auth_header: auth_value` only when `auth_value` is configured, and
+omits `session_id` when the caller did not supply it.
+
+`body` is a raw JSON string inside the JSON envelope, not a nested object. This
+keeps the provider serializer's exact numeric lexemes, including large integers,
+`-0`, and exponent spellings, across the redaction-service round trip.
 
 ```json
 {
   "request_id": "da584df5-7bd5-4590-98e0-8f92a89f9494",
   "session_id": "24395b38-bf3f-426c-a632-10df20ec69c8",
   "placeholder_namespace": "__BK_REDACT_da584df57bd5459098e08f92a89f9494_",
-  "body": {
-    "model": "gpt-4o",
-    "stream": true,
-    "messages": [
-      {"role": "user", "content": "phone: 13800138000"}
-    ]
-  }
+  "body": "{\"model\":\"gpt-4o\",\"stream\":true,\"messages\":[{\"role\":\"user\",\"content\":\"phone: 13800138000\"}]}"
 }
 ```
 
@@ -145,16 +152,7 @@ The service must return HTTP 200 with one JSON object in this form:
 
 ```json
 {
-  "body": {
-    "model": "gpt-4o",
-    "stream": true,
-    "messages": [
-      {
-        "role": "user",
-        "content": "phone: __BK_REDACT_da584df57bd5459098e08f92a89f9494_1__"
-      }
-    ]
-  },
+  "body": "{\"model\":\"gpt-4o\",\"stream\":true,\"messages\":[{\"role\":\"user\",\"content\":\"phone: __BK_REDACT_da584df57bd5459098e08f92a89f9494_1__\"}]}",
   "replacements": [
     {
       "placeholder": "__BK_REDACT_da584df57bd5459098e08f92a89f9494_1__",
@@ -166,20 +164,24 @@ The service must return HTTP 200 with one JSON object in this form:
 
 Before changing the LLM request, the plugin verifies all of these conditions:
 
-- the top-level response and `body` are JSON objects, not arrays;
-- `body` is detected as the same AI client protocol as the original body;
+- the top-level response is a JSON object and `body` is a raw JSON string that
+  decodes to an object;
+- the decoded `body` is detected as the same AI target protocol as the finalized
+  provider body;
 - `model` and `stream` are unchanged;
 - `replacements` is a JSON array with at most `max_mapping_entries` entries;
 - every entry is an object containing string `placeholder` and `original`
   values;
 - every placeholder is unique and exactly matches
   `^<placeholder_namespace>[1-9][0-9]*__$`;
-- every declared placeholder occurs in the compact JSON encoding of the masked
-  body;
+- every declared placeholder occurs in the masked raw JSON string;
 - the sum of placeholder and original string bytes is no greater than
   `max_mapping_bytes`; and
-- the compact encoded masked body is no greater than
-  `max_request_body_bytes`.
+- the masked raw JSON string is no greater than `max_request_body_bytes`;
+- restoring `replacements` reconstructs the finalized provider request: JSON
+  whitespace and equivalent string-escape spellings may differ, but object and
+  array order and shape, literals, numeric lexemes, and all non-redacted semantic
+  string content must match exactly.
 
 These checks establish response shape and mapping consistency, not redaction
 completeness. In particular, an unchanged `body` with an empty `replacements`
@@ -187,14 +189,14 @@ array satisfies the contract. The redaction service is therefore inside the
 security trust boundary: if it misses a sensitive value, that value can be sent
 to the LLM.
 
-The original and masked encoded AI bodies are each limited by
+The finalized original and masked raw AI bodies are each limited by
 `max_request_body_bytes`; an oversized original is HTTP 413, while an oversized
 masked body is a third-party contract failure (HTTP 502). The full outbound
 third-party request envelope has no separate schema limit. The third-party
 response wire body is read with this implementation limit:
 
 ```text
-min(27 + 6 * max_request_body_bytes
+min(29 + 6 * max_request_body_bytes
        + 6 * max_mapping_bytes
        + 33 * max_mapping_entries,
     64 MiB)
@@ -217,19 +219,29 @@ protocols:
 
 - `openai-chat`: `choices[*].delta.content`, `reasoning_content`, `refusal`,
   `function_call.arguments`, and `tool_calls[*].function.arguments`;
-- `openai-responses`: `response.output_text.delta`,
-  `response.reasoning_summary_text.delta`, and
-  `response.function_call_arguments.delta`; and
+- `openai-responses`: the `.delta` and corresponding `.done` events for
+  `response.output_text`, `response.reasoning_summary_text`, and
+  `response.function_call_arguments`; output text is separated by
+  `content_index`, reasoning summaries by `summary_index`, and all families by
+  their item/output identity;
 - `anthropic-messages`: `text_delta.text` and
   `input_json_delta.partial_json` in content-block delta events.
 
 The processor preserves incomplete SSE frames and placeholder prefixes across
 transport chunks. Text fields receive raw originals; JSON-fragment fields
-receive JSON-escaped originals. Comment/keepalive frames, malformed events,
-unknown event shapes, and fields outside the list above pass through unchanged
-without additional restoration. An unterminated SSE remainder is bounded at
-1 MiB; if it grows past that size before EOF, it is emitted unchanged and the
-remainder buffer is reset rather than rejecting the response.
+receive JSON-escaped originals. A field-specific `.done` event first flushes
+only that logical field's pending prefix, then independently restores the
+complete value carried by the done event. Comment/keepalive frames, malformed
+events, unknown event shapes, and fields outside the list above pass through
+unchanged without additional restoration.
+
+Retained streaming state is bounded to a 1 MiB incomplete raw SSE remainder,
+1024 active partial logical fields, 64 KiB of aggregate pending placeholder-
+prefix bytes, and 64 KiB of aggregate dynamic active-key/metadata bytes. A raw
+remainder over 1 MiB is emitted unchanged and reset. If another state bound is
+exceeded, or an unexpected restoration failure occurs, buffered and current
+bytes remain masked, passthrough mode latches for subsequent chunks, and the
+failure path deliberately emits no original value.
 
 Raw client-visible Bedrock `bedrock-converse` AWS EventStream and arbitrary
 passthrough streaming protocols are rejected with HTTP 400 before the redaction
@@ -243,10 +255,13 @@ current capability.
 A protocol terminal event finalizes and flushes pending processor state, but it
 does not clear the request mapping. The mapping and other sensitive state are
 cleared only when the response hook receives `eof=true`, when failure cleanup
-runs, or when the request is disposed. If the client disconnects first, the AI
-streaming loop may stop before its EOF callback; no remaining buffered response
-can be delivered, and the request-local state is reclaimed with the request
-rather than persisted.
+runs, or when the request is disposed. Configured AI-proxy
+`max_response_bytes` and `max_stream_duration_ms` exits run EOF finalization
+before ending a non-disconnected stream, flushing partial masked prefixes and
+clearing request-local sensitive state without fabricating a protocol terminal
+event. If the client disconnects first, downstream writes have already failed,
+so no EOF write is attempted; no remaining buffered response can be delivered,
+and request disposal reclaims the state rather than persisting it.
 
 ### Failure, security, and observability
 
@@ -259,8 +274,8 @@ plugin failures:
 - HTTP 500: the required AI-proxy context is absent, or the runtime
   authentication configuration remains unresolved/unsafe; and
 - HTTP 502: redaction-service connection/request/read failure, non-200 status,
-  malformed or oversized response, changed protocol/model/stream, invalid
-  mapping, or oversized masked body.
+  malformed or oversized response, changed protocol/model/stream or other
+  non-redacted request content, invalid mapping, or oversized masked body.
 
 Response-side restoration does not intentionally fetch or insert an unmasked
 fallback. If complete JSON cannot be decoded or encoded, or the SSE restorer
@@ -276,10 +291,12 @@ and counted as unresolved.
 
 All mappings, namespaces, session IDs, and SSE buffers live only in the current
 request context. The plugin does not use an Nginx shared dictionary, etcd,
-Redis, files, or another cross-request store. Never log request/response bodies,
-original values, placeholders/tokens, mappings, credentials, or `session_id`.
-The implementation logs only operational restoration/connection failures and
-may include the non-secret `request_id` for correlation.
+Redis, files, or another cross-request store. While the final-body filter is
+active, body-bearing provider option and override values are not logged, and
+request-payload logging receives only the contract-verified masked body. This
+plugin path logs no original body, mapping, session, authentication, provider-
+option, or override value. Operational restoration/connection failures may be
+logged with the non-secret `request_id` for correlation.
 
 The implementation maintains request-context-only numeric counters
 `ctx._ai_redaction_restored_count` and
@@ -301,14 +318,20 @@ redaction service to be the sole external raw-data recipient, they must also
 exclude or explicitly trust those services; this plugin cannot enforce that
 route-wide property.
 
+The configured `endpoint` is also inside the administrative trust boundary.
+The plugin applies no SSRF or private-address deny list, so route-configuration
+authority must be restricted to trusted administrators.
+
 ## 中文
 
 ### 概述与执行顺序
 
-`bk-ai-sensitive-data-redaction` 将最终 AI JSON 请求发送给脱敏服务，在协议校验
-通过后把服务返回的 body 设置为 LLM 请求，并在客户端响应中精确还原已知占位符。
-脱敏服务会接收原始请求值。插件信任该服务能够识别并替换全部敏感值，无法证明返回
-body 已完整脱敏。
+`bk-ai-sensitive-data-redaction` 将 provider 定制完成的最终 AI JSON 请求发送给
+脱敏服务，在协议校验通过后把服务返回的 body 设置为 LLM 请求，并在客户端响应中
+精确还原已知占位符。插件的 access 阶段只校验配置和请求元数据，并注册请求局部的
+最终 body filter，不调用第三方服务。该 filter 在协议转换、provider options、
+override 和 model 删除之后执行，紧邻签名与传输之前。脱敏服务会接收原始请求值。
+插件信任该服务能够识别并替换全部敏感值，无法证明返回 body 已完整脱敏。
 
 插件名为 `bk-ai-sensitive-data-redaction`，优先级为 `1039`。APISIX 按优先级
 从高到低执行，因此本插件会在 `ai-proxy-multi`（`1041`）或 `ai-proxy`
@@ -320,7 +343,7 @@ body 已完整脱敏。
 
 | 字段 | 类型 | 必填 | 默认值 | 校验与行为 |
 | --- | --- | --- | --- | --- |
-| `endpoint` | string | 是 | 无 | 带非空主机名的绝对 `http://` 或 `https://` URL；拒绝控制字符和空白字符。 |
+| `endpoint` | string | 是 | 无 | 带非空主机名的绝对 `http://` 或 `https://` URL；拒绝控制字符和空白字符。这是受信任的管理员配置，插件不执行 SSRF 或私网地址拒绝检查。 |
 | `auth_header` | string | 否 | `Authorization` | 非空且合法的 HTTP 请求头名。不区分大小写禁止 `connection`、`content-length`、`content-type`、`host`、`keep-alive`、`proxy-authenticate`、`proxy-authorization`、`te`、`trailer`、`trailers`、`transfer-encoding` 和 `upgrade`。 |
 | `auth_value` | string | 否 | 无 | 写入 `auth_header` 的非空凭据。该字段位于 `encrypt_fields` 中，可使用能被 APISIX 解析的 secret 引用；运行时值不能包含控制字节。省略时不发送认证请求头。 |
 | `session_id_header` | string | 否 | `X-AI-Session-Id` | 用于读取可选会话 UUID 的非空合法 HTTP 请求头名。 |
@@ -407,30 +430,30 @@ request-ID 来源是否错误地在多个请求间复用了同一个 UUID。
 `__BK_REDACT_da584df57bd5459098e08f92a89f9494_`。
 
 `session_id` 可选。`session_id_header` 中的非空值必须符合相同 UUID 格式，否则
-返回 HTTP 400。它只用于第三方服务或 Agent 多轮会话的关联，不会成为 APISIX
-存储键，也不会用于选择 mapping。多轮复用同一个 session ID 不会让 APISIX 持久化
-或复用 replacement：每个 HTTP 请求只在当前请求上下文中存储独立 mapping 和流
-状态，占位符则按唯一 `request_id` 划分命名空间；不存在以 request ID 为键的
-mapping 查询表。后续轮次再次携带的会话历史会重新脱敏。占位符还原始终绑定当前
-HTTP 请求的 `request_id`，而不是 `session_id`。
+返回 HTTP 400；请求头重复出现时使用第一个值。它只用于第三方服务或 Agent 多轮
+会话的关联，不会成为 APISIX 存储键，也不会用于选择或持久化 mapping。多轮复用
+同一个 session ID 不会让 APISIX 持久化或复用 replacement：每个 HTTP 请求具有
+独立的流状态，占位符则按唯一 `request_id` 划分命名空间；不存在以 request ID 或
+session ID 为键的 mapping 查询表。后续轮次再次携带的会话历史会重新脱敏。
 
-请求校验通过后，APISIX 使用 `Content-Type: application/json` 向配置的 endpoint
-发起一次 `POST`（若连接或请求 I/O 失败，则只尝试一次）。只有配置 `auth_value`
-时才会增加 `auth_header: auth_value`。调用方没有提供会话 ID 时会省略
-`session_id`。
+对于每次 provider body 最终定型的尝试，APISIX 都会使用
+`Content-Type: application/json` 向配置的 endpoint 发起一次 `POST`，且不会重试
+失败的脱敏服务连接或请求。`ai-proxy-multi` 的每次 LLM fallback 尝试会分别完成
+provider body 定型和脱敏；每次尝试前都会清除上一次 mapping，只有最终成功尝试的
+mapping 能还原该次响应。脱敏失败不可重试：它会阻止当前 LLM 调用，也不会继续
+fallback 到其他 LLM provider。只有配置 `auth_value` 时才会增加
+`auth_header: auth_value`；调用方没有提供会话 ID 时会省略 `session_id`。
+
+`body` 是 JSON envelope 内的原始 JSON 字符串，而不是嵌套对象。这样能在脱敏服务
+往返过程中保留 provider serializer 产生的精确数值词法形式，包括大整数、`-0`
+和指数写法。
 
 ```json
 {
   "request_id": "da584df5-7bd5-4590-98e0-8f92a89f9494",
   "session_id": "24395b38-bf3f-426c-a632-10df20ec69c8",
   "placeholder_namespace": "__BK_REDACT_da584df57bd5459098e08f92a89f9494_",
-  "body": {
-    "model": "gpt-4o",
-    "stream": true,
-    "messages": [
-      {"role": "user", "content": "phone: 13800138000"}
-    ]
-  }
+  "body": "{\"model\":\"gpt-4o\",\"stream\":true,\"messages\":[{\"role\":\"user\",\"content\":\"phone: 13800138000\"}]}"
 }
 ```
 
@@ -438,16 +461,7 @@ HTTP 请求的 `request_id`，而不是 `session_id`。
 
 ```json
 {
-  "body": {
-    "model": "gpt-4o",
-    "stream": true,
-    "messages": [
-      {
-        "role": "user",
-        "content": "phone: __BK_REDACT_da584df57bd5459098e08f92a89f9494_1__"
-      }
-    ]
-  },
+  "body": "{\"model\":\"gpt-4o\",\"stream\":true,\"messages\":[{\"role\":\"user\",\"content\":\"phone: __BK_REDACT_da584df57bd5459098e08f92a89f9494_1__\"}]}",
   "replacements": [
     {
       "placeholder": "__BK_REDACT_da584df57bd5459098e08f92a89f9494_1__",
@@ -459,28 +473,31 @@ HTTP 请求的 `request_id`，而不是 `session_id`。
 
 修改 LLM 请求前，插件会校验以下全部条件：
 
-- 顶层响应和 `body` 都是 JSON 对象，而不是数组；
-- `body` 被识别为与原始 body 相同的 AI 客户端协议；
+- 顶层响应是 JSON 对象，且 `body` 是能解码为对象的原始 JSON 字符串；
+- 解码后的 `body` 被识别为与最终 provider body 相同的 AI 目标协议；
 - `model` 和 `stream` 未改变；
 - `replacements` 是 JSON 数组，条目数不超过 `max_mapping_entries`；
 - 每个条目都是包含字符串 `placeholder` 和 `original` 的对象；
 - 每个占位符唯一，并严格匹配
   `^<placeholder_namespace>[1-9][0-9]*__$`；
-- 每个声明的占位符都出现在脱敏 body 的紧凑 JSON 编码中；
+- 每个声明的占位符都出现在脱敏后的原始 JSON 字符串中；
 - 占位符与原始值的字符串字节总数不超过 `max_mapping_bytes`；以及
-- 脱敏 body 的紧凑编码不超过 `max_request_body_bytes`。
+- 脱敏后的原始 JSON 字符串不超过 `max_request_body_bytes`；
+- 应用 `replacements` 后能重建最终 provider 请求：允许等价的 JSON 空白和字符串
+  转义写法不同，但对象/数组的顺序与结构、literal、数值词法形式以及所有未脱敏的
+  语义字符串内容必须完全一致。
 
 这些校验只能确认响应结构和 mapping 一致性，不能确认脱敏完整性。例如，未修改的
 `body` 加空 `replacements` 数组也符合协议。因此脱敏服务位于安全信任边界内：如果
 它漏掉敏感值，该值可能被发送给 LLM。
 
-原始和脱敏 AI body 编码后都受 `max_request_body_bytes` 限制；原始 body 超限
-返回 HTTP 413，脱敏 body 超限属于第三方协议错误，返回 HTTP 502。完整的第三方
-出站请求 envelope 没有独立的 schema 限制。第三方响应的 wire body 按以下实现上限
-读取：
+最终原始和脱敏后的 AI 原始 body 都受 `max_request_body_bytes` 限制；原始 body
+超限返回 HTTP 413，脱敏 body 超限属于第三方协议错误，返回 HTTP 502。完整的
+第三方出站请求 envelope 没有独立的 schema 限制。第三方响应的 wire body 按以下
+实现上限读取：
 
 ```text
-min(27 + 6 * max_request_body_bytes
+min(29 + 6 * max_request_body_bytes
        + 6 * max_mapping_bytes
        + 33 * max_mapping_entries,
     64 MiB)
@@ -500,17 +517,24 @@ min(27 + 6 * max_request_body_bytes
 
 - `openai-chat`：`choices[*].delta.content`、`reasoning_content`、`refusal`、
   `function_call.arguments` 和 `tool_calls[*].function.arguments`；
-- `openai-responses`：`response.output_text.delta`、
-  `response.reasoning_summary_text.delta` 和
-  `response.function_call_arguments.delta`；以及
+- `openai-responses`：`response.output_text`、
+  `response.reasoning_summary_text` 和 `response.function_call_arguments` 的
+  `.delta` 及对应 `.done` 事件；output text 按 `content_index` 区分，reasoning
+  summary 按 `summary_index` 区分，所有类别还会按 item/output 身份区分；以及
 - `anthropic-messages`：content-block delta 事件中的 `text_delta.text` 和
   `input_json_delta.partial_json`。
 
 处理器会跨传输 chunk 保留不完整 SSE frame 和占位符前缀。文本字段写入原始值，
-JSON fragment 字段写入经过 JSON 转义的原始值。注释/keepalive frame、格式错误的
-事件、未知事件结构以及上述列表以外的字段均原样透传，不执行额外还原。未终止 SSE
-remainder 的上限为 1 MiB；若它在 EOF 前超过该大小，插件会将其原样输出并重置
-remainder buffer，而不是拒绝响应。
+JSON fragment 字段写入经过 JSON 转义的原始值。字段对应的 `.done` 事件会先只
+flush 该逻辑字段待处理的前缀，再独立还原 done 事件携带的完整值。注释/keepalive
+frame、格式错误的事件、未知事件结构以及上述列表以外的字段均原样透传，不执行
+额外还原。
+
+保留的流状态上限分别为：1 MiB 的不完整原始 SSE remainder、1024 个活跃的局部
+逻辑字段、64 KiB 的占位符待处理前缀总字节数，以及 64 KiB 的动态活跃 key/metadata
+总字节数。原始 remainder 超过 1 MiB 时会原样输出并重置。若触发其他状态上限或
+发生非预期还原失败，已缓冲和当前字节会保持脱敏状态，后续 chunk 锁定为 passthrough；
+失败路径不会主动输出任何原始值。
 
 客户端直接可见的 Bedrock `bedrock-converse` 原始 AWS EventStream 以及任意
 passthrough 流式协议，会在调用脱敏服务和 LLM 之前以 HTTP 400 拒绝。若 Bedrock
@@ -521,8 +545,11 @@ hook 之前生成 OpenAI 或 Anthropic SSE，则该架构可以还原转换后�
 
 协议终止事件只会 finalize 并 flush 待处理的 processor 状态，不会清除请求 mapping。
 只有响应 hook 收到 `eof=true`、执行失败清理，或请求被销毁时，mapping 和其他敏感
-状态才会清除。若客户端提前断开，AI 流式循环可能在执行 EOF 回调前停止；此时剩余
-缓冲响应已无法发送，请求局部状态会随请求回收，而不会被持久化。
+状态才会清除。AI proxy 配置的 `max_response_bytes` 或
+`max_stream_duration_ms` 触发退出时，会在结束未断开的流之前执行 EOF finalization，
+flush 不完整的脱敏占位符前缀并清理请求局部敏感状态，但不会伪造协议终止事件。
+客户端断开是例外：此时下游写入已经失败，因此不会再尝试 EOF 写入；剩余缓冲响应
+无法发送，请求销毁会回收状态而不会持久化。
 
 ### 失败、安全与可观测性
 
@@ -533,7 +560,7 @@ hook 之前生成 OpenAI 或 Anthropic SSE，则该架构可以还原转换后�
 - HTTP 413：原始 body 超过 `max_request_body_bytes`；
 - HTTP 500：缺少必需的 AI proxy 上下文，或运行时认证配置仍未解析/不安全；以及
 - HTTP 502：脱敏服务连接/请求/读取失败、返回非 200、响应格式错误或超限、修改了
-  协议/model/stream、mapping 无效，或脱敏 body 超限。
+  协议/model/stream 或其他未脱敏请求内容、mapping 无效，或脱敏 body 超限。
 
 响应侧还原不会主动获取或插入未脱敏 fallback。完整 JSON 无法解码或编码，或 SSE
 还原器失败时，插件会透传上游字节和已缓冲的占位符数据；SSE 还原器失败后，后续
@@ -543,9 +570,11 @@ chunk 保持 passthrough。如果上游遵守协议，这会保留占位符；�
 事件或 EOF 到达时，待处理的不完整占位符会原样输出，并计入 unresolved 数量。
 
 所有 mapping、命名空间、session ID 和 SSE buffer 只存在于当前请求上下文中。
-插件不使用 Nginx shared dictionary、etcd、Redis、文件或其他跨请求存储。禁止记录
-请求/响应 body、原始值、占位符/token、mapping、凭据或 `session_id`。当前实现只
-记录还原/连接相关的运行错误，并可能携带非秘密的 `request_id` 用于关联。
+插件不使用 Nginx shared dictionary、etcd、Redis、文件或其他跨请求存储。最终
+body filter 生效时，不记录包含 body 的 provider option/override 值，请求 payload
+日志只接收通过协议校验的脱敏 body。该插件路径不会记录原始 body、mapping、session、
+认证、provider option 或 override 值；还原/连接相关的运行错误可能携带非秘密的
+`request_id` 用于关联。
 
 当前实现只在请求上下文内维护数值计数器
 `ctx._ai_redaction_restored_count` 和
@@ -561,3 +590,6 @@ chunk 保持 passthrough。如果上游遵守协议，这会保留占位符；�
 moderation 插件，它们的服务也可能接收或检查原始数据。当运维方要求脱敏服务成为
 唯一接收原始数据的外部组件时，还必须排除或明确信任这些服务；本插件无法强制保证
 整个路由都满足该属性。
+
+配置的 `endpoint` 同样位于管理员信任边界内。插件不执行 SSRF 或私网地址拒绝检查，
+因此必须把路由配置权限限制给受信任的管理员。

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/README.md
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/README.md
@@ -4,10 +4,12 @@
 
 ### Overview and ordering
 
-`bk-ai-sensitive-data-redaction` masks sensitive values in the final AI JSON
-request, sends only the masked request to the LLM, and restores exact known
-placeholders in the client response. The redaction service is the only external
-component that receives the original request values as part of this flow.
+`bk-ai-sensitive-data-redaction` sends the final AI JSON request to a redaction
+service, installs the service-returned body as the LLM request after contract
+validation, and restores exact known placeholders in the client response. The
+redaction service receives the original request values. The plugin relies on
+that trusted service to identify and replace every sensitive value; it cannot
+prove that the returned body is completely redacted.
 
 The plugin name is `bk-ai-sensitive-data-redaction` and its priority is `1039`.
 APISIX executes higher priorities first, so it runs after `ai-proxy-multi`
@@ -114,8 +116,10 @@ the same canonical UUID shape or the request is rejected with HTTP 400. It is
 forwarded only for third-party/Agent conversation correlation. It is never an
 APISIX storage key and never selects a mapping. Reusing one session ID across
 multiple turns does not persist or reuse replacements: every HTTP request has
-an independent mapping and stream state keyed by its unique `request_id`, and
-conversation history sent on a later turn is redacted again.
+an independent mapping and stream state stored only in its current request
+context, while its placeholders are namespaced by the unique `request_id`.
+There is no request-ID-keyed mapping lookup table. Conversation history sent on
+a later turn is redacted again.
 
 After request validation, APISIX makes one `POST` to the configured endpoint
 with `Content-Type: application/json` (or makes one such attempt if connection
@@ -177,6 +181,12 @@ Before changing the LLM request, the plugin verifies all of these conditions:
 - the compact encoded masked body is no greater than
   `max_request_body_bytes`.
 
+These checks establish response shape and mapping consistency, not redaction
+completeness. In particular, an unchanged `body` with an empty `replacements`
+array satisfies the contract. The redaction service is therefore inside the
+security trust boundary: if it misses a sensitive value, that value can be sent
+to the LLM.
+
 The original and masked encoded AI bodies are each limited by
 `max_request_body_bytes`; an oversized original is HTTP 413, while an oversized
 masked body is a third-party contract failure (HTTP 502). The full outbound
@@ -217,21 +227,26 @@ The processor preserves incomplete SSE frames and placeholder prefixes across
 transport chunks. Text fields receive raw originals; JSON-fragment fields
 receive JSON-escaped originals. Comment/keepalive frames, malformed events,
 unknown event shapes, and fields outside the list above pass through unchanged
-and therefore remain masked. An unterminated SSE remainder is bounded at 1 MiB;
-if it grows past that size before EOF, it is emitted unchanged and the remainder
-buffer is reset rather than rejecting the response.
+without additional restoration. An unterminated SSE remainder is bounded at
+1 MiB; if it grows past that size before EOF, it is emitted unchanged and the
+remainder buffer is reset rather than rejecting the response.
 
 Raw client-visible Bedrock `bedrock-converse` AWS EventStream and arbitrary
 passthrough streaming protocols are rejected with HTTP 400 before the redaction
-service or LLM is called. A Bedrock upstream is supported when `ai-proxy`
-converts it to one of the supported OpenAI or Anthropic client-visible SSE
-protocols, because this plugin sees and restores the converted SSE.
+service or LLM is called. The current checkout has no converter from Bedrock
+AWS EventStream to one of the supported client-visible SSE protocols, so
+streaming Bedrock is not currently supported. If such a converter is added in
+the future and runs before this response hook, the architecture can restore its
+converted OpenAI or Anthropic SSE output; that is a future conditional, not a
+current capability.
 
-At a protocol terminal event or transport EOF, pending state is flushed and
-the sensitive request mapping is cleared. If the client disconnects first, the
-AI streaming loop may stop before its EOF callback; no remaining buffered
-response can be delivered, and the request-local state is reclaimed with the
-request rather than persisted.
+A protocol terminal event finalizes and flushes pending processor state, but it
+does not clear the request mapping. The mapping and other sensitive state are
+cleared only when the response hook receives `eof=true`, when failure cleanup
+runs, or when the request is disposed. If the client disconnects first, the AI
+streaming loop may stop before its EOF callback; no remaining buffered response
+can be delivered, and the request-local state is reclaimed with the request
+rather than persisted.
 
 ### Failure, security, and observability
 
@@ -247,12 +262,17 @@ plugin failures:
   malformed or oversized response, changed protocol/model/stream, invalid
   mapping, or oversized masked body.
 
-Response-side restoration never substitutes an unmasked fallback. If complete
-JSON cannot be decoded or encoded, or the SSE restorer fails, the response
-continues with the still-masked data. After an SSE restorer failure, remaining
-chunks stay in masked passthrough mode. Unknown, altered, or incomplete
-placeholders are never restored; a pending incomplete placeholder is emitted
-still masked at a terminal event or EOF and counted as unresolved.
+Response-side restoration does not intentionally fetch or insert an unmasked
+fallback. If complete JSON cannot be decoded or encoded, or the SSE restorer
+fails, the plugin passes through the upstream bytes and any buffered placeholder
+data; after an SSE restorer failure, remaining chunks stay in passthrough mode.
+This preserves placeholders when the upstream honored the contract, but it
+cannot guarantee that passthrough bytes contain no sensitive data if the
+redaction service or upstream violated the contract. Earlier stream content
+that was successfully restored may already have been emitted before a later
+failure. Unknown, altered, or incomplete placeholders are never restored; a
+pending incomplete placeholder is emitted unchanged at a terminal event or EOF
+and counted as unresolved.
 
 All mappings, namespaces, session IDs, and SSE buffers live only in the current
 request context. The plugin does not use an Nginx shared dictionary, etcd,
@@ -272,19 +292,23 @@ correlation after sensitive mapping state is cleared.
 Use HTTPS with `ssl_verify=true` in production, authenticate the redaction
 service with a resolved secret rather than a literal credential, and authorize
 it for the minimum required caller/tenant scope. The redaction service sees the
-original sensitive values by design and must be operated as a trusted data
-processor. If `ai-request-rewrite`, `ai-rag`, or external moderation plugins
-are also bound, their services may receive or inspect raw data; do not bind
-them when the redaction service must be the only external raw-data recipient
-unless those services are explicitly trusted.
+original sensitive values and controls which values reach the LLM; it must be
+operated as a trusted data processor. APISIX validates the returned contract but
+does not determine whether every sensitive value was removed. If
+`ai-request-rewrite`, `ai-rag`, or external moderation plugins are also bound,
+their services may receive or inspect raw data. When operators intend the
+redaction service to be the sole external raw-data recipient, they must also
+exclude or explicitly trust those services; this plugin cannot enforce that
+route-wide property.
 
 ## 中文
 
 ### 概述与执行顺序
 
-`bk-ai-sensitive-data-redaction` 对最终 AI JSON 请求中的敏感值进行脱敏，只把
-脱敏后的请求发送给 LLM，并在客户端响应中精确还原已知占位符。在这条处理链路中，
-脱敏服务是唯一会接收原始请求值的外部组件。
+`bk-ai-sensitive-data-redaction` 将最终 AI JSON 请求发送给脱敏服务，在协议校验
+通过后把服务返回的 body 设置为 LLM 请求，并在客户端响应中精确还原已知占位符。
+脱敏服务会接收原始请求值。插件信任该服务能够识别并替换全部敏感值，无法证明返回
+body 已完整脱敏。
 
 插件名为 `bk-ai-sensitive-data-redaction`，优先级为 `1039`。APISIX 按优先级
 从高到低执行，因此本插件会在 `ai-proxy-multi`（`1041`）或 `ai-proxy`
@@ -385,9 +409,10 @@ request-ID 来源是否错误地在多个请求间复用了同一个 UUID。
 `session_id` 可选。`session_id_header` 中的非空值必须符合相同 UUID 格式，否则
 返回 HTTP 400。它只用于第三方服务或 Agent 多轮会话的关联，不会成为 APISIX
 存储键，也不会用于选择 mapping。多轮复用同一个 session ID 不会让 APISIX 持久化
-或复用 replacement：每个 HTTP 请求都按其唯一 `request_id` 持有独立的 mapping
-和流状态；后续轮次再次携带的会话历史会重新脱敏。占位符还原始终绑定当前 HTTP
-请求的 `request_id`，而不是 `session_id`。
+或复用 replacement：每个 HTTP 请求只在当前请求上下文中存储独立 mapping 和流
+状态，占位符则按唯一 `request_id` 划分命名空间；不存在以 request ID 为键的
+mapping 查询表。后续轮次再次携带的会话历史会重新脱敏。占位符还原始终绑定当前
+HTTP 请求的 `request_id`，而不是 `session_id`。
 
 请求校验通过后，APISIX 使用 `Content-Type: application/json` 向配置的 endpoint
 发起一次 `POST`（若连接或请求 I/O 失败，则只尝试一次）。只有配置 `auth_value`
@@ -445,6 +470,10 @@ request-ID 来源是否错误地在多个请求间复用了同一个 UUID。
 - 占位符与原始值的字符串字节总数不超过 `max_mapping_bytes`；以及
 - 脱敏 body 的紧凑编码不超过 `max_request_body_bytes`。
 
+这些校验只能确认响应结构和 mapping 一致性，不能确认脱敏完整性。例如，未修改的
+`body` 加空 `replacements` 数组也符合协议。因此脱敏服务位于安全信任边界内：如果
+它漏掉敏感值，该值可能被发送给 LLM。
+
 原始和脱敏 AI body 编码后都受 `max_request_body_bytes` 限制；原始 body 超限
 返回 HTTP 413，脱敏 body 超限属于第三方协议错误，返回 HTTP 502。完整的第三方
 出站请求 envelope 没有独立的 schema 限制。第三方响应的 wire body 按以下实现上限
@@ -479,18 +508,21 @@ min(27 + 6 * max_request_body_bytes
 
 处理器会跨传输 chunk 保留不完整 SSE frame 和占位符前缀。文本字段写入原始值，
 JSON fragment 字段写入经过 JSON 转义的原始值。注释/keepalive frame、格式错误的
-事件、未知事件结构以及上述列表以外的字段均原样透传，因此保持脱敏状态。未终止
-SSE remainder 的上限为 1 MiB；若它在 EOF 前超过该大小，插件会将其原样输出并重置
+事件、未知事件结构以及上述列表以外的字段均原样透传，不执行额外还原。未终止 SSE
+remainder 的上限为 1 MiB；若它在 EOF 前超过该大小，插件会将其原样输出并重置
 remainder buffer，而不是拒绝响应。
 
 客户端直接可见的 Bedrock `bedrock-converse` 原始 AWS EventStream 以及任意
 passthrough 流式协议，会在调用脱敏服务和 LLM 之前以 HTTP 400 拒绝。若 Bedrock
-上游被 `ai-proxy` 转换成上述受支持的 OpenAI 或 Anthropic 客户端可见 SSE 协议，
-则仍受支持，因为本插件看到并还原的是转换后的 SSE。
+AWS EventStream 需要转换成受支持的客户端可见 SSE，当前 checkout 并不存在此类
+converter，因此目前不支持 Bedrock 流式响应。若将来新增 converter，并在本响应
+hook 之前生成 OpenAI 或 Anthropic SSE，则该架构可以还原转换后的输出；这是未来
+条件，不是当前能力。
 
-遇到协议终止事件或传输 EOF 时，插件会 flush 待处理状态并清除敏感请求 mapping。
-若客户端提前断开，AI 流式循环可能在执行 EOF 回调前停止；此时剩余缓冲响应已无法
-发送，请求局部状态会随请求回收，而不会被持久化。
+协议终止事件只会 finalize 并 flush 待处理的 processor 状态，不会清除请求 mapping。
+只有响应 hook 收到 `eof=true`、执行失败清理，或请求被销毁时，mapping 和其他敏感
+状态才会清除。若客户端提前断开，AI 流式循环可能在执行 EOF 回调前停止；此时剩余
+缓冲响应已无法发送，请求局部状态会随请求回收，而不会被持久化。
 
 ### 失败、安全与可观测性
 
@@ -503,10 +535,12 @@ passthrough 流式协议，会在调用脱敏服务和 LLM 之前以 HTTP 400 �
 - HTTP 502：脱敏服务连接/请求/读取失败、返回非 200、响应格式错误或超限、修改了
   协议/model/stream、mapping 无效，或脱敏 body 超限。
 
-响应侧还原绝不会用未脱敏数据作为 fallback。完整 JSON 无法解码或编码，或 SSE
-还原器失败时，响应继续使用仍处于脱敏状态的数据；SSE 还原器失败后，后续 chunk
-保持脱敏 passthrough。未知、被修改或不完整的占位符永远不会被还原；协议终止事件
-或 EOF 到达时，待处理的不完整占位符会仍以脱敏形式输出，并计入 unresolved 数量。
+响应侧还原不会主动获取或插入未脱敏 fallback。完整 JSON 无法解码或编码，或 SSE
+还原器失败时，插件会透传上游字节和已缓冲的占位符数据；SSE 还原器失败后，后续
+chunk 保持 passthrough。如果上游遵守协议，这会保留占位符；但若脱敏服务或上游
+违反协议，插件无法保证透传字节中不存在敏感数据。发生后续失败前，先前成功还原的
+流式内容也可能已经发送。未知、被修改或不完整的占位符永远不会被还原；协议终止
+事件或 EOF 到达时，待处理的不完整占位符会原样输出，并计入 unresolved 数量。
 
 所有 mapping、命名空间、session ID 和 SSE buffer 只存在于当前请求上下文中。
 插件不使用 Nginx shared dictionary、etcd、Redis、文件或其他跨请求存储。禁止记录
@@ -521,7 +555,9 @@ passthrough 流式协议，会在调用脱敏服务和 LLM 之前以 HTTP 400 �
 状态清理后仍可在本地关联。
 
 生产环境应使用 HTTPS 和 `ssl_verify=true`，通过已解析的 secret 而不是字面量凭据
-认证脱敏服务，并按调用方/租户授予最小权限。脱敏服务按设计会看到原始敏感值，必须
-作为受信任的数据处理方运行。如果路由还绑定了 `ai-request-rewrite`、`ai-rag` 或
-外部 moderation 插件，它们的服务也可能接收或检查原始数据；当脱敏服务必须是唯一
-接收原始数据的外部组件时，不要绑定这些插件，除非明确信任相应服务。
+认证脱敏服务，并按调用方/租户授予最小权限。脱敏服务会看到原始敏感值并决定哪些值
+进入 LLM，必须作为受信任的数据处理方运行。APISIX 会校验返回协议，但不会判断是否
+删除了全部敏感值。如果路由还绑定了 `ai-request-rewrite`、`ai-rag` 或外部
+moderation 插件，它们的服务也可能接收或检查原始数据。当运维方要求脱敏服务成为
+唯一接收原始数据的外部组件时，还必须排除或明确信任这些服务；本插件无法强制保证
+整个路由都满足该属性。

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
@@ -34,6 +34,7 @@ local MAX_STREAM_KEYS = 1024
 local MAX_STREAM_PENDING_BYTES = 64 * 1024
 local INVALID_JSON_ERROR = "invalid JSON"
 local JSON_DEPTH_ERROR = "JSON nesting depth limit exceeded"
+local OUTPUT_SIZE_ERROR = "restored output size limit exceeded"
 local JSON_LITERALS = {"true", "false", "null"}
 local scan_json_text
 
@@ -88,7 +89,9 @@ local function find_token_candidate(value, namespace, search_from)
 end
 
 
-function _M.validate_mapping(namespace, body, replacements, max_entries, max_bytes)
+function _M.validate_mapping(
+    namespace, body, replacements, max_entries, max_bytes, max_output_bytes
+)
     if type(replacements) ~= "table" or not is_dense_array(replacements) then
         return nil, "replacements must be an array"
     end
@@ -134,7 +137,9 @@ function _M.validate_mapping(namespace, body, replacements, max_entries, max_byt
     end
 
     local present = {}
-    local scanned, _, scan_err = scan_json_text(raw_body, mapping, namespace, 0, present)
+    local scanned, _, scan_err = scan_json_text(
+        raw_body, mapping, namespace, 0, present, max_output_bytes
+    )
     if not scanned then
         return nil, "failed to scan masked body: " .. scan_err
     end
@@ -166,8 +171,9 @@ local function contains_known_token(value, mapping, namespace)
 end
 
 
-local function restore_string(value, mapping, namespace, present)
+local function restore_string(value, mapping, namespace, present, max_output_bytes)
     local out = {}
+    local output_bytes = 0
     local pos = 1
     local search_from = 1
     local count = 0
@@ -184,7 +190,12 @@ local function restore_string(value, mapping, namespace, present)
             if present then
                 present[candidate] = true
             end
-            out[#out + 1] = string_sub(value, pos, start_pos - 1)
+            local prefix = string_sub(value, pos, start_pos - 1)
+            output_bytes = output_bytes + #prefix + #original
+            if max_output_bytes and output_bytes > max_output_bytes then
+                return nil, nil, OUTPUT_SIZE_ERROR
+            end
+            out[#out + 1] = prefix
             out[#out + 1] = original
             pos = end_pos + 1
             count = count + 1
@@ -196,12 +207,23 @@ local function restore_string(value, mapping, namespace, present)
         return value, 0
     end
 
-    out[#out + 1] = string_sub(value, pos)
+    local suffix = string_sub(value, pos)
+    output_bytes = output_bytes + #suffix
+    if max_output_bytes and output_bytes > max_output_bytes then
+        return nil, nil, OUTPUT_SIZE_ERROR
+    end
+    out[#out + 1] = suffix
     return table_concat(out), count
 end
 
 
 local function append(scanner, value)
+    local output_bytes = scanner.output_bytes + #value
+    if scanner.max_output_bytes and output_bytes > scanner.max_output_bytes then
+        scanner.output_error = OUTPUT_SIZE_ERROR
+        return
+    end
+    scanner.output_bytes = output_bytes
     scanner.output[#scanner.output + 1] = value
 end
 
@@ -370,7 +392,37 @@ local function find_string_end(raw, start_pos)
 end
 
 
-local function parse_string(scanner, pos, is_key, depth)
+local function json_string_size(value)
+    local size = 2
+    for pos = 1, #value do
+        local byte = string_byte(value, pos)
+        if byte == 34 or byte == 92 then
+            size = size + 2
+        elseif byte < 32 then
+            size = size + 6
+        else
+            size = size + 1
+        end
+    end
+    return size
+end
+
+
+local function encode_restored_string(scanner, value)
+    if scanner.max_output_bytes
+            and scanner.output_bytes + json_string_size(value) >
+                scanner.max_output_bytes then
+        return nil, OUTPUT_SIZE_ERROR
+    end
+    local encoded = core.json.encode(value)
+    if not encoded then
+        return nil, INVALID_JSON_ERROR
+    end
+    return encoded
+end
+
+
+local function parse_string(scanner, pos, is_key, depth, path)
     local end_pos = find_string_end(scanner.raw, pos)
     if not end_pos then
         return nil, INVALID_JSON_ERROR
@@ -386,6 +438,24 @@ local function parse_string(scanner, pos, is_key, depth)
     if type(decoded) ~= "string" then
         return nil, INVALID_JSON_ERROR
     end
+
+    local replacement = scanner.replacements and scanner.replacements[path]
+    if replacement then
+        if replacement.original ~= decoded or replacement.used then
+            return nil, INVALID_JSON_ERROR
+        end
+        local encoded, encode_err = encode_restored_string(
+            scanner, replacement.restored
+        )
+        if not encoded then
+            return nil, encode_err
+        end
+        replacement.used = true
+        scanner.replacement_count = scanner.replacement_count + 1
+        append(scanner, encoded)
+        return end_pos + 1, 0
+    end
+
     if not contains_known_token(decoded, scanner.mapping, scanner.namespace) then
         append(scanner, raw_string)
         return end_pos + 1, 0
@@ -394,7 +464,12 @@ local function parse_string(scanner, pos, is_key, depth)
     local first_non_space = decoded:match("^%s*(.)")
     if first_non_space == "{" or first_non_space == "[" then
         local embedded, embedded_count, embedded_err = scan_json_text(
-            decoded, scanner.mapping, scanner.namespace, depth + 1, scanner.present
+            decoded,
+            scanner.mapping,
+            scanner.namespace,
+            depth + 1,
+            scanner.present,
+            scanner.max_output_bytes
         )
         if embedded then
             if embedded_count == 0 then
@@ -402,9 +477,9 @@ local function parse_string(scanner, pos, is_key, depth)
                 return end_pos + 1, 0
             end
 
-            local encoded = core.json.encode(embedded)
+            local encoded, encode_err = encode_restored_string(scanner, embedded)
             if not encoded then
-                return nil, INVALID_JSON_ERROR
+                return nil, encode_err
             end
             append(scanner, encoded)
             return end_pos + 1, embedded_count
@@ -414,17 +489,24 @@ local function parse_string(scanner, pos, is_key, depth)
         end
     end
 
-    local restored, count = restore_string(
-        decoded, scanner.mapping, scanner.namespace, scanner.present
+    local restored, count, restore_err = restore_string(
+        decoded,
+        scanner.mapping,
+        scanner.namespace,
+        scanner.present,
+        scanner.max_output_bytes
     )
+    if not restored then
+        return nil, restore_err
+    end
     if count == 0 then
         append(scanner, raw_string)
         return end_pos + 1, 0
     end
 
-    local encoded = core.json.encode(restored)
+    local encoded, encode_err = encode_restored_string(scanner, restored)
     if not encoded then
-        return nil, INVALID_JSON_ERROR
+        return nil, encode_err
     end
     append(scanner, encoded)
     return end_pos + 1, count
@@ -497,7 +579,7 @@ end
 
 local parse_value
 
-local function parse_array(scanner, pos, depth)
+local function parse_array(scanner, pos, depth, path)
     if depth >= MAX_JSON_DEPTH then
         return nil, JSON_DEPTH_ERROR
     end
@@ -510,8 +592,11 @@ local function parse_array(scanner, pos, depth)
     end
 
     local count = 0
+    local index = 1
     while true do
-        local next_pos, count_or_err = parse_value(scanner, pos, depth + 1)
+        local next_pos, count_or_err = parse_value(
+            scanner, pos, depth + 1, path .. "/" .. index
+        )
         if not next_pos then
             return nil, count_or_err
         end
@@ -529,11 +614,12 @@ local function parse_array(scanner, pos, depth)
         end
         append(scanner, ",")
         pos = append_whitespace(scanner, pos + 1)
+        index = index + 1
     end
 end
 
 
-local function parse_object(scanner, pos, depth)
+local function parse_object(scanner, pos, depth, path)
     if depth >= MAX_JSON_DEPTH then
         return nil, JSON_DEPTH_ERROR
     end
@@ -550,7 +636,17 @@ local function parse_object(scanner, pos, depth)
         if string_byte(scanner.raw, pos) ~= 34 then
             return nil, INVALID_JSON_ERROR
         end
-        local next_pos, count_or_err = parse_string(scanner, pos, true, depth)
+        local key_end = find_string_end(scanner.raw, pos)
+        if not key_end then
+            return nil, INVALID_JSON_ERROR
+        end
+        local key = core.json.decode(string_sub(scanner.raw, pos, key_end))
+        if type(key) ~= "string" then
+            return nil, INVALID_JSON_ERROR
+        end
+        local next_pos, count_or_err = parse_string(
+            scanner, pos, true, depth, path
+        )
         if not next_pos then
             return nil, count_or_err
         end
@@ -562,7 +658,10 @@ local function parse_object(scanner, pos, depth)
         append(scanner, ":")
         pos = append_whitespace(scanner, pos + 1)
 
-        next_pos, count_or_err = parse_value(scanner, pos, depth + 1)
+        local escaped_key = key:gsub("~", "~0"):gsub("/", "~1")
+        next_pos, count_or_err = parse_value(
+            scanner, pos, depth + 1, path .. "/" .. escaped_key
+        )
         if not next_pos then
             return nil, count_or_err
         end
@@ -584,17 +683,19 @@ local function parse_object(scanner, pos, depth)
 end
 
 
-parse_value = function(scanner, pos, depth)
+parse_value = function(scanner, pos, depth, path)
     pos = append_whitespace(scanner, pos)
     local byte = string_byte(scanner.raw, pos)
     if byte == 123 then
-        return parse_object(scanner, pos, depth)
+        return parse_object(scanner, pos, depth, path)
     end
     if byte == 91 then
-        return parse_array(scanner, pos, depth)
+        return parse_array(scanner, pos, depth, path)
     end
     if byte == 34 then
-        local next_pos, count_or_err = parse_string(scanner, pos, false, depth)
+        local next_pos, count_or_err = parse_string(
+            scanner, pos, false, depth, path
+        )
         if not next_pos then
             return nil, count_or_err
         end
@@ -619,7 +720,10 @@ parse_value = function(scanner, pos, depth)
 end
 
 
-scan_json_text = function(raw_json, mapping, namespace, initial_depth, present)
+scan_json_text = function(
+    raw_json, mapping, namespace, initial_depth, present, max_output_bytes,
+    replacements
+)
     local scanner = {
         raw = raw_json,
         length = #raw_json,
@@ -627,8 +731,13 @@ scan_json_text = function(raw_json, mapping, namespace, initial_depth, present)
         namespace = namespace,
         present = present,
         output = {},
+        output_bytes = 0,
+        max_output_bytes = max_output_bytes,
+        output_error = nil,
+        replacements = replacements,
+        replacement_count = 0,
     }
-    local pos, count_or_err = parse_value(scanner, 1, initial_depth or 0)
+    local pos, count_or_err = parse_value(scanner, 1, initial_depth or 0, "")
     if not pos then
         return nil, nil, count_or_err
     end
@@ -637,8 +746,12 @@ scan_json_text = function(raw_json, mapping, namespace, initial_depth, present)
     if pos <= scanner.length then
         return nil, nil, INVALID_JSON_ERROR
     end
+    if scanner.output_error then
+        return nil, nil, scanner.output_error
+    end
 
-    return table_concat(scanner.output), count_or_err
+    return table_concat(scanner.output), count_or_err, nil,
+           scanner.replacement_count
 end
 
 
@@ -693,13 +806,15 @@ local function semantic_signature(raw_json, namespace)
 end
 
 
-function _M.restore_json_text(raw_json, mapping, namespace)
+function _M.restore_json_text(raw_json, mapping, namespace, max_output_bytes)
     if type(raw_json) ~= "string" or type(mapping) ~= "table"
             or type(namespace) ~= "string" or namespace == "" then
         return nil, INVALID_JSON_ERROR
     end
 
-    local restored, count, err = scan_json_text(raw_json, mapping, namespace, 0)
+    local restored, count, err = scan_json_text(
+        raw_json, mapping, namespace, 0, nil, max_output_bytes
+    )
     if not restored then
         return nil, err
     end
@@ -708,7 +823,40 @@ function _M.restore_json_text(raw_json, mapping, namespace)
 end
 
 
-function _M.verify_redaction(original_json, masked_json, mapping, namespace)
+function _M.replace_json_strings(raw_json, replacements, max_output_bytes)
+    if type(raw_json) ~= "string" or type(replacements) ~= "table" then
+        return nil, INVALID_JSON_ERROR
+    end
+
+    local by_path = {}
+    local replacement_total = 0
+    for _, replacement in ipairs(replacements) do
+        if type(replacement) ~= "table" or type(replacement.path) ~= "string"
+                or type(replacement.original) ~= "string"
+                or type(replacement.restored) ~= "string"
+                or by_path[replacement.path] then
+            return nil, INVALID_JSON_ERROR
+        end
+        by_path[replacement.path] = replacement
+        replacement_total = replacement_total + 1
+    end
+
+    local restored, _, err, replacement_count = scan_json_text(
+        raw_json, {}, "_", 0, nil, max_output_bytes, by_path
+    )
+    if not restored then
+        return nil, err
+    end
+    if replacement_count ~= replacement_total then
+        return nil, INVALID_JSON_ERROR
+    end
+    return restored
+end
+
+
+function _M.verify_redaction(
+    original_json, masked_json, mapping, namespace, max_output_bytes
+)
     if type(original_json) ~= "string" or type(masked_json) ~= "string"
             or type(mapping) ~= "table" or type(namespace) ~= "string"
             or namespace == "" then
@@ -716,7 +864,7 @@ function _M.verify_redaction(original_json, masked_json, mapping, namespace)
     end
 
     local restored, _, restore_err = scan_json_text(
-        masked_json, mapping, namespace, 0
+        masked_json, mapping, namespace, 0, nil, max_output_bytes
     )
     if not restored then
         return nil, restore_err
@@ -806,7 +954,9 @@ local function find_pending_length(restorer, candidate)
 end
 
 
-local function restore_incremental(restorer, candidate, mode, final)
+local function restore_incremental(
+    restorer, candidate, mode, final, max_output_bytes
+)
     local pending = ""
     if not final and #candidate > 0 then
         local pending_length = find_pending_length(restorer, candidate)
@@ -821,16 +971,30 @@ local function restore_incremental(restorer, candidate, mode, final)
         mapping = restorer.json_fragment_mapping
     end
 
-    local output, count = restore_string(candidate, mapping, restorer.namespace)
+    local limit = restorer.max_output_bytes
+    if max_output_bytes and (not limit or max_output_bytes < limit) then
+        limit = max_output_bytes
+    end
+    local output, count, restore_err = restore_string(
+        candidate, mapping, restorer.namespace, nil, limit
+    )
+    if not output then
+        return nil, nil, nil, restore_err
+    end
     return output, pending, count
 end
 
 
-function StreamRestorer:feed(key, text, mode, final)
+function StreamRestorer:feed(key, text, mode, final, max_output_bytes)
     local state = self.states[key]
     local previous = state and state.pending or ""
     local candidate = previous .. (text or "")
-    local output, pending, count = restore_incremental(self, candidate, mode, final)
+    local output, pending, count, restore_err = restore_incremental(
+        self, candidate, mode, final, max_output_bytes
+    )
+    if not output then
+        return nil, nil, restore_err
+    end
 
     if final or pending == "" then
         if state then
@@ -862,7 +1026,7 @@ function StreamRestorer:feed(key, text, mode, final)
 end
 
 
-function _M.new_stream(mapping, namespace)
+function _M.new_stream(mapping, namespace, max_output_bytes)
     local token_pattern = "^" .. namespace:gsub("([^%w])", "%%%1") .. "[1-9][0-9]*__$"
     local stream_mapping = {}
     local json_fragment_mapping = {}
@@ -898,6 +1062,7 @@ function _M.new_stream(mapping, namespace)
             states = {},
             active_count = 0,
             pending_bytes = 0,
+            max_output_bytes = max_output_bytes,
         },
         StreamRestorer
     )

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
@@ -80,7 +80,7 @@ local function find_token_candidate(value, namespace, search_from)
             end
         end
 
-        search_from = digit_pos
+        search_from = start_pos + 1
     end
 end
 
@@ -223,6 +223,92 @@ local function append_whitespace(scanner, pos)
 end
 
 
+local function hex_value(byte)
+    if byte >= 48 and byte <= 57 then
+        return byte - 48
+    end
+    if byte >= 65 and byte <= 70 then
+        return byte - 55
+    end
+    if byte >= 97 and byte <= 102 then
+        return byte - 87
+    end
+end
+
+
+local function decode_hex_quad(raw, u_pos)
+    local value = 0
+    for offset = 1, 4 do
+        local digit = hex_value(string_byte(raw, u_pos + offset) or 0)
+        if not digit then
+            return
+        end
+        value = value * 16 + digit
+    end
+
+    return value
+end
+
+
+local function valid_continuation(byte)
+    return byte and byte >= 128 and byte <= 191
+end
+
+
+local function utf8_sequence_length(raw, pos)
+    local first = string_byte(raw, pos)
+    local second = string_byte(raw, pos + 1)
+    if first >= 194 and first <= 223 then
+        if valid_continuation(second) then
+            return 2
+        end
+        return
+    end
+
+    local third = string_byte(raw, pos + 2)
+    if first == 224 then
+        if second and second >= 160 and second <= 191
+                and valid_continuation(third) then
+            return 3
+        end
+        return
+    end
+    if (first >= 225 and first <= 236) or (first >= 238 and first <= 239) then
+        if valid_continuation(second) and valid_continuation(third) then
+            return 3
+        end
+        return
+    end
+    if first == 237 then
+        if second and second >= 128 and second <= 159
+                and valid_continuation(third) then
+            return 3
+        end
+        return
+    end
+
+    local fourth = string_byte(raw, pos + 3)
+    if first == 240 then
+        if second and second >= 144 and second <= 191
+                and valid_continuation(third) and valid_continuation(fourth) then
+            return 4
+        end
+        return
+    end
+    if first >= 241 and first <= 243 then
+        if valid_continuation(second) and valid_continuation(third)
+                and valid_continuation(fourth) then
+            return 4
+        end
+        return
+    end
+    if first == 244 and second and second >= 128 and second <= 143
+            and valid_continuation(third) and valid_continuation(fourth) then
+        return 4
+    end
+end
+
+
 local function find_string_end(raw, start_pos)
     local pos = start_pos + 1
     while pos <= #raw do
@@ -240,23 +326,41 @@ local function find_string_end(raw, start_pos)
                 return nil
             end
             if escaped == 117 then
-                for offset = 1, 4 do
-                    local hex = string_byte(raw, pos + offset)
-                    if not hex or not (
-                        (hex >= 48 and hex <= 57)
-                        or (hex >= 65 and hex <= 70)
-                        or (hex >= 97 and hex <= 102)
-                    ) then
+                local code_unit = decode_hex_quad(raw, pos)
+                if not code_unit then
+                    return nil
+                end
+                if code_unit >= 0xD800 and code_unit <= 0xDBFF then
+                    if string_byte(raw, pos + 5) ~= 92
+                            or string_byte(raw, pos + 6) ~= 117 then
                         return nil
                     end
+                    local low_surrogate = decode_hex_quad(raw, pos + 6)
+                    if not low_surrogate
+                            or low_surrogate < 0xDC00 or low_surrogate > 0xDFFF then
+                        return nil
+                    end
+                    pos = pos + 10
+
+                elseif code_unit >= 0xDC00 and code_unit <= 0xDFFF then
+                    return nil
+
+                else
+                    pos = pos + 4
                 end
-                pos = pos + 4
 
             elseif escaped ~= 34 and escaped ~= 47 and escaped ~= 92
                     and escaped ~= 98 and escaped ~= 102 and escaped ~= 110
                     and escaped ~= 114 and escaped ~= 116 then
                 return nil
             end
+
+        elseif byte >= 128 then
+            local sequence_length = utf8_sequence_length(raw, pos)
+            if not sequence_length then
+                return nil
+            end
+            pos = pos + sequence_length - 1
         end
         pos = pos + 1
     end
@@ -274,9 +378,7 @@ local function parse_string(scanner, pos, is_key, depth)
     end
 
     local raw_string = string_sub(scanner.raw, pos, end_pos)
-    if is_key or not contains_known_token(
-        raw_string, scanner.mapping, scanner.namespace
-    ) then
+    if is_key then
         append(scanner, raw_string)
         return end_pos + 1, 0
     end
@@ -284,6 +386,10 @@ local function parse_string(scanner, pos, is_key, depth)
     local decoded = core.json.decode(raw_string)
     if type(decoded) ~= "string" then
         return nil, INVALID_JSON_ERROR
+    end
+    if not contains_known_token(decoded, scanner.mapping, scanner.namespace) then
+        append(scanner, raw_string)
+        return end_pos + 1, 0
     end
 
     local first_non_space = decoded:match("^%s*(.)")
@@ -586,7 +692,7 @@ local function find_pending_length(restorer, candidate)
             break
         end
         namespace_start = start_pos
-        search_from = start_pos + #restorer.namespace
+        search_from = start_pos + 1
     end
     if namespace_start then
         local suffix = string_sub(candidate, namespace_start)

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
@@ -22,10 +22,17 @@ local math_max = math.max
 local pairs = pairs
 local rawget = rawget
 local setmetatable = setmetatable
+local string_byte = string.byte
+local string_find = string.find
+local string_sub = string.sub
 local table_concat = table.concat
 local type = type
 
 local _M = {}
+local MAX_JSON_DEPTH = 128
+local INVALID_JSON_ERROR = "invalid JSON"
+local JSON_DEPTH_ERROR = "JSON nesting depth limit exceeded"
+local JSON_LITERALS = {"true", "false", "null"}
 
 
 local function is_dense_array(value)
@@ -48,6 +55,36 @@ local function is_dense_array(value)
 end
 
 
+local function find_token_candidate(value, namespace, search_from)
+    while search_from <= #value do
+        local start_pos = string_find(value, namespace, search_from, true)
+        if not start_pos then
+            return
+        end
+
+        local digit_pos = start_pos + #namespace
+        local first_digit = string_byte(value, digit_pos)
+        if first_digit and first_digit >= 49 and first_digit <= 57 then
+            local end_pos = digit_pos + 1
+            while true do
+                local byte = string_byte(value, end_pos)
+                if not byte or byte < 48 or byte > 57 then
+                    break
+                end
+                end_pos = end_pos + 1
+            end
+
+            if string_sub(value, end_pos, end_pos + 1) == "__" then
+                return start_pos, end_pos + 1,
+                       string_sub(value, start_pos, end_pos + 1)
+            end
+        end
+
+        search_from = digit_pos
+    end
+end
+
+
 function _M.validate_mapping(namespace, body, replacements, max_entries, max_bytes)
     if type(replacements) ~= "table" or not is_dense_array(replacements) then
         return nil, "replacements must be an array"
@@ -63,9 +100,10 @@ function _M.validate_mapping(namespace, body, replacements, max_entries, max_byt
     end
 
     local mapping = {}
+    local tokens = {}
     local bytes = 0
     local token_pattern = "^" .. namespace:gsub("([^%w])", "%%%1") .. "[1-9][0-9]*__$"
-    for _, item in ipairs(replacements) do
+    for index, item in ipairs(replacements) do
         if type(item) ~= "table" or type(item.placeholder) ~= "string"
                 or type(item.original) ~= "string" then
             return nil, "invalid mapping entry"
@@ -79,99 +117,427 @@ function _M.validate_mapping(namespace, body, replacements, max_entries, max_byt
             return nil, "duplicate placeholder"
         end
 
-        if not encoded_body:find(item.placeholder, 1, true) then
-            return nil, "placeholder is absent from masked body"
-        end
-
         bytes = bytes + #item.placeholder + #item.original
         if bytes > max_bytes then
             return nil, "mapping byte limit exceeded"
         end
 
         mapping[item.placeholder] = item.original
+        tokens[index] = item.placeholder
+    end
+
+    local present = {}
+    local search_from = 1
+    while true do
+        local start_pos, end_pos, candidate = find_token_candidate(
+            encoded_body, namespace, search_from
+        )
+        if not start_pos then
+            break
+        end
+        if mapping[candidate] ~= nil then
+            present[candidate] = true
+        end
+        search_from = end_pos + 1
+    end
+
+    for _, token in ipairs(tokens) do
+        if not present[token] then
+            return nil, "placeholder is absent from masked body"
+        end
     end
 
     return mapping
 end
 
 
-local function contains_known_token(value, mapping)
-    for token in pairs(mapping) do
-        if value:find(token, 1, true) then
+local function contains_known_token(value, mapping, namespace)
+    local search_from = 1
+    while true do
+        local start_pos, end_pos, candidate = find_token_candidate(
+            value, namespace, search_from
+        )
+        if not start_pos then
+            return false
+        end
+        if mapping[candidate] ~= nil then
             return true
         end
+        search_from = end_pos + 1
     end
-
-    return false
 end
 
 
-local function restore_string(value, mapping)
+local function restore_string(value, mapping, namespace)
     local out = {}
     local pos = 1
+    local search_from = 1
     local count = 0
-    while pos <= #value do
-        local nearest_start
-        local nearest_token
-        for token in pairs(mapping) do
-            local start_pos = value:find(token, pos, true)
-            if start_pos and (not nearest_start or start_pos < nearest_start) then
-                nearest_start = start_pos
-                nearest_token = token
-            end
-        end
-
-        if not nearest_start then
-            out[#out + 1] = value:sub(pos)
+    while search_from <= #value do
+        local start_pos, end_pos, candidate = find_token_candidate(
+            value, namespace, search_from
+        )
+        if not start_pos then
             break
         end
 
-        out[#out + 1] = value:sub(pos, nearest_start - 1)
-        out[#out + 1] = mapping[nearest_token]
-        count = count + 1
-        pos = nearest_start + #nearest_token
+        local original = mapping[candidate]
+        if original ~= nil then
+            out[#out + 1] = string_sub(value, pos, start_pos - 1)
+            out[#out + 1] = original
+            pos = end_pos + 1
+            count = count + 1
+        end
+        search_from = end_pos + 1
     end
 
+    if count == 0 then
+        return value, 0
+    end
+
+    out[#out + 1] = string_sub(value, pos)
     return table_concat(out), count
 end
 
 
-local restore_value
-
-restore_value = function(value, mapping)
-    if type(value) == "table" then
-        local count = 0
-        for key, item in pairs(value) do
-            local restored_item, restored_count = restore_value(item, mapping)
-            value[key] = restored_item
-            count = count + restored_count
-        end
-
-        return value, count
-    end
-
-    if type(value) ~= "string" or not contains_known_token(value, mapping) then
-        return value, 0
-    end
-
-    local first_non_space = value:match("^%s*(.)")
-    if first_non_space == "{" or first_non_space == "[" then
-        local decoded = core.json.decode(value)
-        if type(decoded) == "table" then
-            local restored_decoded, count = restore_value(decoded, mapping)
-            local encoded = core.json.encode(restored_decoded)
-            if encoded then
-                return encoded, count
-            end
-        end
-    end
-
-    return restore_string(value, mapping)
+local function append(scanner, value)
+    scanner.output[#scanner.output + 1] = value
 end
 
 
-function _M.restore_json(value, mapping)
-    return restore_value(value, mapping)
+local function append_whitespace(scanner, pos)
+    local start_pos = pos
+    while pos <= scanner.length do
+        local byte = string_byte(scanner.raw, pos)
+        if byte ~= 32 and byte ~= 9 and byte ~= 10 and byte ~= 13 then
+            break
+        end
+        pos = pos + 1
+    end
+
+    if pos > start_pos then
+        append(scanner, string_sub(scanner.raw, start_pos, pos - 1))
+    end
+
+    return pos
+end
+
+
+local function find_string_end(raw, start_pos)
+    local pos = start_pos + 1
+    while pos <= #raw do
+        local byte = string_byte(raw, pos)
+        if byte == 34 then
+            return pos
+        end
+        if byte < 32 then
+            return nil
+        end
+        if byte == 92 then
+            pos = pos + 1
+            local escaped = string_byte(raw, pos)
+            if not escaped then
+                return nil
+            end
+            if escaped == 117 then
+                for offset = 1, 4 do
+                    local hex = string_byte(raw, pos + offset)
+                    if not hex or not (
+                        (hex >= 48 and hex <= 57)
+                        or (hex >= 65 and hex <= 70)
+                        or (hex >= 97 and hex <= 102)
+                    ) then
+                        return nil
+                    end
+                end
+                pos = pos + 4
+
+            elseif escaped ~= 34 and escaped ~= 47 and escaped ~= 92
+                    and escaped ~= 98 and escaped ~= 102 and escaped ~= 110
+                    and escaped ~= 114 and escaped ~= 116 then
+                return nil
+            end
+        end
+        pos = pos + 1
+    end
+
+    return nil
+end
+
+
+local scan_json_text
+
+local function parse_string(scanner, pos, is_key, depth)
+    local end_pos = find_string_end(scanner.raw, pos)
+    if not end_pos then
+        return nil, INVALID_JSON_ERROR
+    end
+
+    local raw_string = string_sub(scanner.raw, pos, end_pos)
+    if is_key or not contains_known_token(
+        raw_string, scanner.mapping, scanner.namespace
+    ) then
+        append(scanner, raw_string)
+        return end_pos + 1, 0
+    end
+
+    local decoded = core.json.decode(raw_string)
+    if type(decoded) ~= "string" then
+        return nil, INVALID_JSON_ERROR
+    end
+
+    local first_non_space = decoded:match("^%s*(.)")
+    if first_non_space == "{" or first_non_space == "[" then
+        local embedded, embedded_count, embedded_err = scan_json_text(
+            decoded, scanner.mapping, scanner.namespace, depth + 1
+        )
+        if embedded then
+            if embedded_count == 0 then
+                append(scanner, raw_string)
+                return end_pos + 1, 0
+            end
+
+            local encoded = core.json.encode(embedded)
+            if not encoded then
+                return nil, INVALID_JSON_ERROR
+            end
+            append(scanner, encoded)
+            return end_pos + 1, embedded_count
+        end
+        if embedded_err == JSON_DEPTH_ERROR then
+            return nil, embedded_err
+        end
+    end
+
+    local restored, count = restore_string(
+        decoded, scanner.mapping, scanner.namespace
+    )
+    if count == 0 then
+        append(scanner, raw_string)
+        return end_pos + 1, 0
+    end
+
+    local encoded = core.json.encode(restored)
+    if not encoded then
+        return nil, INVALID_JSON_ERROR
+    end
+    append(scanner, encoded)
+    return end_pos + 1, count
+end
+
+
+local function parse_number(scanner, pos)
+    local start_pos = pos
+    if string_byte(scanner.raw, pos) == 45 then
+        pos = pos + 1
+    end
+
+    local byte = string_byte(scanner.raw, pos)
+    if byte == 48 then
+        pos = pos + 1
+
+    elseif byte and byte >= 49 and byte <= 57 then
+        repeat
+            pos = pos + 1
+            byte = string_byte(scanner.raw, pos)
+        until not byte or byte < 48 or byte > 57
+
+    else
+        return nil, INVALID_JSON_ERROR
+    end
+
+    if string_byte(scanner.raw, pos) == 46 then
+        pos = pos + 1
+        byte = string_byte(scanner.raw, pos)
+        if not byte or byte < 48 or byte > 57 then
+            return nil, INVALID_JSON_ERROR
+        end
+        repeat
+            pos = pos + 1
+            byte = string_byte(scanner.raw, pos)
+        until not byte or byte < 48 or byte > 57
+    end
+
+    byte = string_byte(scanner.raw, pos)
+    if byte == 69 or byte == 101 then
+        pos = pos + 1
+        byte = string_byte(scanner.raw, pos)
+        if byte == 43 or byte == 45 then
+            pos = pos + 1
+        end
+        byte = string_byte(scanner.raw, pos)
+        if not byte or byte < 48 or byte > 57 then
+            return nil, INVALID_JSON_ERROR
+        end
+        repeat
+            pos = pos + 1
+            byte = string_byte(scanner.raw, pos)
+        until not byte or byte < 48 or byte > 57
+    end
+
+    append(scanner, string_sub(scanner.raw, start_pos, pos - 1))
+    return pos, 0
+end
+
+
+local parse_value
+
+local function parse_array(scanner, pos, depth)
+    if depth >= MAX_JSON_DEPTH then
+        return nil, JSON_DEPTH_ERROR
+    end
+
+    append(scanner, "[")
+    pos = append_whitespace(scanner, pos + 1)
+    if string_byte(scanner.raw, pos) == 93 then
+        append(scanner, "]")
+        return pos + 1, 0
+    end
+
+    local count = 0
+    while true do
+        local next_pos, count_or_err = parse_value(scanner, pos, depth + 1)
+        if not next_pos then
+            return nil, count_or_err
+        end
+        pos = next_pos
+        count = count + count_or_err
+        pos = append_whitespace(scanner, pos)
+
+        local byte = string_byte(scanner.raw, pos)
+        if byte == 93 then
+            append(scanner, "]")
+            return pos + 1, count
+        end
+        if byte ~= 44 then
+            return nil, INVALID_JSON_ERROR
+        end
+        append(scanner, ",")
+        pos = append_whitespace(scanner, pos + 1)
+    end
+end
+
+
+local function parse_object(scanner, pos, depth)
+    if depth >= MAX_JSON_DEPTH then
+        return nil, JSON_DEPTH_ERROR
+    end
+
+    append(scanner, "{")
+    pos = append_whitespace(scanner, pos + 1)
+    if string_byte(scanner.raw, pos) == 125 then
+        append(scanner, "}")
+        return pos + 1, 0
+    end
+
+    local count = 0
+    while true do
+        if string_byte(scanner.raw, pos) ~= 34 then
+            return nil, INVALID_JSON_ERROR
+        end
+        local next_pos, count_or_err = parse_string(scanner, pos, true, depth)
+        if not next_pos then
+            return nil, count_or_err
+        end
+        pos = next_pos
+        pos = append_whitespace(scanner, pos)
+        if string_byte(scanner.raw, pos) ~= 58 then
+            return nil, INVALID_JSON_ERROR
+        end
+        append(scanner, ":")
+        pos = append_whitespace(scanner, pos + 1)
+
+        next_pos, count_or_err = parse_value(scanner, pos, depth + 1)
+        if not next_pos then
+            return nil, count_or_err
+        end
+        pos = next_pos
+        count = count + count_or_err
+        pos = append_whitespace(scanner, pos)
+
+        local byte = string_byte(scanner.raw, pos)
+        if byte == 125 then
+            append(scanner, "}")
+            return pos + 1, count
+        end
+        if byte ~= 44 then
+            return nil, INVALID_JSON_ERROR
+        end
+        append(scanner, ",")
+        pos = append_whitespace(scanner, pos + 1)
+    end
+end
+
+
+parse_value = function(scanner, pos, depth)
+    pos = append_whitespace(scanner, pos)
+    local byte = string_byte(scanner.raw, pos)
+    if byte == 123 then
+        return parse_object(scanner, pos, depth)
+    end
+    if byte == 91 then
+        return parse_array(scanner, pos, depth)
+    end
+    if byte == 34 then
+        local next_pos, count_or_err = parse_string(scanner, pos, false, depth)
+        if not next_pos then
+            return nil, count_or_err
+        end
+        return next_pos, count_or_err
+    end
+    if byte == 45 or (byte and byte >= 48 and byte <= 57) then
+        local next_pos, count_or_err = parse_number(scanner, pos)
+        if not next_pos then
+            return nil, count_or_err
+        end
+        return next_pos, count_or_err
+    end
+
+    for _, literal in ipairs(JSON_LITERALS) do
+        if string_sub(scanner.raw, pos, pos + #literal - 1) == literal then
+            append(scanner, literal)
+            return pos + #literal, 0
+        end
+    end
+
+    return nil, INVALID_JSON_ERROR
+end
+
+
+scan_json_text = function(raw_json, mapping, namespace, initial_depth)
+    local scanner = {
+        raw = raw_json,
+        length = #raw_json,
+        mapping = mapping,
+        namespace = namespace,
+        output = {},
+    }
+    local pos, count_or_err = parse_value(scanner, 1, initial_depth or 0)
+    if not pos then
+        return nil, nil, count_or_err
+    end
+
+    pos = append_whitespace(scanner, pos)
+    if pos <= scanner.length then
+        return nil, nil, INVALID_JSON_ERROR
+    end
+
+    return table_concat(scanner.output), count_or_err
+end
+
+
+function _M.restore_json_text(raw_json, mapping, namespace)
+    if type(raw_json) ~= "string" or type(mapping) ~= "table"
+            or type(namespace) ~= "string" or namespace == "" then
+        return nil, INVALID_JSON_ERROR
+    end
+
+    local restored, count, err = scan_json_text(raw_json, mapping, namespace, 0)
+    if not restored then
+        return nil, err
+    end
+
+    return restored, count
 end
 
 
@@ -179,30 +545,63 @@ local StreamRestorer = {}
 StreamRestorer.__index = StreamRestorer
 
 
-local function find_pending_length(candidate, tokens, max_token_length)
-    local last_complete_end = 0
-    for _, token in ipairs(tokens) do
-        local search_from = 1
-        while search_from <= #candidate do
-            local start_pos = candidate:find(token, search_from, true)
-            if not start_pos then
-                break
-            end
+local function is_known_token_prefix(restorer, value)
+    local node = restorer.token_prefix_trie
+    for index = 1, #value do
+        node = node[string_byte(value, index)]
+        if not node then
+            return false
+        end
+    end
 
-            last_complete_end = math_max(last_complete_end, start_pos + #token - 1)
-            search_from = start_pos + #token
+    return not node.complete
+end
+
+
+local function find_pending_length(restorer, candidate)
+    if not restorer.has_tokens then
+        return 0
+    end
+
+    local last_complete_end = 0
+    local search_from = 1
+    while true do
+        local start_pos, end_pos, token = find_token_candidate(
+            candidate, restorer.namespace, search_from
+        )
+        if not start_pos then
+            break
+        end
+        if restorer.mapping[token] ~= nil then
+            last_complete_end = end_pos
+        end
+        search_from = end_pos + 1
+    end
+
+    local namespace_start
+    search_from = last_complete_end + 1
+    while true do
+        local start_pos = string_find(candidate, restorer.namespace, search_from, true)
+        if not start_pos then
+            break
+        end
+        namespace_start = start_pos
+        search_from = start_pos + #restorer.namespace
+    end
+    if namespace_start then
+        local suffix = string_sub(candidate, namespace_start)
+        if is_known_token_prefix(restorer, suffix) then
+            return #suffix
         end
     end
 
     local first_possible = math_max(
-        last_complete_end + 1, #candidate - max_token_length + 2, 1
+        last_complete_end + 1, #candidate - #restorer.namespace + 2, 1
     )
     for start_pos = first_possible, #candidate do
-        local suffix = candidate:sub(start_pos)
-        for _, token in ipairs(tokens) do
-            if #suffix < #token and token:sub(1, #suffix) == suffix then
-                return #suffix
-            end
+        local suffix = string_sub(candidate, start_pos)
+        if string_sub(restorer.namespace, 1, #suffix) == suffix then
+            return #suffix
         end
     end
 
@@ -213,12 +612,10 @@ end
 local function restore_incremental(restorer, candidate, mode, final)
     local pending = ""
     if not final and #candidate > 0 then
-        local pending_length = find_pending_length(
-            candidate, restorer.tokens, restorer.max_token_length
-        )
+        local pending_length = find_pending_length(restorer, candidate)
         if pending_length > 0 then
-            pending = candidate:sub(-pending_length)
-            candidate = candidate:sub(1, #candidate - pending_length)
+            pending = string_sub(candidate, -pending_length)
+            candidate = string_sub(candidate, 1, #candidate - pending_length)
         end
     end
 
@@ -227,7 +624,7 @@ local function restore_incremental(restorer, candidate, mode, final)
         mapping = restorer.json_fragment_mapping
     end
 
-    local output, count = restore_string(candidate, mapping)
+    local output, count = restore_string(candidate, mapping, restorer.namespace)
     return output, pending, count
 end
 
@@ -250,8 +647,8 @@ function _M.new_stream(mapping, namespace)
     local token_pattern = "^" .. namespace:gsub("([^%w])", "%%%1") .. "[1-9][0-9]*__$"
     local stream_mapping = {}
     local json_fragment_mapping = {}
-    local tokens = {}
-    local max_token_length = 0
+    local token_prefix_trie = {}
+    local has_tokens = false
 
     for token, original in pairs(mapping) do
         if type(token) == "string" and type(original) == "string"
@@ -259,10 +656,16 @@ function _M.new_stream(mapping, namespace)
             stream_mapping[token] = original
 
             local encoded_original = core.json.encode(original)
-            json_fragment_mapping[token] = encoded_original:sub(2, -2)
+            json_fragment_mapping[token] = string_sub(encoded_original, 2, -2)
 
-            tokens[#tokens + 1] = token
-            max_token_length = math_max(max_token_length, #token)
+            local node = token_prefix_trie
+            for index = 1, #token do
+                local byte = string_byte(token, index)
+                node[byte] = node[byte] or {}
+                node = node[byte]
+            end
+            node.complete = true
+            has_tokens = true
         end
     end
 
@@ -270,8 +673,9 @@ function _M.new_stream(mapping, namespace)
         {
             mapping = stream_mapping,
             json_fragment_mapping = json_fragment_mapping,
-            tokens = tokens,
-            max_token_length = max_token_length,
+            namespace = namespace,
+            token_prefix_trie = token_prefix_trie,
+            has_tokens = has_tokens,
             states = {},
         },
         StreamRestorer

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
@@ -20,6 +20,7 @@ local core = require("apisix.core")
 local ipairs = ipairs
 local math_max = math.max
 local pairs = pairs
+local rawget = rawget
 local setmetatable = setmetatable
 local table_concat = table.concat
 local type = type
@@ -27,8 +28,28 @@ local type = type
 local _M = {}
 
 
+local function is_dense_array(value)
+    local count = 0
+    for key in pairs(value) do
+        if type(key) ~= "number" or key < 1 or key % 1 ~= 0 then
+            return false
+        end
+
+        count = count + 1
+    end
+
+    for index = 1, count do
+        if rawget(value, index) == nil then
+            return false
+        end
+    end
+
+    return true
+end
+
+
 function _M.validate_mapping(namespace, body, replacements, max_entries, max_bytes)
-    if type(replacements) ~= "table" then
+    if type(replacements) ~= "table" or not is_dense_array(replacements) then
         return nil, "replacements must be an array"
     end
 

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
@@ -33,6 +33,7 @@ local MAX_JSON_DEPTH = 128
 local INVALID_JSON_ERROR = "invalid JSON"
 local JSON_DEPTH_ERROR = "JSON nesting depth limit exceeded"
 local JSON_LITERALS = {"true", "false", "null"}
+local scan_json_text
 
 
 local function is_dense_array(value)
@@ -94,9 +95,13 @@ function _M.validate_mapping(namespace, body, replacements, max_entries, max_byt
         return nil, "mapping entry limit exceeded"
     end
 
-    local encoded_body, encode_err = core.json.encode(body)
-    if not encoded_body then
-        return nil, "failed to encode masked body: " .. encode_err
+    local raw_body = body
+    if type(raw_body) ~= "string" then
+        local encode_err
+        raw_body, encode_err = core.json.encode(body)
+        if not raw_body then
+            return nil, "failed to encode masked body: " .. encode_err
+        end
     end
 
     local mapping = {}
@@ -127,18 +132,9 @@ function _M.validate_mapping(namespace, body, replacements, max_entries, max_byt
     end
 
     local present = {}
-    local search_from = 1
-    while true do
-        local start_pos, end_pos, candidate = find_token_candidate(
-            encoded_body, namespace, search_from
-        )
-        if not start_pos then
-            break
-        end
-        if mapping[candidate] ~= nil then
-            present[candidate] = true
-        end
-        search_from = end_pos + 1
+    local scanned, _, scan_err = scan_json_text(raw_body, mapping, namespace, 0, present)
+    if not scanned then
+        return nil, "failed to scan masked body: " .. scan_err
     end
 
     for _, token in ipairs(tokens) do
@@ -168,7 +164,7 @@ local function contains_known_token(value, mapping, namespace)
 end
 
 
-local function restore_string(value, mapping, namespace)
+local function restore_string(value, mapping, namespace, present)
     local out = {}
     local pos = 1
     local search_from = 1
@@ -183,6 +179,9 @@ local function restore_string(value, mapping, namespace)
 
         local original = mapping[candidate]
         if original ~= nil then
+            if present then
+                present[candidate] = true
+            end
             out[#out + 1] = string_sub(value, pos, start_pos - 1)
             out[#out + 1] = original
             pos = end_pos + 1
@@ -369,8 +368,6 @@ local function find_string_end(raw, start_pos)
 end
 
 
-local scan_json_text
-
 local function parse_string(scanner, pos, is_key, depth)
     local end_pos = find_string_end(scanner.raw, pos)
     if not end_pos then
@@ -395,7 +392,7 @@ local function parse_string(scanner, pos, is_key, depth)
     local first_non_space = decoded:match("^%s*(.)")
     if first_non_space == "{" or first_non_space == "[" then
         local embedded, embedded_count, embedded_err = scan_json_text(
-            decoded, scanner.mapping, scanner.namespace, depth + 1
+            decoded, scanner.mapping, scanner.namespace, depth + 1, scanner.present
         )
         if embedded then
             if embedded_count == 0 then
@@ -416,7 +413,7 @@ local function parse_string(scanner, pos, is_key, depth)
     end
 
     local restored, count = restore_string(
-        decoded, scanner.mapping, scanner.namespace
+        decoded, scanner.mapping, scanner.namespace, scanner.present
     )
     if count == 0 then
         append(scanner, raw_string)
@@ -610,12 +607,13 @@ parse_value = function(scanner, pos, depth)
 end
 
 
-scan_json_text = function(raw_json, mapping, namespace, initial_depth)
+scan_json_text = function(raw_json, mapping, namespace, initial_depth, present)
     local scanner = {
         raw = raw_json,
         length = #raw_json,
         mapping = mapping,
         namespace = namespace,
+        present = present,
         output = {},
     }
     local pos, count_or_err = parse_value(scanner, 1, initial_depth or 0)

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
@@ -30,6 +30,8 @@ local type = type
 
 local _M = {}
 local MAX_JSON_DEPTH = 128
+local MAX_STREAM_KEYS = 1024
+local MAX_STREAM_PENDING_BYTES = 64 * 1024
 local INVALID_JSON_ERROR = "invalid JSON"
 local JSON_DEPTH_ERROR = "JSON nesting depth limit exceeded"
 local JSON_LITERALS = {"true", "false", "null"}
@@ -825,14 +827,36 @@ end
 
 
 function StreamRestorer:feed(key, text, mode, final)
-    local state = self.states[key] or {pending = ""}
-    self.states[key] = state
-    local candidate = state.pending .. (text or "")
+    local state = self.states[key]
+    local previous = state and state.pending or ""
+    local candidate = previous .. (text or "")
     local output, pending, count = restore_incremental(self, candidate, mode, final)
-    state.pending = pending
-    if final then
-        self.states[key] = nil
+
+    if final or pending == "" then
+        if state then
+            self.states[key] = nil
+            self.active_count = self.active_count - 1
+            self.pending_bytes = self.pending_bytes - #previous
+        end
+        return output, count
     end
+
+    if not state and self.active_count >= MAX_STREAM_KEYS then
+        return nil, nil, "stream active key limit exceeded"
+    end
+
+    local pending_bytes = self.pending_bytes - #previous + #pending
+    if pending_bytes > MAX_STREAM_PENDING_BYTES then
+        return nil, nil, "stream pending byte limit exceeded"
+    end
+
+    if not state then
+        state = {}
+        self.states[key] = state
+        self.active_count = self.active_count + 1
+    end
+    state.pending = pending
+    self.pending_bytes = pending_bytes
 
     return output, count
 end
@@ -872,6 +896,8 @@ function _M.new_stream(mapping, namespace)
             token_prefix_trie = token_prefix_trie,
             has_tokens = has_tokens,
             states = {},
+            active_count = 0,
+            pending_bytes = 0,
         },
         StreamRestorer
     )

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
@@ -429,57 +429,67 @@ local function parse_string(scanner, pos, is_key, depth)
 end
 
 
-local function parse_number(scanner, pos)
-    local start_pos = pos
-    if string_byte(scanner.raw, pos) == 45 then
+local function find_number_end(raw, pos)
+    if string_byte(raw, pos) == 45 then
         pos = pos + 1
     end
 
-    local byte = string_byte(scanner.raw, pos)
+    local byte = string_byte(raw, pos)
     if byte == 48 then
         pos = pos + 1
 
     elseif byte and byte >= 49 and byte <= 57 then
         repeat
             pos = pos + 1
-            byte = string_byte(scanner.raw, pos)
+            byte = string_byte(raw, pos)
         until not byte or byte < 48 or byte > 57
 
     else
         return nil, INVALID_JSON_ERROR
     end
 
-    if string_byte(scanner.raw, pos) == 46 then
+    if string_byte(raw, pos) == 46 then
         pos = pos + 1
-        byte = string_byte(scanner.raw, pos)
+        byte = string_byte(raw, pos)
         if not byte or byte < 48 or byte > 57 then
             return nil, INVALID_JSON_ERROR
         end
         repeat
             pos = pos + 1
-            byte = string_byte(scanner.raw, pos)
+            byte = string_byte(raw, pos)
         until not byte or byte < 48 or byte > 57
     end
 
-    byte = string_byte(scanner.raw, pos)
+    byte = string_byte(raw, pos)
     if byte == 69 or byte == 101 then
         pos = pos + 1
-        byte = string_byte(scanner.raw, pos)
+        byte = string_byte(raw, pos)
         if byte == 43 or byte == 45 then
             pos = pos + 1
         end
-        byte = string_byte(scanner.raw, pos)
+        byte = string_byte(raw, pos)
         if not byte or byte < 48 or byte > 57 then
             return nil, INVALID_JSON_ERROR
         end
         repeat
             pos = pos + 1
-            byte = string_byte(scanner.raw, pos)
+            byte = string_byte(raw, pos)
         until not byte or byte < 48 or byte > 57
     end
 
-    append(scanner, string_sub(scanner.raw, start_pos, pos - 1))
-    return pos, 0
+    return pos
+end
+
+
+local function parse_number(scanner, pos)
+    local start_pos = pos
+    local next_pos, err = find_number_end(scanner.raw, pos)
+    if not next_pos then
+        return nil, err
+    end
+
+    append(scanner, string_sub(scanner.raw, start_pos, next_pos - 1))
+    return next_pos, 0
 end
 
 
@@ -630,6 +640,57 @@ scan_json_text = function(raw_json, mapping, namespace, initial_depth, present)
 end
 
 
+local function semantic_signature(raw_json, namespace)
+    local scanned, _, scan_err = scan_json_text(raw_json, {}, namespace, 0)
+    if not scanned then
+        return nil, scan_err
+    end
+
+    local tokens = {}
+    local pos = 1
+    while pos <= #raw_json do
+        local byte = string_byte(raw_json, pos)
+        if byte == 32 or byte == 9 or byte == 10 or byte == 13 then
+            pos = pos + 1
+
+        elseif byte == 34 then
+            local end_pos = find_string_end(raw_json, pos)
+            local decoded = core.json.decode(string_sub(raw_json, pos, end_pos))
+            local encoded = core.json.encode(decoded)
+            tokens[#tokens + 1] = "s" .. #encoded .. ":" .. encoded
+            pos = end_pos + 1
+
+        elseif byte == 45 or (byte >= 48 and byte <= 57) then
+            local end_pos = find_number_end(raw_json, pos)
+            local number = string_sub(raw_json, pos, end_pos - 1)
+            tokens[#tokens + 1] = "n" .. #number .. ":" .. number
+            pos = end_pos
+
+        elseif byte == 123 or byte == 125 or byte == 91 or byte == 93
+                or byte == 44 or byte == 58 then
+            tokens[#tokens + 1] = "p" .. string_sub(raw_json, pos, pos)
+            pos = pos + 1
+
+        else
+            local matched
+            for _, literal in ipairs(JSON_LITERALS) do
+                if string_sub(raw_json, pos, pos + #literal - 1) == literal then
+                    tokens[#tokens + 1] = "l" .. literal
+                    pos = pos + #literal
+                    matched = true
+                    break
+                end
+            end
+            if not matched then
+                return nil, INVALID_JSON_ERROR
+            end
+        end
+    end
+
+    return table_concat(tokens, "\0")
+end
+
+
 function _M.restore_json_text(raw_json, mapping, namespace)
     if type(raw_json) ~= "string" or type(mapping) ~= "table"
             or type(namespace) ~= "string" or namespace == "" then
@@ -642,6 +703,36 @@ function _M.restore_json_text(raw_json, mapping, namespace)
     end
 
     return restored, count
+end
+
+
+function _M.verify_redaction(original_json, masked_json, mapping, namespace)
+    if type(original_json) ~= "string" or type(masked_json) ~= "string"
+            or type(mapping) ~= "table" or type(namespace) ~= "string"
+            or namespace == "" then
+        return nil, INVALID_JSON_ERROR
+    end
+
+    local restored, _, restore_err = scan_json_text(
+        masked_json, mapping, namespace, 0
+    )
+    if not restored then
+        return nil, restore_err
+    end
+
+    local original_signature, original_err = semantic_signature(original_json, namespace)
+    if not original_signature then
+        return nil, original_err
+    end
+    local restored_signature, restored_err = semantic_signature(restored, namespace)
+    if not restored_signature then
+        return nil, restored_err
+    end
+    if original_signature ~= restored_signature then
+        return nil, "redaction service changed non-sensitive request content"
+    end
+
+    return true
 end
 
 

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/restorer.lua
@@ -1,0 +1,261 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+
+local core = require("apisix.core")
+local ipairs = ipairs
+local math_max = math.max
+local pairs = pairs
+local setmetatable = setmetatable
+local table_concat = table.concat
+local type = type
+
+local _M = {}
+
+
+function _M.validate_mapping(namespace, body, replacements, max_entries, max_bytes)
+    if type(replacements) ~= "table" then
+        return nil, "replacements must be an array"
+    end
+
+    if #replacements > max_entries then
+        return nil, "mapping entry limit exceeded"
+    end
+
+    local encoded_body, encode_err = core.json.encode(body)
+    if not encoded_body then
+        return nil, "failed to encode masked body: " .. encode_err
+    end
+
+    local mapping = {}
+    local bytes = 0
+    local token_pattern = "^" .. namespace:gsub("([^%w])", "%%%1") .. "[1-9][0-9]*__$"
+    for _, item in ipairs(replacements) do
+        if type(item) ~= "table" or type(item.placeholder) ~= "string"
+                or type(item.original) ~= "string" then
+            return nil, "invalid mapping entry"
+        end
+
+        if not item.placeholder:match(token_pattern) then
+            return nil, "placeholder is outside request namespace"
+        end
+
+        if mapping[item.placeholder] ~= nil then
+            return nil, "duplicate placeholder"
+        end
+
+        if not encoded_body:find(item.placeholder, 1, true) then
+            return nil, "placeholder is absent from masked body"
+        end
+
+        bytes = bytes + #item.placeholder + #item.original
+        if bytes > max_bytes then
+            return nil, "mapping byte limit exceeded"
+        end
+
+        mapping[item.placeholder] = item.original
+    end
+
+    return mapping
+end
+
+
+local function contains_known_token(value, mapping)
+    for token in pairs(mapping) do
+        if value:find(token, 1, true) then
+            return true
+        end
+    end
+
+    return false
+end
+
+
+local function restore_string(value, mapping)
+    local out = {}
+    local pos = 1
+    local count = 0
+    while pos <= #value do
+        local nearest_start
+        local nearest_token
+        for token in pairs(mapping) do
+            local start_pos = value:find(token, pos, true)
+            if start_pos and (not nearest_start or start_pos < nearest_start) then
+                nearest_start = start_pos
+                nearest_token = token
+            end
+        end
+
+        if not nearest_start then
+            out[#out + 1] = value:sub(pos)
+            break
+        end
+
+        out[#out + 1] = value:sub(pos, nearest_start - 1)
+        out[#out + 1] = mapping[nearest_token]
+        count = count + 1
+        pos = nearest_start + #nearest_token
+    end
+
+    return table_concat(out), count
+end
+
+
+local restore_value
+
+restore_value = function(value, mapping)
+    if type(value) == "table" then
+        local count = 0
+        for key, item in pairs(value) do
+            local restored_item, restored_count = restore_value(item, mapping)
+            value[key] = restored_item
+            count = count + restored_count
+        end
+
+        return value, count
+    end
+
+    if type(value) ~= "string" or not contains_known_token(value, mapping) then
+        return value, 0
+    end
+
+    local first_non_space = value:match("^%s*(.)")
+    if first_non_space == "{" or first_non_space == "[" then
+        local decoded = core.json.decode(value)
+        if type(decoded) == "table" then
+            local restored_decoded, count = restore_value(decoded, mapping)
+            local encoded = core.json.encode(restored_decoded)
+            if encoded then
+                return encoded, count
+            end
+        end
+    end
+
+    return restore_string(value, mapping)
+end
+
+
+function _M.restore_json(value, mapping)
+    return restore_value(value, mapping)
+end
+
+
+local StreamRestorer = {}
+StreamRestorer.__index = StreamRestorer
+
+
+local function find_pending_length(candidate, tokens, max_token_length)
+    local last_complete_end = 0
+    for _, token in ipairs(tokens) do
+        local search_from = 1
+        while search_from <= #candidate do
+            local start_pos = candidate:find(token, search_from, true)
+            if not start_pos then
+                break
+            end
+
+            last_complete_end = math_max(last_complete_end, start_pos + #token - 1)
+            search_from = start_pos + #token
+        end
+    end
+
+    local first_possible = math_max(
+        last_complete_end + 1, #candidate - max_token_length + 2, 1
+    )
+    for start_pos = first_possible, #candidate do
+        local suffix = candidate:sub(start_pos)
+        for _, token in ipairs(tokens) do
+            if #suffix < #token and token:sub(1, #suffix) == suffix then
+                return #suffix
+            end
+        end
+    end
+
+    return 0
+end
+
+
+local function restore_incremental(restorer, candidate, mode, final)
+    local pending = ""
+    if not final and #candidate > 0 then
+        local pending_length = find_pending_length(
+            candidate, restorer.tokens, restorer.max_token_length
+        )
+        if pending_length > 0 then
+            pending = candidate:sub(-pending_length)
+            candidate = candidate:sub(1, #candidate - pending_length)
+        end
+    end
+
+    local mapping = restorer.mapping
+    if mode == "json_fragment" then
+        mapping = restorer.json_fragment_mapping
+    end
+
+    local output, count = restore_string(candidate, mapping)
+    return output, pending, count
+end
+
+
+function StreamRestorer:feed(key, text, mode, final)
+    local state = self.states[key] or {pending = ""}
+    self.states[key] = state
+    local candidate = state.pending .. (text or "")
+    local output, pending, count = restore_incremental(self, candidate, mode, final)
+    state.pending = pending
+    if final then
+        self.states[key] = nil
+    end
+
+    return output, count
+end
+
+
+function _M.new_stream(mapping, namespace)
+    local token_pattern = "^" .. namespace:gsub("([^%w])", "%%%1") .. "[1-9][0-9]*__$"
+    local stream_mapping = {}
+    local json_fragment_mapping = {}
+    local tokens = {}
+    local max_token_length = 0
+
+    for token, original in pairs(mapping) do
+        if type(token) == "string" and type(original) == "string"
+                and token:match(token_pattern) then
+            stream_mapping[token] = original
+
+            local encoded_original = core.json.encode(original)
+            json_fragment_mapping[token] = encoded_original:sub(2, -2)
+
+            tokens[#tokens + 1] = token
+            max_token_length = math_max(max_token_length, #token)
+        end
+    end
+
+    return setmetatable(
+        {
+            mapping = stream_mapping,
+            json_fragment_mapping = json_fragment_mapping,
+            tokens = tokens,
+            max_token_length = max_token_length,
+            states = {},
+        },
+        StreamRestorer
+    )
+end
+
+
+return _M

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/sse.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/sse.lua
@@ -159,6 +159,21 @@ local function is_optional_string(value)
 end
 
 
+local function is_absent_chat_value(value)
+    return value == nil or value == core.json.null
+end
+
+
+local function is_optional_chat_index(value)
+    return is_absent_chat_value(value) or type(value) == "number"
+end
+
+
+local function is_optional_chat_string(value)
+    return is_absent_chat_value(value) or type(value) == "string"
+end
+
+
 local function is_valid_chat_value(value)
     if value.choices == nil then
         return true
@@ -168,42 +183,43 @@ local function is_valid_chat_value(value)
     end
 
     for _, choice in ipairs(value.choices) do
-        if type(choice) ~= "table" or not is_optional_index(choice.index) then
+        if type(choice) ~= "table" or not is_optional_chat_index(choice.index) then
             return false
         end
 
         local delta = choice.delta
-        if delta ~= nil then
+        if not is_absent_chat_value(delta) then
             if type(delta) ~= "table" then
                 return false
             end
             for _, field in ipairs(CHAT_TEXT_FIELDS) do
-                if not is_optional_string(delta[field]) then
+                if not is_optional_chat_string(delta[field]) then
                     return false
                 end
             end
 
             local function_call = delta.function_call
-            if function_call ~= nil then
+            if not is_absent_chat_value(function_call) then
                 if type(function_call) ~= "table"
-                        or not is_optional_string(function_call.arguments) then
+                        or not is_optional_chat_string(function_call.arguments) then
                     return false
                 end
             end
 
             local tool_calls = delta.tool_calls
-            if tool_calls ~= nil then
+            if not is_absent_chat_value(tool_calls) then
                 if type(tool_calls) ~= "table" then
                     return false
                 end
                 for _, tool_call in ipairs(tool_calls) do
                     if type(tool_call) ~= "table"
-                            or not is_optional_index(tool_call.index) then
+                            or not is_optional_chat_index(tool_call.index) then
                         return false
                     end
                     local func = tool_call["function"]
-                    if func ~= nil and (type(func) ~= "table"
-                            or not is_optional_string(func.arguments)) then
+                    if not is_absent_chat_value(func)
+                            and (type(func) ~= "table"
+                                 or not is_optional_chat_string(func.arguments)) then
                         return false
                     end
                 end
@@ -319,7 +335,7 @@ function Processor:process_chat_event(event, value)
         local delta = choice.delta
         if type(delta) == "table" then
             local choice_index = choice.index
-            if choice_index == nil then
+            if is_absent_chat_value(choice_index) then
                 choice_index = choice_pos - 1
             end
 
@@ -372,7 +388,7 @@ function Processor:process_chat_event(event, value)
             if type(delta.tool_calls) == "table" then
                 for tool_pos, tool_call in ipairs(delta.tool_calls) do
                     local tool_index = tool_call.index
-                    if tool_index == nil then
+                    if is_absent_chat_value(tool_index) then
                         tool_index = tool_pos - 1
                     end
                     local func = tool_call["function"]

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/sse.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/sse.lua
@@ -149,6 +149,108 @@ local function make_final_event(meta, text)
 end
 
 
+local function is_optional_index(value)
+    return value == nil or type(value) == "number"
+end
+
+
+local function is_optional_string(value)
+    return value == nil or type(value) == "string"
+end
+
+
+local function is_valid_chat_value(value)
+    if value.choices == nil then
+        return true
+    end
+    if type(value.choices) ~= "table" then
+        return false
+    end
+
+    for _, choice in ipairs(value.choices) do
+        if type(choice) ~= "table" or not is_optional_index(choice.index) then
+            return false
+        end
+
+        local delta = choice.delta
+        if delta ~= nil then
+            if type(delta) ~= "table" then
+                return false
+            end
+            for _, field in ipairs(CHAT_TEXT_FIELDS) do
+                if not is_optional_string(delta[field]) then
+                    return false
+                end
+            end
+
+            local function_call = delta.function_call
+            if function_call ~= nil then
+                if type(function_call) ~= "table"
+                        or not is_optional_string(function_call.arguments) then
+                    return false
+                end
+            end
+
+            local tool_calls = delta.tool_calls
+            if tool_calls ~= nil then
+                if type(tool_calls) ~= "table" then
+                    return false
+                end
+                for _, tool_call in ipairs(tool_calls) do
+                    if type(tool_call) ~= "table"
+                            or not is_optional_index(tool_call.index) then
+                        return false
+                    end
+                    local func = tool_call["function"]
+                    if func ~= nil and (type(func) ~= "table"
+                            or not is_optional_string(func.arguments)) then
+                        return false
+                    end
+                end
+            end
+        end
+    end
+
+    return true
+end
+
+
+local function is_valid_response_value(event, value)
+    if not is_optional_string(value.type) then
+        return false
+    end
+
+    local field_config = RESPONSE_MODES[value.type or event.type]
+    if not field_config then
+        return true
+    end
+
+    return type(value[field_config.field]) == "string"
+           and is_optional_string(value.item_id)
+           and is_optional_index(value.output_index)
+end
+
+
+local function is_valid_anthropic_value(value)
+    if not is_optional_string(value.type) or not is_optional_index(value.index) then
+        return false
+    end
+    if value.delta == nil then
+        return true
+    end
+    if type(value.delta) ~= "table" or not is_optional_string(value.delta.type) then
+        return false
+    end
+
+    local field_config = ANTHROPIC_MODES[value.delta.type]
+    if not field_config then
+        return true
+    end
+
+    return type(value.delta[field_config.field]) == "string"
+end
+
+
 local Processor = {}
 Processor.__index = Processor
 
@@ -183,10 +285,33 @@ function Processor:finalize()
 end
 
 
+function Processor:fail_closed(buffered)
+    local output = {}
+    local unresolved_count = 0
+    for _, key in ipairs(self.key_order) do
+        local state = self.stream.states[key]
+        if type(state) == "table" and type(state.pending) == "string"
+                and state.pending ~= "" then
+            output[#output + 1] = sse_codec.encode(
+                make_final_event(self.keys[key], state.pending)
+            )
+            unresolved_count = unresolved_count + 1
+        end
+        self.stream.states[key] = nil
+    end
+
+    self.keys = {}
+    self.key_order = {}
+    self.remainder = ""
+    output[#output + 1] = buffered or ""
+    return table_concat(output), unresolved_count
+end
+
+
 function Processor:process_chat_event(event, value)
     local changed = false
     local restored_count = 0
-    if type(value.choices) ~= "table" then
+    if not is_valid_chat_value(value) or type(value.choices) ~= "table" then
         return false, 0
     end
 
@@ -283,6 +408,10 @@ end
 
 
 function Processor:process_response_event(event, value)
+    if not is_valid_response_value(event, value) then
+        return false, 0
+    end
+
     local data_type = value.type or event.type
     local field_config = RESPONSE_MODES[data_type]
     if not field_config or type(value[field_config.field]) ~= "string" then
@@ -318,6 +447,10 @@ end
 
 
 function Processor:process_anthropic_event(event, value)
+    if not is_valid_anthropic_value(value) then
+        return false, 0
+    end
+
     local delta = value.delta
     if type(delta) ~= "table" then
         return false, 0

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/sse.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/sse.lua
@@ -356,7 +356,11 @@ end
 
 
 function Processor:restore_field(key, meta, value, mode)
-    local output, count, stream_err = self.stream:feed(key, value, mode, false)
+    local remaining = self.max_output_bytes and
+                      self.max_output_bytes - self.output_bytes or nil
+    local output, count, stream_err = self.stream:feed(
+        key, value, mode, false, remaining
+    )
     if stream_err then
         error(stream_err, 0)
     end
@@ -379,7 +383,17 @@ function Processor:restore_field(key, meta, value, mode)
         remove_key(self, key)
     end
 
+    self.output_bytes = self.output_bytes + #output
     return output, count
+end
+
+
+function Processor:record_replacement(path, original, restored)
+    self.frame_replacements[#self.frame_replacements + 1] = {
+        path = path,
+        original = original,
+        restored = restored,
+    }
 end
 
 
@@ -487,6 +501,11 @@ function Processor:process_chat_event(event, value)
                         "text"
                     )
                     if restored ~= delta[field] then
+                        self:record_replacement(
+                            "/choices/" .. choice_pos .. "/delta/" .. field,
+                            delta[field],
+                            restored
+                        )
                         delta[field] = restored
                         changed = true
                     end
@@ -511,6 +530,12 @@ function Processor:process_chat_event(event, value)
                     "json_fragment"
                 )
                 if restored ~= delta.function_call.arguments then
+                    self:record_replacement(
+                        "/choices/" .. choice_pos ..
+                        "/delta/function_call/arguments",
+                        delta.function_call.arguments,
+                        restored
+                    )
                     delta.function_call.arguments = restored
                     changed = true
                 end
@@ -541,6 +566,13 @@ function Processor:process_chat_event(event, value)
                             "json_fragment"
                         )
                         if restored ~= func.arguments then
+                            self:record_replacement(
+                                "/choices/" .. choice_pos ..
+                                "/delta/tool_calls/" .. tool_pos ..
+                                "/function/arguments",
+                                func.arguments,
+                                restored
+                            )
                             func.arguments = restored
                             changed = true
                         end
@@ -612,12 +644,15 @@ function Processor:process_response_event(event, value)
     local count
     if field_config.done then
         local stream_err
+        local remaining = self.max_output_bytes and
+                          self.max_output_bytes - self.output_bytes or nil
         restored, count, stream_err = self.stream:feed(
-            key, value[field_config.field], field_config.mode, true
+            key, value[field_config.field], field_config.mode, true, remaining
         )
         if stream_err then
             error(stream_err, 0)
         end
+        self.output_bytes = self.output_bytes + #restored
     else
         restored, count = self:restore_field(
             key, meta, value[field_config.field], field_config.mode
@@ -628,6 +663,9 @@ function Processor:process_response_event(event, value)
         return false, count, prefix, unresolved_count
     end
 
+    self:record_replacement(
+        "/" .. field_config.field, value[field_config.field], restored
+    )
     value[field_config.field] = restored
     return true, count, prefix, unresolved_count
 end
@@ -666,6 +704,11 @@ function Processor:process_anthropic_event(event, value)
         return false, count
     end
 
+    self:record_replacement(
+        "/delta/" .. field_config.field,
+        delta[field_config.field],
+        restored
+    )
     delta[field_config.field] = restored
     return true, count
 end
@@ -702,6 +745,7 @@ function Processor:process_frame(frame)
     local restored_count
     local prefix = ""
     local unresolved_count = 0
+    self.frame_replacements = {}
     if self.protocol_name == "openai-chat" then
         changed, restored_count = self:process_chat_event(event, value)
 
@@ -716,7 +760,13 @@ function Processor:process_frame(frame)
         return prefix .. frame, restored_count, unresolved_count
     end
 
-    event.data = core.json.encode(value)
+    local restored_data, restore_err = restorer.replace_json_strings(
+        event.data, self.frame_replacements, self.max_output_bytes
+    )
+    if not restored_data then
+        error(restore_err, 0)
+    end
+    event.data = restored_data
     return prefix .. sse_codec.encode(event), restored_count, unresolved_count
 end
 
@@ -802,6 +852,7 @@ end
 
 function Processor:feed(chunk, eof)
     local snapshot = snapshot_processor(self)
+    self.output_bytes = 0
     local ok, output, restored_count, unresolved_count = pcall(
         feed_unsafe, self, chunk, eof
     )
@@ -821,7 +872,7 @@ function Processor:feed(chunk, eof)
 end
 
 
-function _M.new(protocol_name, mapping, namespace)
+function _M.new(protocol_name, mapping, namespace, max_output_bytes)
     if protocol_name == "bedrock-converse" then
         return nil, "raw AWS EventStream restoration is not supported"
     end
@@ -835,11 +886,14 @@ function _M.new(protocol_name, mapping, namespace)
         {
             protocol_name = protocol_name,
             remainder = "",
-            stream = restorer.new_stream(mapping, namespace),
+            stream = restorer.new_stream(mapping, namespace, max_output_bytes),
             keys = {},
             key_order = {},
             key_metadata_bytes = {},
             metadata_bytes = 0,
+            max_output_bytes = max_output_bytes,
+            output_bytes = 0,
+            frame_replacements = {},
         },
         Processor
     )

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/sse.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/sse.lua
@@ -1,0 +1,462 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+
+local core = require("apisix.core")
+local restorer = require("apisix.plugins.bk-ai-sensitive-data-redaction.restorer")
+local sse_codec = require("apisix.plugins.ai-transport.sse")
+local ipairs = ipairs
+local setmetatable = setmetatable
+local table_concat = table.concat
+local tostring = tostring
+local type = type
+
+local _M = {}
+
+local CHAT_TEXT_FIELDS = {
+    "content",
+    "reasoning_content",
+    "refusal",
+}
+
+local RESPONSE_MODES = {
+    ["response.output_text.delta"] = {field = "delta", mode = "text"},
+    ["response.reasoning_summary_text.delta"] = {field = "delta", mode = "text"},
+    ["response.function_call_arguments.delta"] = {
+        field = "delta",
+        mode = "json_fragment",
+    },
+}
+
+local ANTHROPIC_MODES = {
+    text_delta = {field = "text", mode = "text"},
+    input_json_delta = {field = "partial_json", mode = "json_fragment"},
+}
+
+local TERMINAL_EVENTS = {
+    ["response.completed"] = true,
+    ["response.failed"] = true,
+    ["response.incomplete"] = true,
+    error = true,
+    message_stop = true,
+}
+
+
+local function next_boundary(buffer, start_pos)
+    local lf_pos = buffer:find("\n\n", start_pos, true)
+    local crlf_pos = buffer:find("\r\n\r\n", start_pos, true)
+    if lf_pos and (not crlf_pos or lf_pos <= crlf_pos) then
+        return lf_pos, 2
+    end
+
+    if crlf_pos then
+        return crlf_pos, 4
+    end
+end
+
+
+local function make_chat_final_event(meta, text)
+    local delta = {}
+    if meta.field == "function_call.arguments" then
+        delta.function_call = {arguments = text}
+
+    elseif meta.field == "tool_calls.function.arguments" then
+        delta.tool_calls = {
+            {
+                index = meta.tool_index,
+                ["function"] = {arguments = text},
+            },
+        }
+
+    else
+        delta[meta.field] = text
+    end
+
+    return {
+        type = meta.event_type,
+        data = core.json.encode({
+            choices = {
+                {
+                    index = meta.choice_index,
+                    delta = delta,
+                },
+            },
+        }),
+    }
+end
+
+
+local function make_response_final_event(meta, text)
+    local data = {
+        type = meta.data_type,
+        delta = text,
+    }
+    if meta.item_id ~= nil then
+        data.item_id = meta.item_id
+    end
+    if meta.output_index ~= nil then
+        data.output_index = meta.output_index
+    end
+
+    return {
+        type = meta.event_type,
+        data = core.json.encode(data),
+    }
+end
+
+
+local function make_anthropic_final_event(meta, text)
+    return {
+        type = meta.event_type,
+        data = core.json.encode({
+            type = "content_block_delta",
+            index = meta.index,
+            delta = {
+                type = meta.delta_type,
+                [meta.field] = text,
+            },
+        }),
+    }
+end
+
+
+local function make_final_event(meta, text)
+    if meta.protocol_name == "openai-chat" then
+        return make_chat_final_event(meta, text)
+    end
+
+    if meta.protocol_name == "openai-responses" then
+        return make_response_final_event(meta, text)
+    end
+
+    return make_anthropic_final_event(meta, text)
+end
+
+
+local Processor = {}
+Processor.__index = Processor
+
+
+function Processor:restore_field(key, meta, value, mode)
+    local output, count = self.stream:feed(key, value, mode, false)
+    if self.keys[key] == nil then
+        self.key_order[#self.key_order + 1] = key
+    end
+    self.keys[key] = meta
+    return output, count
+end
+
+
+function Processor:finalize()
+    local output = {}
+    local restored_count = 0
+    local unresolved_count = 0
+    for _, key in ipairs(self.key_order) do
+        local meta = self.keys[key]
+        local pending, count = self.stream:feed(key, "", meta.mode, true)
+        restored_count = restored_count + count
+        if pending ~= "" then
+            output[#output + 1] = sse_codec.encode(make_final_event(meta, pending))
+            unresolved_count = unresolved_count + 1
+        end
+    end
+
+    self.keys = {}
+    self.key_order = {}
+    return table_concat(output), restored_count, unresolved_count
+end
+
+
+function Processor:process_chat_event(event, value)
+    local changed = false
+    local restored_count = 0
+    if type(value.choices) ~= "table" then
+        return false, 0
+    end
+
+    for choice_pos, choice in ipairs(value.choices) do
+        local delta = choice.delta
+        if type(delta) == "table" then
+            local choice_index = choice.index
+            if choice_index == nil then
+                choice_index = choice_pos - 1
+            end
+
+            for _, field in ipairs(CHAT_TEXT_FIELDS) do
+                if type(delta[field]) == "string" then
+                    local key = event.type .. ":choice:" .. choice_index .. ":" .. field
+                    local restored, count = self:restore_field(
+                        key,
+                        {
+                            event_type = event.type,
+                            protocol_name = self.protocol_name,
+                            choice_index = choice_index,
+                            field = field,
+                            mode = "text",
+                        },
+                        delta[field],
+                        "text"
+                    )
+                    if restored ~= delta[field] then
+                        delta[field] = restored
+                        changed = true
+                    end
+                    restored_count = restored_count + count
+                end
+            end
+
+            if type(delta.function_call) == "table"
+                    and type(delta.function_call.arguments) == "string" then
+                local key = event.type .. ":choice:" .. choice_index ..
+                            ":function_call.arguments"
+                local restored, count = self:restore_field(
+                    key,
+                    {
+                        event_type = event.type,
+                        protocol_name = self.protocol_name,
+                        choice_index = choice_index,
+                        field = "function_call.arguments",
+                        mode = "json_fragment",
+                    },
+                    delta.function_call.arguments,
+                    "json_fragment"
+                )
+                if restored ~= delta.function_call.arguments then
+                    delta.function_call.arguments = restored
+                    changed = true
+                end
+                restored_count = restored_count + count
+            end
+
+            if type(delta.tool_calls) == "table" then
+                for tool_pos, tool_call in ipairs(delta.tool_calls) do
+                    local tool_index = tool_call.index
+                    if tool_index == nil then
+                        tool_index = tool_pos - 1
+                    end
+                    local func = tool_call["function"]
+                    if type(func) == "table" and type(func.arguments) == "string" then
+                        local key = event.type .. ":choice:" .. choice_index .. ":tool:" ..
+                                    tool_index .. ":function.arguments"
+                        local restored, count = self:restore_field(
+                            key,
+                            {
+                                event_type = event.type,
+                                protocol_name = self.protocol_name,
+                                choice_index = choice_index,
+                                tool_index = tool_index,
+                                field = "tool_calls.function.arguments",
+                                mode = "json_fragment",
+                            },
+                            func.arguments,
+                            "json_fragment"
+                        )
+                        if restored ~= func.arguments then
+                            func.arguments = restored
+                            changed = true
+                        end
+                        restored_count = restored_count + count
+                    end
+                end
+            end
+        end
+    end
+
+    return changed, restored_count
+end
+
+
+function Processor:process_response_event(event, value)
+    local data_type = value.type or event.type
+    local field_config = RESPONSE_MODES[data_type]
+    if not field_config or type(value[field_config.field]) ~= "string" then
+        return false, 0
+    end
+
+    local logical_id = value.item_id
+    if logical_id == nil then
+        logical_id = value.output_index
+    end
+    local key = data_type .. ":" .. tostring(logical_id or "") .. ":" .. field_config.field
+    local restored, count = self:restore_field(
+        key,
+        {
+            event_type = event.type,
+            protocol_name = self.protocol_name,
+            data_type = data_type,
+            field = field_config.field,
+            mode = field_config.mode,
+            item_id = value.item_id,
+            output_index = value.output_index,
+        },
+        value[field_config.field],
+        field_config.mode
+    )
+    if restored == value[field_config.field] then
+        return false, count
+    end
+
+    value[field_config.field] = restored
+    return true, count
+end
+
+
+function Processor:process_anthropic_event(event, value)
+    local delta = value.delta
+    if type(delta) ~= "table" then
+        return false, 0
+    end
+
+    local field_config = ANTHROPIC_MODES[delta.type]
+    if not field_config or type(delta[field_config.field]) ~= "string" then
+        return false, 0
+    end
+
+    local key = event.type .. ":" .. tostring(value.index or "") .. ":" .. delta.type
+    local restored, count = self:restore_field(
+        key,
+        {
+            event_type = event.type,
+            protocol_name = self.protocol_name,
+            index = value.index,
+            delta_type = delta.type,
+            field = field_config.field,
+            mode = field_config.mode,
+        },
+        delta[field_config.field],
+        field_config.mode
+    )
+    if restored == delta[field_config.field] then
+        return false, count
+    end
+
+    delta[field_config.field] = restored
+    return true, count
+end
+
+
+local function is_terminal_event(event, value)
+    return TERMINAL_EVENTS[event.type] or TERMINAL_EVENTS[value.type]
+end
+
+
+function Processor:process_frame(frame)
+    local events = sse_codec.decode(frame)
+    if #events ~= 1 then
+        return frame, 0, 0
+    end
+
+    local event = events[1]
+    if event.data == "[DONE]" then
+        local final_output, restored_count, unresolved_count = self:finalize()
+        return final_output .. frame, restored_count, unresolved_count
+    end
+
+    local value = core.json.decode(event.data)
+    if type(value) ~= "table" then
+        return frame, 0, 0
+    end
+
+    if is_terminal_event(event, value) then
+        local final_output, restored_count, unresolved_count = self:finalize()
+        return final_output .. frame, restored_count, unresolved_count
+    end
+
+    local changed
+    local restored_count
+    if self.protocol_name == "openai-chat" then
+        changed, restored_count = self:process_chat_event(event, value)
+
+    elseif self.protocol_name == "openai-responses" then
+        changed, restored_count = self:process_response_event(event, value)
+
+    else
+        changed, restored_count = self:process_anthropic_event(event, value)
+    end
+    if not changed then
+        return frame, restored_count, 0
+    end
+
+    event.data = core.json.encode(value)
+    return sse_codec.encode(event), restored_count, 0
+end
+
+
+function Processor:feed(chunk, eof)
+    local buffer = self.remainder .. (chunk or "")
+    local output = {}
+    local restored_count = 0
+    local unresolved_count = 0
+    local start_pos = 1
+    while true do
+        local boundary_pos, boundary_length = next_boundary(buffer, start_pos)
+        if not boundary_pos then
+            break
+        end
+
+        local frame = buffer:sub(start_pos, boundary_pos + boundary_length - 1)
+        local restored, frame_count, frame_unresolved = self:process_frame(frame)
+        output[#output + 1] = restored
+        restored_count = restored_count + frame_count
+        unresolved_count = unresolved_count + frame_unresolved
+        start_pos = boundary_pos + boundary_length
+    end
+
+    self.remainder = buffer:sub(start_pos)
+    if eof then
+        if self.remainder ~= "" then
+            local restored, frame_count, frame_unresolved = self:process_frame(self.remainder)
+            output[#output + 1] = restored
+            restored_count = restored_count + frame_count
+            unresolved_count = unresolved_count + frame_unresolved
+            self.remainder = ""
+        end
+
+        local final_output, final_count, final_unresolved = self:finalize()
+        output[#output + 1] = final_output
+        restored_count = restored_count + final_count
+        unresolved_count = unresolved_count + final_unresolved
+    end
+
+    return table_concat(output), restored_count, unresolved_count
+end
+
+
+function _M.new(protocol_name, mapping, namespace)
+    if protocol_name == "bedrock-converse" then
+        return nil, "raw AWS EventStream restoration is not supported"
+    end
+
+    if protocol_name ~= "openai-chat" and protocol_name ~= "openai-responses"
+            and protocol_name ~= "anthropic-messages" then
+        return nil, "streaming protocol passthrough is not supported"
+    end
+
+    return setmetatable(
+        {
+            protocol_name = protocol_name,
+            remainder = "",
+            stream = restorer.new_stream(mapping, namespace),
+            keys = {},
+            key_order = {},
+        },
+        Processor
+    )
+end
+
+
+return _M

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/sse.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/sse.lua
@@ -32,6 +32,7 @@ local type = type
 local _M = {}
 
 local MAX_REMAINDER = 1024 * 1024
+local MAX_STREAM_METADATA_BYTES = 64 * 1024
 
 local CHAT_TEXT_FIELDS = {
     "content",
@@ -41,12 +42,14 @@ local CHAT_TEXT_FIELDS = {
 
 local RESPONSE_MODES = {
     ["response.output_text.delta"] = {
+        data_type = "response.output_text.delta",
         field = "delta",
         mode = "text",
         family = "output_text",
         part_index = "content_index",
     },
     ["response.output_text.done"] = {
+        data_type = "response.output_text.done",
         field = "text",
         mode = "text",
         family = "output_text",
@@ -54,12 +57,14 @@ local RESPONSE_MODES = {
         done = true,
     },
     ["response.reasoning_summary_text.delta"] = {
+        data_type = "response.reasoning_summary_text.delta",
         field = "delta",
         mode = "text",
         family = "reasoning_summary_text",
         part_index = "summary_index",
     },
     ["response.reasoning_summary_text.done"] = {
+        data_type = "response.reasoning_summary_text.done",
         field = "text",
         mode = "text",
         family = "reasoning_summary_text",
@@ -67,11 +72,13 @@ local RESPONSE_MODES = {
         done = true,
     },
     ["response.function_call_arguments.delta"] = {
+        data_type = "response.function_call_arguments.delta",
         field = "delta",
         mode = "json_fragment",
         family = "function_call_arguments",
     },
     ["response.function_call_arguments.done"] = {
+        data_type = "response.function_call_arguments.done",
         field = "arguments",
         mode = "json_fragment",
         family = "function_call_arguments",
@@ -80,8 +87,12 @@ local RESPONSE_MODES = {
 }
 
 local ANTHROPIC_MODES = {
-    text_delta = {field = "text", mode = "text"},
-    input_json_delta = {field = "partial_json", mode = "json_fragment"},
+    text_delta = {field = "text", mode = "text", delta_type = "text_delta"},
+    input_json_delta = {
+        field = "partial_json",
+        mode = "json_fragment",
+        delta_type = "input_json_delta",
+    },
 }
 
 local TERMINAL_EVENTS = {
@@ -314,11 +325,26 @@ local Processor = {}
 Processor.__index = Processor
 
 
+local function retained_metadata_bytes(key, meta)
+    local bytes = #key
+    if type(meta.event_type) == "string" then
+        bytes = bytes + #meta.event_type
+    end
+    if type(meta.item_id) == "string" then
+        bytes = bytes + #meta.item_id
+    end
+    return bytes
+end
+
+
 local function remove_key(processor, key)
     if processor.keys[key] == nil then
         return
     end
 
+    processor.metadata_bytes =
+        processor.metadata_bytes - processor.key_metadata_bytes[key]
+    processor.key_metadata_bytes[key] = nil
     processor.keys[key] = nil
     for index, ordered_key in ipairs(processor.key_order) do
         if ordered_key == key then
@@ -336,10 +362,19 @@ function Processor:restore_field(key, meta, value, mode)
     end
 
     if self.stream.states[key] then
+        local previous_bytes = self.key_metadata_bytes[key] or 0
+        local metadata_bytes = retained_metadata_bytes(key, meta)
+        local total_bytes = self.metadata_bytes - previous_bytes + metadata_bytes
+        if total_bytes > MAX_STREAM_METADATA_BYTES then
+            error("stream metadata byte limit exceeded", 0)
+        end
+
         if self.keys[key] == nil then
             self.key_order[#self.key_order + 1] = key
         end
         self.keys[key] = meta
+        self.key_metadata_bytes[key] = metadata_bytes
+        self.metadata_bytes = total_bytes
     else
         remove_key(self, key)
     end
@@ -386,6 +421,8 @@ function Processor:finalize()
 
     self.keys = {}
     self.key_order = {}
+    self.key_metadata_bytes = {}
+    self.metadata_bytes = 0
     self.stream.active_count = 0
     self.stream.pending_bytes = 0
     return table_concat(output), restored_count, unresolved_count
@@ -411,6 +448,8 @@ function Processor:fail_closed(buffered)
     self.stream.pending_bytes = 0
     self.keys = {}
     self.key_order = {}
+    self.key_metadata_bytes = {}
+    self.metadata_bytes = 0
     self.remainder = ""
     output[#output + 1] = buffered or ""
     return table_concat(output), unresolved_count
@@ -561,7 +600,7 @@ function Processor:process_response_event(event, value)
     local meta = {
         event_type = event.type,
         protocol_name = self.protocol_name,
-        data_type = data_type,
+        data_type = field_config.data_type,
         field = field_config.field,
         mode = field_config.mode,
         item_id = value.item_id,
@@ -616,7 +655,7 @@ function Processor:process_anthropic_event(event, value)
             event_type = event.type,
             protocol_name = self.protocol_name,
             index = value.index,
-            delta_type = delta.type,
+            delta_type = field_config.delta_type,
             field = field_config.field,
             mode = field_config.mode,
         },
@@ -743,6 +782,11 @@ local function snapshot_processor(processor)
         key_order[index] = key
     end
 
+    local key_metadata_bytes = {}
+    for key, bytes in pairs(processor.key_metadata_bytes) do
+        key_metadata_bytes[key] = bytes
+    end
+
     return {
         remainder = processor.remainder,
         states = states,
@@ -750,6 +794,8 @@ local function snapshot_processor(processor)
         pending_bytes = processor.stream.pending_bytes,
         keys = keys,
         key_order = key_order,
+        key_metadata_bytes = key_metadata_bytes,
+        metadata_bytes = processor.metadata_bytes,
     }
 end
 
@@ -769,6 +815,8 @@ function Processor:feed(chunk, eof)
     self.stream.pending_bytes = snapshot.pending_bytes
     self.keys = snapshot.keys
     self.key_order = snapshot.key_order
+    self.key_metadata_bytes = snapshot.key_metadata_bytes
+    self.metadata_bytes = snapshot.metadata_bytes
     error(output, 0)
 end
 
@@ -790,6 +838,8 @@ function _M.new(protocol_name, mapping, namespace)
             stream = restorer.new_stream(mapping, namespace),
             keys = {},
             key_order = {},
+            key_metadata_bytes = {},
+            metadata_bytes = 0,
         },
         Processor
     )

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/sse.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/sse.lua
@@ -27,6 +27,8 @@ local type = type
 
 local _M = {}
 
+local MAX_REMAINDER = 1024 * 1024
+
 local CHAT_TEXT_FIELDS = {
     "content",
     "reasoning_content",
@@ -349,11 +351,6 @@ function Processor:process_anthropic_event(event, value)
 end
 
 
-local function is_terminal_event(event, value)
-    return TERMINAL_EVENTS[event.type] or TERMINAL_EVENTS[value.type]
-end
-
-
 function Processor:process_frame(frame)
     local events = sse_codec.decode(frame)
     if #events ~= 1 then
@@ -366,12 +363,17 @@ function Processor:process_frame(frame)
         return final_output .. frame, restored_count, unresolved_count
     end
 
+    if TERMINAL_EVENTS[event.type] then
+        local final_output, restored_count, unresolved_count = self:finalize()
+        return final_output .. frame, restored_count, unresolved_count
+    end
+
     local value = core.json.decode(event.data)
     if type(value) ~= "table" then
         return frame, 0, 0
     end
 
-    if is_terminal_event(event, value) then
+    if TERMINAL_EVENTS[value.type] then
         local final_output, restored_count, unresolved_count = self:finalize()
         return final_output .. frame, restored_count, unresolved_count
     end
@@ -417,6 +419,11 @@ function Processor:feed(chunk, eof)
     end
 
     self.remainder = buffer:sub(start_pos)
+    if not eof and #self.remainder > MAX_REMAINDER then
+        output[#output + 1] = self.remainder
+        self.remainder = ""
+    end
+
     if eof then
         if self.remainder ~= "" then
             local restored, frame_count, frame_unresolved = self:process_frame(self.remainder)

--- a/src/apisix/plugins/bk-ai-sensitive-data-redaction/sse.lua
+++ b/src/apisix/plugins/bk-ai-sensitive-data-redaction/sse.lua
@@ -19,9 +19,13 @@
 local core = require("apisix.core")
 local restorer = require("apisix.plugins.bk-ai-sensitive-data-redaction.restorer")
 local sse_codec = require("apisix.plugins.ai-transport.sse")
+local error = error
 local ipairs = ipairs
+local pairs = pairs
+local pcall = pcall
 local setmetatable = setmetatable
 local table_concat = table.concat
+local table_remove = table.remove
 local tostring = tostring
 local type = type
 
@@ -36,11 +40,42 @@ local CHAT_TEXT_FIELDS = {
 }
 
 local RESPONSE_MODES = {
-    ["response.output_text.delta"] = {field = "delta", mode = "text"},
-    ["response.reasoning_summary_text.delta"] = {field = "delta", mode = "text"},
+    ["response.output_text.delta"] = {
+        field = "delta",
+        mode = "text",
+        family = "output_text",
+        part_index = "content_index",
+    },
+    ["response.output_text.done"] = {
+        field = "text",
+        mode = "text",
+        family = "output_text",
+        part_index = "content_index",
+        done = true,
+    },
+    ["response.reasoning_summary_text.delta"] = {
+        field = "delta",
+        mode = "text",
+        family = "reasoning_summary_text",
+        part_index = "summary_index",
+    },
+    ["response.reasoning_summary_text.done"] = {
+        field = "text",
+        mode = "text",
+        family = "reasoning_summary_text",
+        part_index = "summary_index",
+        done = true,
+    },
     ["response.function_call_arguments.delta"] = {
         field = "delta",
         mode = "json_fragment",
+        family = "function_call_arguments",
+    },
+    ["response.function_call_arguments.done"] = {
+        field = "arguments",
+        mode = "json_fragment",
+        family = "function_call_arguments",
+        done = true,
     },
 }
 
@@ -112,6 +147,12 @@ local function make_response_final_event(meta, text)
     end
     if meta.output_index ~= nil then
         data.output_index = meta.output_index
+    end
+    if meta.content_index ~= nil then
+        data.content_index = meta.content_index
+    end
+    if meta.summary_index ~= nil then
+        data.summary_index = meta.summary_index
     end
 
     return {
@@ -244,6 +285,8 @@ local function is_valid_response_value(event, value)
     return type(value[field_config.field]) == "string"
            and is_optional_string(value.item_id)
            and is_optional_index(value.output_index)
+           and is_optional_index(value.content_index)
+           and is_optional_index(value.summary_index)
 end
 
 
@@ -271,13 +314,56 @@ local Processor = {}
 Processor.__index = Processor
 
 
-function Processor:restore_field(key, meta, value, mode)
-    local output, count = self.stream:feed(key, value, mode, false)
-    if self.keys[key] == nil then
-        self.key_order[#self.key_order + 1] = key
+local function remove_key(processor, key)
+    if processor.keys[key] == nil then
+        return
     end
-    self.keys[key] = meta
+
+    processor.keys[key] = nil
+    for index, ordered_key in ipairs(processor.key_order) do
+        if ordered_key == key then
+            table_remove(processor.key_order, index)
+            return
+        end
+    end
+end
+
+
+function Processor:restore_field(key, meta, value, mode)
+    local output, count, stream_err = self.stream:feed(key, value, mode, false)
+    if stream_err then
+        error(stream_err, 0)
+    end
+
+    if self.stream.states[key] then
+        if self.keys[key] == nil then
+            self.key_order[#self.key_order + 1] = key
+        end
+        self.keys[key] = meta
+    else
+        remove_key(self, key)
+    end
+
     return output, count
+end
+
+
+function Processor:finalize_key(key)
+    local meta = self.keys[key]
+    if not meta then
+        return "", 0, 0
+    end
+
+    local pending, count, stream_err = self.stream:feed(key, "", meta.mode, true)
+    if stream_err then
+        error(stream_err, 0)
+    end
+    remove_key(self, key)
+    if pending == "" then
+        return "", count, 0
+    end
+
+    return sse_codec.encode(make_final_event(meta, pending)), count, 1
 end
 
 
@@ -287,7 +373,10 @@ function Processor:finalize()
     local unresolved_count = 0
     for _, key in ipairs(self.key_order) do
         local meta = self.keys[key]
-        local pending, count = self.stream:feed(key, "", meta.mode, true)
+        local pending, count, stream_err = self.stream:feed(key, "", meta.mode, true)
+        if stream_err then
+            error(stream_err, 0)
+        end
         restored_count = restored_count + count
         if pending ~= "" then
             output[#output + 1] = sse_codec.encode(make_final_event(meta, pending))
@@ -297,6 +386,8 @@ function Processor:finalize()
 
     self.keys = {}
     self.key_order = {}
+    self.stream.active_count = 0
+    self.stream.pending_bytes = 0
     return table_concat(output), restored_count, unresolved_count
 end
 
@@ -313,9 +404,11 @@ function Processor:fail_closed(buffered)
             )
             unresolved_count = unresolved_count + 1
         end
-        self.stream.states[key] = nil
     end
 
+    self.stream.states = {}
+    self.stream.active_count = 0
+    self.stream.pending_bytes = 0
     self.keys = {}
     self.key_order = {}
     self.remainder = ""
@@ -423,42 +516,81 @@ function Processor:process_chat_event(event, value)
 end
 
 
+local function response_key_part(value)
+    if type(value) == "string" then
+        return "s" .. #value .. ":" .. value
+    end
+    if type(value) == "number" then
+        return "n" .. tostring(value)
+    end
+    return "-"
+end
+
+
+local function response_key(field_config, value)
+    local part_index
+    if field_config.part_index then
+        part_index = value[field_config.part_index]
+    end
+    return "response:" .. field_config.family .. ":" ..
+           response_key_part(value.item_id) .. ":" ..
+           response_key_part(value.output_index) .. ":" ..
+           response_key_part(part_index)
+end
+
+
 function Processor:process_response_event(event, value)
     if not is_valid_response_value(event, value) then
-        return false, 0
+        return false, 0, "", 0
     end
 
     local data_type = value.type or event.type
     local field_config = RESPONSE_MODES[data_type]
     if not field_config or type(value[field_config.field]) ~= "string" then
-        return false, 0
+        return false, 0, "", 0
     end
 
-    local logical_id = value.item_id
-    if logical_id == nil then
-        logical_id = value.output_index
+    local key = response_key(field_config, value)
+    local prefix = ""
+    local prefix_count = 0
+    local unresolved_count = 0
+    if field_config.done then
+        prefix, prefix_count, unresolved_count = self:finalize_key(key)
     end
-    local key = data_type .. ":" .. tostring(logical_id or "") .. ":" .. field_config.field
-    local restored, count = self:restore_field(
-        key,
-        {
-            event_type = event.type,
-            protocol_name = self.protocol_name,
-            data_type = data_type,
-            field = field_config.field,
-            mode = field_config.mode,
-            item_id = value.item_id,
-            output_index = value.output_index,
-        },
-        value[field_config.field],
-        field_config.mode
-    )
+
+    local meta = {
+        event_type = event.type,
+        protocol_name = self.protocol_name,
+        data_type = data_type,
+        field = field_config.field,
+        mode = field_config.mode,
+        item_id = value.item_id,
+        output_index = value.output_index,
+        content_index = value.content_index,
+        summary_index = value.summary_index,
+    }
+    local restored
+    local count
+    if field_config.done then
+        local stream_err
+        restored, count, stream_err = self.stream:feed(
+            key, value[field_config.field], field_config.mode, true
+        )
+        if stream_err then
+            error(stream_err, 0)
+        end
+    else
+        restored, count = self:restore_field(
+            key, meta, value[field_config.field], field_config.mode
+        )
+    end
+    count = count + prefix_count
     if restored == value[field_config.field] then
-        return false, count
+        return false, count, prefix, unresolved_count
     end
 
     value[field_config.field] = restored
-    return true, count
+    return true, count, prefix, unresolved_count
 end
 
 
@@ -529,25 +661,28 @@ function Processor:process_frame(frame)
 
     local changed
     local restored_count
+    local prefix = ""
+    local unresolved_count = 0
     if self.protocol_name == "openai-chat" then
         changed, restored_count = self:process_chat_event(event, value)
 
     elseif self.protocol_name == "openai-responses" then
-        changed, restored_count = self:process_response_event(event, value)
+        changed, restored_count, prefix, unresolved_count =
+            self:process_response_event(event, value)
 
     else
         changed, restored_count = self:process_anthropic_event(event, value)
     end
     if not changed then
-        return frame, restored_count, 0
+        return prefix .. frame, restored_count, unresolved_count
     end
 
     event.data = core.json.encode(value)
-    return sse_codec.encode(event), restored_count, 0
+    return prefix .. sse_codec.encode(event), restored_count, unresolved_count
 end
 
 
-function Processor:feed(chunk, eof)
+local function feed_unsafe(self, chunk, eof)
     local buffer = self.remainder .. (chunk or "")
     local output = {}
     local restored_count = 0
@@ -589,6 +724,52 @@ function Processor:feed(chunk, eof)
     end
 
     return table_concat(output), restored_count, unresolved_count
+end
+
+
+local function snapshot_processor(processor)
+    local states = {}
+    for key, state in pairs(processor.stream.states) do
+        states[key] = {pending = state.pending}
+    end
+
+    local keys = {}
+    for key, meta in pairs(processor.keys) do
+        keys[key] = meta
+    end
+
+    local key_order = {}
+    for index, key in ipairs(processor.key_order) do
+        key_order[index] = key
+    end
+
+    return {
+        remainder = processor.remainder,
+        states = states,
+        active_count = processor.stream.active_count,
+        pending_bytes = processor.stream.pending_bytes,
+        keys = keys,
+        key_order = key_order,
+    }
+end
+
+
+function Processor:feed(chunk, eof)
+    local snapshot = snapshot_processor(self)
+    local ok, output, restored_count, unresolved_count = pcall(
+        feed_unsafe, self, chunk, eof
+    )
+    if ok then
+        return output, restored_count, unresolved_count
+    end
+
+    self.remainder = snapshot.remainder
+    self.stream.states = snapshot.states
+    self.stream.active_count = snapshot.active_count
+    self.stream.pending_bytes = snapshot.pending_bytes
+    self.keys = snapshot.keys
+    self.key_order = snapshot.key_order
+    error(output, 0)
 end
 
 

--- a/src/apisix/t/bk-ai-final-request-body-filter.t
+++ b/src/apisix/t/bk-ai-final-request-body-filter.t
@@ -552,33 +552,40 @@ final-extra-opts-content-free
 
 
 
-=== TEST 7: ai-proxy-multi log releases least-conn attempt state after filter failure
+=== TEST 7: ai-proxy-multi log defers picker cleanup to the generic log phase
 --- config
     location /t {
         content_by_lua_block {
-            local core = require("apisix.core")
-            local least_conn = require("apisix.balancer.least_conn")
             local ai_proxy_multi = require("apisix.plugins.ai-proxy-multi")
-            local picker = least_conn.new({first = 1}, {first = 1})
+            local cleanup_calls = 0
+            local picker = {
+                after_balance = function(ctx, before_retry)
+                    assert(before_retry == false)
+                    cleanup_calls = cleanup_calls + 1
+                    ctx.balancer_tried_servers = nil
+                end,
+            }
             local ctx = {
                 server_picker = picker,
-                balancer_tried_servers = core.tablepool.fetch(
-                    "balancer_tried_servers", 0, 2
-                ),
+                balancer_tried_servers = {first = true},
                 var = {},
             }
-            local server = assert(picker.get(ctx))
-            ctx.balancer_server = server
 
+            -- APISIX http_log_phase first executes plugin log handlers.
             ai_proxy_multi.log({}, ctx)
+            assert(cleanup_calls == 0)
+            assert(ctx.balancer_tried_servers ~= nil)
 
+            -- It then owns the one request-final picker cleanup.
+            ctx.server_picker.after_balance(ctx, false)
+            assert(cleanup_calls == 1)
             assert(ctx.server_picker == picker)
             assert(ctx.balancer_tried_servers == nil)
-            ngx.say("least-conn-filter-failure-cleaned")
+            ngx.say("picker-cleaned-once-by-generic-log-phase")
         }
     }
 --- response_body
-least-conn-filter-failure-cleaned
+picker-cleaned-once-by-generic-log-phase
 
 
 

--- a/src/apisix/t/bk-ai-final-request-body-filter.t
+++ b/src/apisix/t/bk-ai-final-request-body-filter.t
@@ -1278,3 +1278,100 @@ POST /t
 Content-Type: application/json
 --- response_body
 legacy-original-payload-retained
+
+
+
+=== TEST 18: provider routing failure clears pre-existing finalized-filter payload view
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local ai_proxy = require("apisix.plugins.ai-proxy")
+            local base = require("apisix.plugins.ai-proxy.base")
+            local logged = {}
+            local original_log_info = core.log.info
+            local original_log_error = core.log.error
+            local callback_calls = 0
+            local ctx = {
+                ai_client_protocol = "openai-chat",
+                ai_final_request_body_filter = function(body)
+                    callback_calls = callback_calls + 1
+                    return body
+                end,
+                picked_ai_instance = {
+                    name = "routing-mismatch",
+                    provider = "bedrock",
+                    provider_conf = {region = "us-east-1"},
+                    auth = {},
+                    override = {
+                        request_body = {
+                            ["bedrock-converse"] = {
+                                metadata = {secret = "routing-override-secret"},
+                            },
+                        },
+                    },
+                },
+                var = {
+                    uri = "/v1/chat/completions",
+                    request_type = "ai_chat",
+                    llm_request_body = {
+                        messages = {{
+                            role = "user",
+                            content = "rewrite-residue-secret",
+                        }},
+                    },
+                },
+            }
+
+            local function capture(...)
+                for index = 1, select("#", ...) do
+                    local value = select(index, ...)
+                    if type(value) == "string" then
+                        logged[#logged + 1] = value
+                    else
+                        local ok, encoded = pcall(core.json.encode, value)
+                        logged[#logged + 1] = ok and encoded or tostring(value)
+                    end
+                end
+            end
+
+            core.log.info = capture
+            core.log.error = capture
+            ngx.ctx.api_ctx = ctx
+            local ok, err = xpcall(function()
+                local code, body = base.before_proxy({}, ctx)
+                assert(code == 400)
+                assert(type(body) == "string")
+                assert(body:find("does not support openai-chat", 1, true))
+                assert(callback_calls == 0)
+
+                ai_proxy.log({logging = {summaries = false, payloads = true}}, ctx)
+            end, debug.traceback)
+            core.log.info = original_log_info
+            core.log.error = original_log_error
+            assert(ok, err)
+
+            local payload = assert(core.json.encode(ctx.llm_request))
+            local output = table.concat(logged)
+            for _, secret in ipairs({
+                "routing-client-secret",
+                "rewrite-residue-secret",
+                "routing-override-secret",
+            }) do
+                assert(not payload:find(secret, 1, true), payload)
+                assert(not output:find(secret, 1, true), output)
+            end
+            ngx.say("routing-failure-payload-safe")
+        }
+    }
+--- request
+POST /t
+{"messages":[{"role":"user","content":"routing-client-secret"}]}
+--- more_headers
+Content-Type: application/json
+--- response_body
+routing-failure-payload-safe
+--- no_error_log
+routing-client-secret
+rewrite-residue-secret
+routing-override-secret

--- a/src/apisix/t/bk-ai-final-request-body-filter.t
+++ b/src/apisix/t/bk-ai-final-request-body-filter.t
@@ -1375,3 +1375,222 @@ routing-failure-payload-safe
 routing-client-secret
 rewrite-residue-secret
 routing-override-secret
+
+
+
+=== TEST 19: finalized-filter request logs omit headers while transport stays intact
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local base = require("apisix.plugins.ai-proxy.base")
+            local provider_base = require("apisix.plugins.ai-providers.base")
+            local transport = require("apisix.plugins.ai-transport.http")
+            local exporter = require("apisix.plugins.prometheus.exporter")
+            local module_name = "apisix.plugins.ai-providers.task14-filtered-log-probe"
+            local original_provider = package.loaded[module_name]
+            local original_request = transport.request
+            local original_log_info = core.log.info
+            local original_inc = exporter.inc_llm_active_connections
+            local original_dec = exporter.dec_llm_active_connections
+            local logged = {}
+            local transported
+
+            package.loaded[module_name] = provider_base.new({
+                capabilities = {
+                    ["openai-chat"] = {
+                        path = "/v1/chat/completions",
+                        host = "filtered-llm.example.com",
+                    },
+                },
+            })
+            transport.request = function(params)
+                transported = core.table.deepcopy(params)
+                return nil, "timeout"
+            end
+            core.log.info = function(...)
+                for index = 1, select("#", ...) do
+                    logged[#logged + 1] = tostring(select(index, ...))
+                end
+            end
+            exporter.inc_llm_active_connections = function() end
+            exporter.dec_llm_active_connections = function() end
+
+            local ctx = {
+                ai_client_protocol = "openai-chat",
+                ai_final_request_body_filter = function(body)
+                    local masked = body:gsub(
+                        "filtered%-client%-body%-secret", "masked-final-body", 1
+                    )
+                    return masked
+                end,
+                picked_ai_instance = {
+                    name = "filtered-log-probe",
+                    provider = "task14-filtered-log-probe",
+                    auth = {
+                        header = {["X-Custom-Token"] = "custom-auth-value"},
+                    },
+                    override = {
+                        endpoint = "https://filtered-llm.example.com" ..
+                                   "/v1/chat/completions" ..
+                                   "?query-token=query-log-secret",
+                    },
+                },
+                var = {
+                    uri = "/v1/chat/completions",
+                    request_type = "ai_chat",
+                },
+            }
+            ngx.ctx.api_ctx = ctx
+
+            local ok, err = xpcall(function()
+                local code = base.before_proxy({ssl_verify = true}, ctx)
+                assert(type(code) == "number")
+            end, debug.traceback)
+            package.loaded[module_name] = original_provider
+            transport.request = original_request
+            core.log.info = original_log_info
+            exporter.inc_llm_active_connections = original_inc
+            exporter.dec_llm_active_connections = original_dec
+            assert(ok, err)
+
+            assert(transported.method == "POST")
+            assert(transported.scheme == "https")
+            assert(transported.host == "filtered-llm.example.com")
+            assert(transported.path == "/v1/chat/completions")
+            assert(transported.headers["x-ai-session-id"] == "session-header-value")
+            assert(transported.headers["x-custom-token"] == "custom-auth-value")
+            assert(transported.headers["x-forwarded-probe"] == "forwarded-value")
+            assert(transported.query["query-token"] == "query-log-secret")
+            assert(transported.body:find("masked-final-body", 1, true))
+            assert(not transported.body:find(
+                "filtered-client-body-secret", 1, true
+            ))
+
+            local output = table.concat(logged)
+            assert(output:find("sending request to LLM server", 1, true), output)
+            assert(output:find("filtered-llm.example.com", 1, true), output)
+            assert(output:find("/v1/chat/completions", 1, true), output)
+            for _, forbidden in ipairs({
+                "x-ai-session-id",
+                "session-header-value",
+                "x-custom-token",
+                "custom-auth-value",
+                "x-forwarded-probe",
+                "forwarded-value",
+                "query-token",
+                "query-log-secret",
+                "filtered-client-body-secret",
+                "masked-final-body",
+            }) do
+                assert(not output:lower():find(forbidden, 1, true), output)
+            end
+            ngx.say("filtered-request-log-header-free")
+        }
+    }
+--- request
+POST /t
+{"model":"test","messages":[{"role":"user","content":"filtered-client-body-secret"}]}
+--- more_headers
+Content-Type: application/json
+X-AI-Session-Id: session-header-value
+X-Forwarded-Probe: forwarded-value
+--- response_body
+filtered-request-log-header-free
+
+
+
+=== TEST 20: routes without a finalized filter retain forwarded request headers in logs
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local base = require("apisix.plugins.ai-proxy.base")
+            local provider_base = require("apisix.plugins.ai-providers.base")
+            local transport = require("apisix.plugins.ai-transport.http")
+            local exporter = require("apisix.plugins.prometheus.exporter")
+            local module_name = "apisix.plugins.ai-providers.task14-legacy-log-probe"
+            local original_provider = package.loaded[module_name]
+            local original_request = transport.request
+            local original_log_info = core.log.info
+            local original_inc = exporter.inc_llm_active_connections
+            local original_dec = exporter.dec_llm_active_connections
+            local logged = {}
+            local transported
+
+            package.loaded[module_name] = provider_base.new({
+                capabilities = {
+                    ["openai-chat"] = {
+                        path = "/v1/chat/completions",
+                        host = "legacy-llm.example.com",
+                    },
+                },
+            })
+            transport.request = function(params)
+                transported = core.table.deepcopy(params)
+                return nil, "timeout"
+            end
+            core.log.info = function(...)
+                for index = 1, select("#", ...) do
+                    logged[#logged + 1] = tostring(select(index, ...))
+                end
+            end
+            exporter.inc_llm_active_connections = function() end
+            exporter.dec_llm_active_connections = function() end
+
+            local ctx = {
+                ai_client_protocol = "openai-chat",
+                picked_ai_instance = {
+                    name = "legacy-log-probe",
+                    provider = "task14-legacy-log-probe",
+                    auth = {
+                        header = {["X-Custom-Token"] = "legacy-auth-value"},
+                    },
+                    override = {
+                        endpoint = "https://legacy-llm.example.com/v1/chat/completions",
+                    },
+                },
+                var = {
+                    uri = "/v1/chat/completions",
+                    request_type = "ai_chat",
+                },
+            }
+            ngx.ctx.api_ctx = ctx
+
+            local ok, err = xpcall(function()
+                local code = base.before_proxy({ssl_verify = true}, ctx)
+                assert(type(code) == "number")
+            end, debug.traceback)
+            package.loaded[module_name] = original_provider
+            transport.request = original_request
+            core.log.info = original_log_info
+            exporter.inc_llm_active_connections = original_inc
+            exporter.dec_llm_active_connections = original_dec
+            assert(ok, err)
+
+            assert(transported.headers["x-ai-session-id"] == "legacy-session-value")
+            assert(transported.headers["x-custom-token"] == "legacy-auth-value")
+            assert(transported.headers["x-forwarded-probe"] == "legacy-forwarded-value")
+            local output = table.concat(logged):lower()
+            for _, expected in ipairs({
+                "x-ai-session-id",
+                "legacy-session-value",
+                "x-custom-token",
+                "legacy-auth-value",
+                "x-forwarded-probe",
+                "legacy-forwarded-value",
+            }) do
+                assert(output:find(expected, 1, true), output)
+            end
+            ngx.say("legacy-request-log-headers-retained")
+        }
+    }
+--- request
+POST /t
+{"model":"test","messages":[{"role":"user","content":"legacy-body"}]}
+--- more_headers
+Content-Type: application/json
+X-AI-Session-Id: legacy-session-value
+X-Forwarded-Probe: legacy-forwarded-value
+--- response_body
+legacy-request-log-headers-retained

--- a/src/apisix/t/bk-ai-final-request-body-filter.t
+++ b/src/apisix/t/bk-ai-final-request-body-filter.t
@@ -1,0 +1,767 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+
+    my $http_config = $block->http_config // <<'_EOC_';
+        server {
+            listen 6727;
+
+            location /redact {
+                content_by_lua_block {
+                    local core = require("apisix.core")
+                    ngx.req.read_body()
+                    local payload = assert(core.json.decode(ngx.req.get_body_data()))
+                    assert(type(payload.body) == "string")
+                    local raw = payload.body
+                    local body = assert(core.json.decode(raw))
+                    local content = body.messages[1].content
+                    local namespace = payload.placeholder_namespace
+                    local replacements = {}
+                    local state = ngx.shared["plugin-limit-conn"]
+                    state:incr("final-redactor-calls", 1, 0)
+
+                    if content == "override-secret" then
+                        assert(body.model == "options-model")
+                        assert(body.max_completion_tokens == 111)
+                        assert(body.metadata.source == "override-secret")
+                        local message_token = namespace .. "1__"
+                        body.messages[1].content = message_token
+                        body.metadata.source = message_token
+                        raw = assert(core.json.encode(body))
+                        replacements = {
+                            {placeholder = message_token, original = "override-secret"},
+                        }
+
+                    elseif content == "numeric-control" then
+                        state:set("numeric-redactor-raw", raw)
+
+                    elseif content == "first-secret" then
+                        assert(body.model == "first-model")
+                        local token = namespace .. "1__"
+                        body.messages[1].content = token
+                        raw = assert(core.json.encode(body))
+                        replacements = {{placeholder = token, original = content}}
+
+                    elseif content == "second-secret" then
+                        assert(body.model == "second-model")
+                        local token = namespace .. "2__"
+                        body.messages[1].content = token
+                        raw = assert(core.json.encode(body))
+                        replacements = {{placeholder = token, original = content}}
+
+                    else
+                        error("unexpected finalized content")
+                    end
+
+                    if #replacements == 0 then
+                        setmetatable(replacements, core.json.array_mt)
+                    end
+                    ngx.header.content_type = "application/json"
+                    ngx.print(assert(core.json.encode({
+                        body = raw,
+                        replacements = replacements,
+                    })))
+                }
+            }
+
+            location /fail {
+                content_by_lua_block {
+                    ngx.shared["plugin-limit-conn"]:incr(
+                        "failed-redactor-calls", 1, 0
+                    )
+                    ngx.status = 500
+                    ngx.say("redactor unavailable")
+                }
+            }
+        }
+
+        server {
+            listen 6728;
+
+            location / {
+                content_by_lua_block {
+                    local core = require("apisix.core")
+                    ngx.req.read_body()
+                    local raw = ngx.req.get_body_data()
+                    local body = assert(core.json.decode(raw))
+                    local content = body.messages[1].content
+                    assert(body.model == "first-model")
+                    assert(content:find("__BK_REDACT_", 1, true))
+                    assert(not raw:find("first-secret", 1, true))
+                    ngx.shared["plugin-limit-conn"]:incr("first-llm-calls", 1, 0)
+                    ngx.status = 500
+                    ngx.header.content_type = "application/json"
+                    ngx.say('{"error":{"message":"retryable"}}')
+                }
+            }
+        }
+
+        server {
+            listen 6729;
+
+            location / {
+                content_by_lua_block {
+                    local core = require("apisix.core")
+                    ngx.req.read_body()
+                    local raw = ngx.req.get_body_data()
+                    local body = assert(core.json.decode(raw))
+                    local content = body.messages[1].content
+                    local response_content
+
+                    if body.model == "options-model" then
+                        assert(body.max_completion_tokens == 111)
+                        assert(not raw:find("client-secret", 1, true))
+                        assert(not raw:find("override-secret", 1, true))
+                        assert(content:find("__BK_REDACT_", 1, true))
+                        assert(body.metadata.source:find("__BK_REDACT_", 1, true))
+                        response_content = content .. ":" .. body.metadata.source
+
+                    elseif body.model == "numeric-model" then
+                        ngx.shared["plugin-limit-conn"]:set("numeric-llm-raw", raw)
+                        response_content = "numeric-ok"
+
+                    elseif body.model == "second-model" then
+                        assert(content:find("_2__", 1, true))
+                        assert(not raw:find("first-secret", 1, true))
+                        assert(not raw:find("second-secret", 1, true))
+                        ngx.shared["plugin-limit-conn"]:incr("second-llm-calls", 1, 0)
+                        response_content = content
+
+                    else
+                        error("unexpected LLM model")
+                    end
+
+                    ngx.header.content_type = "application/json"
+                    ngx.print(assert(core.json.encode({
+                        id = "chatcmpl-final-filter",
+                        object = "chat.completion",
+                        choices = {{
+                            index = 0,
+                            message = {role = "assistant", content = response_content},
+                            finish_reason = "stop",
+                        }},
+                        usage = {
+                            prompt_tokens = 1,
+                            completion_tokens = 1,
+                            total_tokens = 2,
+                        },
+                    })))
+                }
+            }
+        }
+
+        server {
+            listen 6730;
+
+            location / {
+                content_by_lua_block {
+                    ngx.shared["plugin-limit-conn"]:incr("forbidden-llm-calls", 1, 0)
+                    ngx.status = 500
+                }
+            }
+        }
+_EOC_
+    $block->set_value("http_config", $http_config);
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: final-body filter observes all provider overrides and isolates attempts
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local base = require("apisix.plugins.ai-providers.base")
+            local provider = base.new({
+                capabilities = {
+                    ["openai-chat"] = {
+                        path = "/v1/chat/completions",
+                        host = "localhost",
+                        rewrite_request_body = function(body, override)
+                            for key, value in pairs(override) do
+                                body[key] = value
+                            end
+                        end,
+                    },
+                },
+            })
+            local request_body = {
+                model = "client-model",
+                stream = false,
+                messages = {{role = "user", content = "client-secret"}},
+            }
+            local seen = {}
+            local ctx = {
+                ai_target_protocol = "openai-chat",
+                var = {},
+                ai_final_request_body_filter = function(raw_body)
+                    seen[#seen + 1] = raw_body
+                    local body = assert(core.json.decode(raw_body))
+                    body.messages[1].content = "masked"
+                    return assert(core.json.encode(body))
+                end,
+            }
+            local opts = {
+                auth = {},
+                conf = {},
+                target_path = "/v1/chat/completions",
+                model_options = {
+                    model = "options-model",
+                    option_secret = "option-secret",
+                },
+                override_llm_options = {llm_secret = "llm-secret"},
+                request_body_override_map = {
+                    ["openai-chat"] = {
+                        request_secret = "request-secret",
+                        messages = {{role = "user", content = "override-secret"}},
+                    },
+                },
+                request_body_force_override = true,
+            }
+
+            local params = assert(provider:build_request(
+                ctx, {ssl_verify = false}, request_body, opts
+            ))
+            local finalized = assert(core.json.decode(seen[1]))
+            assert(finalized.model == "options-model")
+            assert(finalized.option_secret == "option-secret")
+            assert(finalized.llm_secret == "llm-secret")
+            assert(finalized.request_secret == "request-secret")
+            assert(finalized.messages[1].content == "override-secret")
+            assert(assert(core.json.decode(params.body)).messages[1].content == "masked")
+            assert(request_body.model == "client-model")
+            assert(request_body.messages[1].content == "client-secret")
+
+            opts.model_options.model = "second-model"
+            opts.request_body_override_map["openai-chat"].messages[1].content =
+                "second-secret"
+            assert(provider:build_request(ctx, {ssl_verify = false}, request_body, opts))
+            local second = assert(core.json.decode(seen[2]))
+            assert(second.model == "second-model")
+            assert(second.messages[1].content == "second-secret")
+            assert(request_body.model == "client-model")
+            assert(request_body.messages[1].content == "client-secret")
+            ngx.say("final-overrides-isolated")
+        }
+    }
+--- response_body
+final-overrides-isolated
+
+
+
+=== TEST 2: untouched raw JSON numeric lexemes reach the filter and transport unchanged
+--- config
+    location /t {
+        content_by_lua_block {
+            local base = require("apisix.plugins.ai-providers.base")
+            local provider = base.new({capabilities = {}})
+            local raw = '{"model":"gpt-4o","large":9007199254740993,' ..
+                        '"long":123456789012345678901234567890,' ..
+                        '"negative_zero":-0,"exponent":1.2300e+40,' ..
+                        '"messages":[{"role":"user","content":"secret"}]}'
+            local seen
+            local ctx = {
+                ai_target_protocol = "openai-chat",
+                ai_raw_request_body = raw,
+                var = {},
+                ai_final_request_body_filter = function(body)
+                    seen = body
+                    local masked = body:gsub("secret", "masked", 1)
+                    return masked
+                end,
+            }
+            local params = assert(provider:build_request(
+                ctx,
+                {ssl_verify = false},
+                {model = "gpt-4o", messages = {{role = "user", content = "secret"}}},
+                {auth = {}, conf = {}, target_path = "/v1/chat/completions"}
+            ))
+
+            assert(seen == raw)
+            assert(params.body == raw:gsub("secret", "masked", 1))
+            assert(params.body:find("9007199254740993", 1, true))
+            assert(params.body:find("123456789012345678901234567890", 1, true))
+            assert(params.body:find("-0", 1, true))
+            assert(params.body:find("1.2300e+40", 1, true))
+            ngx.say("numeric-lexemes-preserved")
+        }
+    }
+--- response_body
+numeric-lexemes-preserved
+
+
+
+=== TEST 3: SigV4 signs the filtered AWS serialization
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local base = require("apisix.plugins.ai-providers.base")
+            local old_auth_aws = package.loaded["apisix.plugins.ai-transport.auth-aws"]
+            local signed_body
+            package.loaded["apisix.plugins.ai-transport.auth-aws"] = {
+                sign_request = function(params)
+                    signed_body = params.body
+                end,
+            }
+
+            local ok, err = xpcall(function()
+                local provider = base.new({
+                    aws_sigv4 = true,
+                    remove_model = true,
+                    capabilities = {},
+                })
+                local filtered = '{"messages":[{"content":[{"text":"masked"}],' ..
+                                 '"role":"user"}]}'
+                local seen
+                local ctx = {
+                    ai_target_protocol = "bedrock-converse",
+                    var = {},
+                    ai_final_request_body_filter = function(body)
+                        seen = body
+                        return filtered
+                    end,
+                }
+                local params = assert(provider:build_request(
+                    ctx,
+                    {ssl_verify = false},
+                    {
+                        model = "bedrock-model",
+                        messages = {{
+                            role = "user",
+                            content = {{text = "secret"}},
+                        }},
+                    },
+                    {
+                        auth = {aws = {
+                            access_key_id = "test",
+                            secret_access_key = "test",
+                        }},
+                        conf = {region = "us-east-1"},
+                        target_path = "/model/bedrock-model/converse",
+                    }
+                ))
+
+                local serialized = assert(core.json.decode(seen))
+                assert(serialized.model == nil)
+                assert(serialized.messages[1].content[1].text == "secret")
+                assert(signed_body == filtered)
+                assert(params.body == filtered)
+            end, debug.traceback)
+
+            package.loaded["apisix.plugins.ai-transport.auth-aws"] = old_auth_aws
+            assert(ok, err)
+            ngx.say("filtered-body-signed")
+        }
+    }
+--- response_body
+filtered-body-signed
+
+
+
+=== TEST 4: callback exceptions and invalid returns fail generically and non-retryably
+--- config
+    location /t {
+        content_by_lua_block {
+            local base = require("apisix.plugins.ai-providers.base")
+            local provider = base.new({capabilities = {}})
+
+            local function build(callback)
+                local picker = {}
+                local ctx = {
+                    ai_target_protocol = "openai-chat",
+                    ai_request_body_changed = true,
+                    ai_final_request_body_filter = callback,
+                    server_picker = picker,
+                    var = {},
+                }
+                local params, err, status = provider:build_request(
+                    ctx,
+                    {ssl_verify = false},
+                    {messages = {{role = "user", content = "secret"}}},
+                    {auth = {}, conf = {}, target_path = "/v1/chat/completions"}
+                )
+                assert(params == nil)
+                assert(type(err) == "table")
+                assert(err.message == "failed to filter final AI request body")
+                assert(status == 500)
+                assert(ctx.server_picker == nil)
+            end
+
+            build(function()
+                error("secret must not be copied to an error")
+            end)
+            build(function()
+                return {}
+            end)
+            ngx.say("callback-failures-contained")
+        }
+    }
+--- response_body
+callback-failures-contained
+--- no_error_log
+secret must not be copied to an error
+
+
+
+=== TEST 5: routes without a callback retain table transport behavior
+--- config
+    location /t {
+        content_by_lua_block {
+            local base = require("apisix.plugins.ai-providers.base")
+            local provider = base.new({capabilities = {}})
+            local request_body = {
+                model = "gpt-4o",
+                messages = {{role = "user", content = "unchanged"}},
+            }
+            local params = assert(provider:build_request(
+                {ai_target_protocol = "openai-chat", var = {}},
+                {ssl_verify = false},
+                request_body,
+                {
+                    auth = {},
+                    conf = {},
+                    target_path = "/v1/chat/completions",
+                    model_options = {temperature = 0.5},
+                }
+            ))
+            assert(type(params.body) == "table")
+            assert(params.body == request_body)
+            ngx.say("legacy-route-unchanged")
+        }
+    }
+--- response_body
+legacy-route-unchanged
+
+
+
+=== TEST 6: configure finalized-body integration routes
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin").test
+            local state = ngx.shared["plugin-limit-conn"]
+            for _, key in ipairs({
+                "final-redactor-calls",
+                "numeric-redactor-raw",
+                "numeric-llm-raw",
+                "first-llm-calls",
+                "second-llm-calls",
+                "failed-redactor-calls",
+                "forbidden-llm-calls",
+            }) do
+                state:delete(key)
+            end
+
+            local redaction = {
+                endpoint = "http://127.0.0.1:6727/redact",
+                ssl_verify = false,
+                keepalive = false,
+            }
+            local routes = {
+                {
+                    id = 20,
+                    value = {
+                        uri = "/final-overrides",
+                        plugins = {
+                            ["ai-proxy"] = {
+                                provider = "openai",
+                                auth = {header = {Authorization = "Bearer test"}},
+                                options = {model = "options-model"},
+                                override = {
+                                    endpoint = "http://127.0.0.1:6729",
+                                    llm_options = {max_tokens = 111},
+                                    request_body = {
+                                        ["openai-chat"] = {
+                                            messages = {{
+                                                role = "user",
+                                                content = "override-secret",
+                                            }},
+                                            metadata = {source = "override-secret"},
+                                        },
+                                    },
+                                    request_body_force_override = true,
+                                },
+                                ssl_verify = false,
+                            },
+                            ["bk-ai-sensitive-data-redaction"] = redaction,
+                        },
+                    },
+                },
+                {
+                    id = 21,
+                    value = {
+                        uri = "/numeric-lexemes",
+                        plugins = {
+                            ["ai-proxy"] = {
+                                provider = "openai",
+                                auth = {header = {Authorization = "Bearer test"}},
+                                override = {endpoint = "http://127.0.0.1:6729"},
+                                ssl_verify = false,
+                            },
+                            ["bk-ai-sensitive-data-redaction"] = redaction,
+                        },
+                    },
+                },
+                {
+                    id = 22,
+                    value = {
+                        uri = "/multi-fallback",
+                        plugins = {
+                            ["ai-proxy-multi"] = {
+                                fallback_strategy = {"http_5xx"},
+                                balancer = {algorithm = "roundrobin"},
+                                instances = {
+                                    {
+                                        name = "first",
+                                        provider = "openai",
+                                        priority = 10,
+                                        weight = 1,
+                                        auth = {header = {Authorization = "Bearer test"}},
+                                        options = {model = "first-model"},
+                                        override = {
+                                            endpoint = "http://127.0.0.1:6728",
+                                            request_body = {[
+                                                "openai-chat"
+                                            ] = {messages = {{
+                                                role = "user",
+                                                content = "first-secret",
+                                            }}}},
+                                            request_body_force_override = true,
+                                        },
+                                    },
+                                    {
+                                        name = "second",
+                                        provider = "openai",
+                                        priority = 0,
+                                        weight = 1,
+                                        auth = {header = {Authorization = "Bearer test"}},
+                                        options = {model = "second-model"},
+                                        override = {
+                                            endpoint = "http://127.0.0.1:6729",
+                                            request_body = {[
+                                                "openai-chat"
+                                            ] = {messages = {{
+                                                role = "user",
+                                                content = "second-secret",
+                                            }}}},
+                                            request_body_force_override = true,
+                                        },
+                                    },
+                                },
+                                ssl_verify = false,
+                            },
+                            ["bk-ai-sensitive-data-redaction"] = redaction,
+                        },
+                    },
+                },
+                {
+                    id = 23,
+                    value = {
+                        uri = "/multi-redactor-failure",
+                        plugins = {
+                            ["ai-proxy-multi"] = {
+                                fallback_strategy = {"http_5xx"},
+                                balancer = {algorithm = "roundrobin"},
+                                instances = {
+                                    {
+                                        name = "forbidden-first",
+                                        provider = "openai",
+                                        priority = 10,
+                                        weight = 1,
+                                        auth = {header = {Authorization = "Bearer test"}},
+                                        options = {model = "first-model"},
+                                        override = {endpoint = "http://127.0.0.1:6730"},
+                                    },
+                                    {
+                                        name = "forbidden-second",
+                                        provider = "openai",
+                                        priority = 0,
+                                        weight = 1,
+                                        auth = {header = {Authorization = "Bearer test"}},
+                                        options = {model = "second-model"},
+                                        override = {endpoint = "http://127.0.0.1:6730"},
+                                    },
+                                },
+                                ssl_verify = false,
+                            },
+                            ["bk-ai-sensitive-data-redaction"] = {
+                                endpoint = "http://127.0.0.1:6727/fail",
+                                ssl_verify = false,
+                                keepalive = false,
+                            },
+                        },
+                    },
+                },
+            }
+
+            for _, route in ipairs(routes) do
+                local code, body = t(
+                    "/apisix/admin/routes/" .. route.id,
+                    ngx.HTTP_PUT,
+                    assert(core.json.encode(route.value))
+                )
+                assert(code < 300, body)
+            end
+            ngx.say("routes-configured")
+        }
+    }
+--- response_body
+routes-configured
+
+
+
+=== TEST 7: redactor and LLM observe finalized overrides and identical numeric lexemes
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local http = require("resty.http")
+            local base_url = "http://127.0.0.1:" .. ngx.var.server_port
+            local final = assert(http.new():request_uri(base_url .. "/final-overrides", {
+                method = "POST",
+                keepalive = false,
+                headers = {["Content-Type"] = "application/json"},
+                body = assert(core.json.encode({
+                    model = "client-model",
+                    stream = false,
+                    messages = {{role = "user", content = "client-secret"}},
+                })),
+            }))
+            assert(final.status == 200, final.body)
+            local final_body = assert(core.json.decode(final.body))
+            assert(
+                final_body.choices[1].message.content ==
+                "override-secret:override-secret"
+            )
+            assert(not final.body:find("__BK_REDACT_", 1, true))
+
+            local numeric_raw =
+                '{"model":"numeric-model","stream":false,' ..
+                '"large":9007199254740993,' ..
+                '"long":123456789012345678901234567890,' ..
+                '"negative_zero":-0,"exponent":1.2300e+40,' ..
+                '"messages":[{"role":"user","content":"numeric-control"}]}'
+            local numeric = assert(http.new():request_uri(base_url .. "/numeric-lexemes", {
+                method = "POST",
+                keepalive = false,
+                headers = {["Content-Type"] = "application/json"},
+                body = numeric_raw,
+            }))
+            assert(numeric.status == 200, numeric.body)
+            local state = ngx.shared["plugin-limit-conn"]
+            local redactor_raw = state:get("numeric-redactor-raw")
+            local llm_raw = state:get("numeric-llm-raw")
+            assert(redactor_raw == numeric_raw)
+            assert(llm_raw == numeric_raw)
+            for _, lexeme in ipairs({
+                "9007199254740993",
+                "123456789012345678901234567890",
+                "-0",
+                "1.2300e+40",
+            }) do
+                assert(redactor_raw:find(lexeme, 1, true))
+                assert(llm_raw:find(lexeme, 1, true))
+            end
+            ngx.say("final-and-numeric-observed")
+        }
+    }
+--- response_body
+final-and-numeric-observed
+
+
+
+=== TEST 8: retryable LLM failure re-filters second attempt and restores newest mapping
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local response = assert(require("resty.http").new():request_uri(
+                "http://127.0.0.1:" .. ngx.var.server_port .. "/multi-fallback", {
+                    method = "POST",
+                    keepalive = false,
+                    headers = {["Content-Type"] = "application/json"},
+                    body = assert(core.json.encode({
+                        model = "client-model",
+                        stream = false,
+                        messages = {{role = "user", content = "client-secret"}},
+                    })),
+                }
+            ))
+            assert(
+                response.status == 200,
+                "unexpected multi status " .. response.status .. ": " .. response.body
+            )
+            local body = assert(core.json.decode(response.body))
+            assert(body.choices[1].message.content == "second-secret")
+            assert(not response.body:find("first-secret", 1, true))
+            assert(not response.body:find("__BK_REDACT_", 1, true))
+            local state = ngx.shared["plugin-limit-conn"]
+            assert(state:get("first-llm-calls") == 1)
+            assert(state:get("second-llm-calls") == 1)
+            assert(state:get("final-redactor-calls") == 2)
+            ngx.say("multi-fallback-restored")
+        }
+    }
+--- response_body
+multi-fallback-restored
+
+
+
+=== TEST 9: redactor 502 is returned without an LLM call or fallback
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local response = assert(require("resty.http").new():request_uri(
+                "http://127.0.0.1:" .. ngx.var.server_port ..
+                "/multi-redactor-failure", {
+                    method = "POST",
+                    keepalive = false,
+                    headers = {["Content-Type"] = "application/json"},
+                    body = assert(core.json.encode({
+                        model = "client-model",
+                        stream = false,
+                        messages = {{role = "user", content = "secret"}},
+                    })),
+                }
+            ))
+            assert(response.status == 502, response.body)
+            local state = ngx.shared["plugin-limit-conn"]
+            assert(state:get("failed-redactor-calls") == 1)
+            assert((state:get("forbidden-llm-calls") or 0) == 0)
+            ngx.say("redactor-failure-not-retried")
+        }
+    }
+--- response_body
+redactor-failure-not-retried

--- a/src/apisix/t/bk-ai-final-request-body-filter.t
+++ b/src/apisix/t/bk-ai-final-request-body-filter.t
@@ -52,9 +52,11 @@ add_block_preprocessor(sub {
                         assert(body.max_completion_tokens == 111)
                         assert(body.metadata.source == "override-secret")
                         local message_token = namespace .. "1__"
-                        body.messages[1].content = message_token
-                        body.metadata.source = message_token
-                        raw = assert(core.json.encode(body))
+                        local replacement_count
+                        raw, replacement_count = raw:gsub(
+                            "override%-secret", message_token
+                        )
+                        assert(replacement_count == 2)
                         replacements = {
                             {placeholder = message_token, original = "override-secret"},
                         }
@@ -65,15 +67,13 @@ add_block_preprocessor(sub {
                     elseif content == "first-secret" then
                         assert(body.model == "first-model")
                         local token = namespace .. "1__"
-                        body.messages[1].content = token
-                        raw = assert(core.json.encode(body))
+                        raw = raw:gsub("first%-secret", token, 1)
                         replacements = {{placeholder = token, original = content}}
 
                     elseif content == "second-secret" then
                         assert(body.model == "second-model")
                         local token = namespace .. "2__"
-                        body.messages[1].content = token
-                        raw = assert(core.json.encode(body))
+                        raw = raw:gsub("second%-secret", token, 1)
                         replacements = {{placeholder = token, original = content}}
 
                     else
@@ -404,7 +404,7 @@ filtered-body-signed
                     server_picker = picker,
                     var = {},
                 }
-                local params, err, status = provider:build_request(
+                local params, err, status, non_retryable = provider:build_request(
                     ctx,
                     {ssl_verify = false},
                     {messages = {{role = "user", content = "secret"}}},
@@ -414,7 +414,8 @@ filtered-body-signed
                 assert(type(err) == "table")
                 assert(err.message == "failed to filter final AI request body")
                 assert(status == 500)
-                assert(ctx.server_picker == nil)
+                assert(non_retryable == true)
+                assert(ctx.server_picker == picker)
             end
 
             build(function()
@@ -433,7 +434,155 @@ secret must not be copied to an error
 
 
 
-=== TEST 5: routes without a callback retain table transport behavior
+=== TEST 5: provider-local mutations do not force later retries to re-encode raw JSON
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local base = require("apisix.plugins.ai-providers.base")
+            local provider = base.new({capabilities = {}})
+            local raw = '{"model":"client-model","large":9007199254740993,' ..
+                        '"messages":[{"role":"user","content":"client-secret"}]}'
+            local request_body = assert(core.json.decode(raw))
+            local seen = {}
+            local ctx = {
+                ai_target_protocol = "openai-chat",
+                ai_raw_request_body = raw,
+                var = {},
+                ai_final_request_body_filter = function(body)
+                    seen[#seen + 1] = body
+                    return body
+                end,
+            }
+
+            assert(provider:build_request(
+                ctx, {ssl_verify = false}, request_body, {
+                    auth = {},
+                    conf = {},
+                    target_path = "/v1/chat/completions",
+                    model_options = {model = "first-provider-model"},
+                }
+            ))
+            assert(assert(core.json.decode(seen[1])).model == "first-provider-model")
+            assert(ctx.ai_request_body_changed == nil)
+
+            local second = assert(provider:build_request(
+                ctx, {ssl_verify = false}, request_body,
+                {auth = {}, conf = {}, target_path = "/v1/chat/completions"}
+            ))
+            assert(seen[2] == raw)
+            assert(second.body == raw)
+            assert(second.body:find("9007199254740993", 1, true))
+            ngx.say("retry-kept-raw-lexeme")
+        }
+    }
+--- response_body
+retry-kept-raw-lexeme
+
+
+
+=== TEST 6: finalized-body routes omit body-bearing extra options from logs
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local base = require("apisix.plugins.ai-providers.base")
+            local provider = base.new({
+                capabilities = {
+                    ["openai-chat"] = {
+                        rewrite_request_body = function(body, override)
+                            for key, value in pairs(override) do
+                                body[key] = value
+                            end
+                        end,
+                    },
+                },
+            })
+            local logged = {}
+            local original_log_info = core.log.info
+            core.log.info = function(...)
+                for index = 1, select("#", ...) do
+                    logged[#logged + 1] = tostring(select(index, ...))
+                end
+            end
+
+            local ok, err = xpcall(function()
+                assert(provider:build_request(
+                    {
+                        ai_target_protocol = "openai-chat",
+                        var = {},
+                        ai_final_request_body_filter = function(body)
+                            return body
+                        end,
+                    },
+                    {ssl_verify = false},
+                    {messages = {{role = "user", content = "client-log-secret"}}},
+                    {
+                        auth = {},
+                        conf = {},
+                        target_path = "/v1/chat/completions",
+                        model_options = {model = "model-option-log-secret"},
+                        override_llm_options = {metadata = "llm-option-log-secret"},
+                        request_body_override_map = {
+                            ["openai-chat"] = {
+                                prompt = "request-override-log-secret",
+                            },
+                        },
+                        request_body_force_override = true,
+                    }
+                ))
+            end, debug.traceback)
+            core.log.info = original_log_info
+            assert(ok, err)
+
+            local output = table.concat(logged)
+            for _, secret in ipairs({
+                "client-log-secret",
+                "model-option-log-secret",
+                "llm-option-log-secret",
+                "request-override-log-secret",
+            }) do
+                assert(not output:find(secret, 1, true), output)
+            end
+            ngx.say("final-extra-opts-content-free")
+        }
+    }
+--- response_body
+final-extra-opts-content-free
+
+
+
+=== TEST 7: ai-proxy-multi log releases least-conn attempt state after filter failure
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local least_conn = require("apisix.balancer.least_conn")
+            local ai_proxy_multi = require("apisix.plugins.ai-proxy-multi")
+            local picker = least_conn.new({first = 1}, {first = 1})
+            local ctx = {
+                server_picker = picker,
+                balancer_tried_servers = core.tablepool.fetch(
+                    "balancer_tried_servers", 0, 2
+                ),
+                var = {},
+            }
+            local server = assert(picker.get(ctx))
+            ctx.balancer_server = server
+
+            ai_proxy_multi.log({}, ctx)
+
+            assert(ctx.server_picker == picker)
+            assert(ctx.balancer_tried_servers == nil)
+            ngx.say("least-conn-filter-failure-cleaned")
+        }
+    }
+--- response_body
+least-conn-filter-failure-cleaned
+
+
+
+=== TEST 8: routes without a callback retain table transport behavior
 --- config
     location /t {
         content_by_lua_block {
@@ -464,7 +613,7 @@ legacy-route-unchanged
 
 
 
-=== TEST 6: configure finalized-body integration routes
+=== TEST 9: configure finalized-body integration routes
 --- config
     location /t {
         content_by_lua_block {
@@ -623,6 +772,42 @@ legacy-route-unchanged
                         },
                     },
                 },
+                {
+                    id = 24,
+                    value = {
+                        uri = "/callback-exception",
+                        plugins = {
+                            ["serverless-pre-function"] = {
+                                phase = "access",
+                                functions = {
+                                    "return function(conf, ctx) " ..
+                                    "ctx.ai_final_request_body_filter = function() " ..
+                                    "error('callback exploded') end end",
+                                },
+                            },
+                            ["ai-proxy"] = {
+                                provider = "openai",
+                                auth = {header = {Authorization = "Bearer test"}},
+                                override = {endpoint = "http://127.0.0.1:6730"},
+                                ssl_verify = false,
+                            },
+                        },
+                    },
+                },
+                {
+                    id = 25,
+                    value = {
+                        uri = "/ordinary-build-error/v1/messages",
+                        plugins = {
+                            ["ai-proxy"] = {
+                                provider = "openai",
+                                auth = {header = {Authorization = "Bearer test"}},
+                                override = {endpoint = "http://127.0.0.1:6730"},
+                                ssl_verify = false,
+                            },
+                        },
+                    },
+                },
             }
 
             for _, route in ipairs(routes) do
@@ -641,7 +826,7 @@ routes-configured
 
 
 
-=== TEST 7: redactor and LLM observe finalized overrides and identical numeric lexemes
+=== TEST 10: redactor and LLM observe finalized overrides and identical numeric lexemes
 --- config
     location /t {
         content_by_lua_block {
@@ -701,7 +886,7 @@ final-and-numeric-observed
 
 
 
-=== TEST 8: retryable LLM failure re-filters second attempt and restores newest mapping
+=== TEST 11: retryable LLM failure re-filters second attempt and restores newest mapping
 --- config
     location /t {
         content_by_lua_block {
@@ -738,7 +923,7 @@ multi-fallback-restored
 
 
 
-=== TEST 9: redactor 502 is returned without an LLM call or fallback
+=== TEST 12: redactor 502 propagates directly without fallback
 --- config
     location /t {
         content_by_lua_block {
@@ -757,11 +942,84 @@ multi-fallback-restored
                 }
             ))
             assert(response.status == 502, response.body)
+            local error_body = assert(core.json.decode(response.body))
+            assert(error_body.message == "redaction service returned status 500")
+            assert(error_body.error_msg == nil)
+            local fields = 0
+            for _ in pairs(error_body) do
+                fields = fields + 1
+            end
+            assert(fields == 1)
             local state = ngx.shared["plugin-limit-conn"]
             assert(state:get("failed-redactor-calls") == 1)
             assert((state:get("forbidden-llm-calls") or 0) == 0)
-            ngx.say("redactor-failure-not-retried")
+            ngx.say("redactor-failure-direct")
         }
     }
 --- response_body
-redactor-failure-not-retried
+redactor-failure-direct
+
+
+
+=== TEST 13: callback exceptions propagate the generic body without nesting
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local response = assert(require("resty.http").new():request_uri(
+                "http://127.0.0.1:" .. ngx.var.server_port ..
+                "/callback-exception", {
+                    method = "POST",
+                    keepalive = false,
+                    headers = {["Content-Type"] = "application/json"},
+                    body = '{"model":"test","messages":' ..
+                           '[{"role":"user","content":"secret"}]}',
+                }
+            ))
+            assert(response.status == 500, response.body)
+            local error_body = assert(core.json.decode(response.body))
+            assert(error_body.message == "failed to filter final AI request body")
+            assert(error_body.error_msg == nil)
+            local fields = 0
+            for _ in pairs(error_body) do
+                fields = fields + 1
+            end
+            assert(fields == 1)
+            ngx.say("generic-filter-error-direct")
+        }
+    }
+--- response_body
+generic-filter-error-direct
+
+
+
+=== TEST 14: ordinary provider build errors retain the error_msg wrapper
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local response = assert(require("resty.http").new():request_uri(
+                "http://127.0.0.1:" .. ngx.var.server_port ..
+                "/ordinary-build-error/v1/messages", {
+                    method = "POST",
+                    keepalive = false,
+                    headers = {["Content-Type"] = "application/json"},
+                    body = '{"model":"ordinary-model"}',
+                }
+            ))
+            assert(response.status == 400, response.body)
+            local error_body = assert(core.json.decode(response.body))
+            assert(
+                error_body.error_msg == "missing messages"
+            )
+            assert(error_body.message == nil)
+            local fields = 0
+            for _ in pairs(error_body) do
+                fields = fields + 1
+            end
+            assert(fields == 1)
+            ngx.say("ordinary-build-error-wrapped")
+        }
+    }
+--- response_body
+ordinary-build-error-wrapped

--- a/src/apisix/t/bk-ai-final-request-body-filter.t
+++ b/src/apisix/t/bk-ai-final-request-body-filter.t
@@ -1030,3 +1030,251 @@ generic-filter-error-direct
     }
 --- response_body
 ordinary-build-error-wrapped
+
+
+
+=== TEST 15: early provider build failure keeps finalized-filter payload logging empty
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local ai_proxy = require("apisix.plugins.ai-proxy")
+            local base = require("apisix.plugins.ai-proxy.base")
+            local exporter = require("apisix.plugins.prometheus.exporter")
+            local logged = {}
+            local original_log_info = core.log.info
+            local original_log_error = core.log.error
+            local original_inc = exporter.inc_llm_active_connections
+            local original_dec = exporter.dec_llm_active_connections
+            local callback_calls = 0
+            local ctx = {
+                ai_client_protocol = "bedrock-converse",
+                ai_final_request_body_filter = function(body)
+                    callback_calls = callback_calls + 1
+                    return body
+                end,
+                picked_ai_instance = {
+                    name = "early-build-failure",
+                    provider = "bedrock",
+                    provider_conf = {region = "us-east-1"},
+                    auth = {},
+                    override = {
+                        request_body = {
+                            ["bedrock-converse"] = {
+                                metadata = {secret = "body-bearing-override-secret"},
+                            },
+                        },
+                    },
+                },
+                var = {
+                    uri = "/model/missing/converse",
+                    request_type = "ai_chat",
+                },
+            }
+
+            local function capture(...)
+                for index = 1, select("#", ...) do
+                    local value = select(index, ...)
+                    if type(value) == "string" then
+                        logged[#logged + 1] = value
+                    else
+                        local ok, encoded = pcall(core.json.encode, value)
+                        logged[#logged + 1] = ok and encoded or tostring(value)
+                    end
+                end
+            end
+
+            core.log.info = capture
+            core.log.error = capture
+            exporter.inc_llm_active_connections = function() end
+            exporter.dec_llm_active_connections = function() end
+            ngx.ctx.api_ctx = ctx
+            local ok, err = xpcall(function()
+                local code, body = base.before_proxy({}, ctx)
+                assert(code == 400)
+                assert(type(body) == "table")
+                assert(body.error_msg:find("could not resolve upstream path", 1, true))
+                assert(callback_calls == 0)
+
+                ai_proxy.log({logging = {summaries = false, payloads = true}}, ctx)
+            end, debug.traceback)
+            core.log.info = original_log_info
+            core.log.error = original_log_error
+            exporter.inc_llm_active_connections = original_inc
+            exporter.dec_llm_active_connections = original_dec
+            assert(ok, err)
+
+            local payload = assert(core.json.encode(ctx.llm_request))
+            local output = table.concat(logged)
+            for _, secret in ipairs({
+                "early-client-secret",
+                "body-bearing-override-secret",
+            }) do
+                assert(not payload:find(secret, 1, true), payload)
+                assert(not output:find(secret, 1, true), output)
+            end
+            ngx.say("early-build-payload-safe")
+        }
+    }
+--- request
+POST /t
+{"messages":[{"role":"user","content":[{"text":"early-client-secret"}]}]}
+--- more_headers
+Content-Type: application/json
+--- response_body
+early-build-payload-safe
+--- no_error_log
+early-client-secret
+body-bearing-override-secret
+
+
+
+=== TEST 16: every finalized-filter retry clears the prior logging view before build
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local ai_proxy = require("apisix.plugins.ai-proxy")
+            local base = require("apisix.plugins.ai-proxy.base")
+            local exporter = require("apisix.plugins.prometheus.exporter")
+            local module_name = "apisix.plugins.ai-providers.task10-attempt-probe"
+            local original_provider = package.loaded[module_name]
+            local original_inc = exporter.inc_llm_active_connections
+            local original_dec = exporter.dec_llm_active_connections
+            local snapshots = {}
+            local callback_calls = 0
+            local attempts = 0
+            local ctx
+
+            package.loaded[module_name] = {
+                capabilities = {
+                    ["openai-chat"] = {
+                        path = "/v1/chat/completions",
+                        host = "localhost",
+                    },
+                },
+                build_request = function(_, build_ctx)
+                    attempts = attempts + 1
+                    snapshots[attempts] = core.table.deepcopy(
+                        build_ctx.var.llm_request_body
+                    )
+                    assert(build_ctx.ai_final_request_body_filter("{}") == "{}")
+                    if attempts == 1 then
+                        return nil, "retry first build", 500
+                    end
+                    return nil, "stop second build", 400
+                end,
+            }
+            exporter.inc_llm_active_connections = function() end
+            exporter.dec_llm_active_connections = function() end
+
+            ctx = {
+                ai_client_protocol = "openai-chat",
+                ai_final_request_body_filter = function(body)
+                    callback_calls = callback_calls + 1
+                    ctx.var.llm_request_body = {
+                        messages = {{
+                            role = "user",
+                            content = "masked-attempt-" .. callback_calls,
+                        }},
+                    }
+                    return body
+                end,
+                picked_ai_instance = {
+                    name = "attempt-probe",
+                    provider = "task10-attempt-probe",
+                    auth = {},
+                },
+                var = {
+                    uri = "/v1/chat/completions",
+                    request_type = "ai_chat",
+                    llm_request_body = {
+                        messages = {{role = "user", content = "stale-masked-view"}},
+                    },
+                },
+            }
+            ngx.ctx.api_ctx = ctx
+
+            local ok, err = xpcall(function()
+                local code = base.before_proxy({}, ctx, function(_, _, attempt_code)
+                    if attempt_code == 500 then
+                        return
+                    end
+                    return attempt_code
+                end)
+                assert(code == 400)
+                assert(attempts == 2)
+                assert(callback_calls == 2)
+                assert(next(snapshots[1]) == nil)
+                assert(next(snapshots[2]) == nil)
+
+                ai_proxy.log({logging = {summaries = false, payloads = true}}, ctx)
+                local payload = assert(core.json.encode(ctx.llm_request))
+                assert(payload:find("masked%-attempt%-2"))
+                assert(not payload:find("retry-client-secret", 1, true))
+                assert(not payload:find("stale-masked-view", 1, true))
+            end, debug.traceback)
+            package.loaded[module_name] = original_provider
+            exporter.inc_llm_active_connections = original_inc
+            exporter.dec_llm_active_connections = original_dec
+            assert(ok, err)
+            ngx.say("every-attempt-view-reset")
+        }
+    }
+--- request
+POST /t
+{"messages":[{"role":"user","content":"retry-client-secret"}]}
+--- more_headers
+Content-Type: application/json
+--- response_body
+every-attempt-view-reset
+
+
+
+=== TEST 17: routes without a finalized filter retain the original logging view
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local ai_proxy = require("apisix.plugins.ai-proxy")
+            local base = require("apisix.plugins.ai-proxy.base")
+            local exporter = require("apisix.plugins.prometheus.exporter")
+            local original_inc = exporter.inc_llm_active_connections
+            local original_dec = exporter.dec_llm_active_connections
+            exporter.inc_llm_active_connections = function() end
+            exporter.dec_llm_active_connections = function() end
+            local ctx = {
+                ai_client_protocol = "bedrock-converse",
+                picked_ai_instance = {
+                    name = "legacy-build-failure",
+                    provider = "bedrock",
+                    provider_conf = {region = "us-east-1"},
+                    auth = {},
+                },
+                var = {
+                    uri = "/model/missing/converse",
+                    request_type = "ai_chat",
+                },
+            }
+            ngx.ctx.api_ctx = ctx
+
+            local code, body = base.before_proxy({}, ctx)
+            assert(code == 400, assert(core.json.encode({code = code, body = body})))
+            assert(type(body) == "table")
+            assert(body.error_msg:find("could not resolve upstream path", 1, true))
+
+            ai_proxy.log({logging = {summaries = false, payloads = true}}, ctx)
+            exporter.inc_llm_active_connections = original_inc
+            exporter.dec_llm_active_connections = original_dec
+            local payload = assert(core.json.encode(ctx.llm_request))
+            assert(payload:find("legacy-client-secret", 1, true))
+            ngx.say("legacy-original-payload-retained")
+        }
+    }
+--- request
+POST /t
+{"messages":[{"role":"user","content":[{"text":"legacy-client-secret"}]}]}
+--- more_headers
+Content-Type: application/json
+--- response_body
+legacy-original-payload-retained

--- a/src/apisix/t/bk-ai-response-filter-eof.t
+++ b/src/apisix/t/bk-ai-response-filter-eof.t
@@ -489,23 +489,136 @@ aborting AI stream: max_response_bytes exceeded
                 base, ctx, res, target_proto, nil,
                 {streaming_flush_interval_ms = 0})
             local headers_sent = ngx.headers_sent
+            local fallback_calls = 0
             if code and not headers_sent then
+                fallback_calls = fallback_calls + 1
                 ngx.status = code
             end
             ngx.say("code:", code, ", eof_calls:", eof_calls,
                     ", reason:", abort_reason,
-                    ", headers_sent:", headers_sent)
+                    ", headers_sent:", headers_sent,
+                    ", fallback_calls:", fallback_calls)
         }
     }
 --- response_body
-code:504, eof_calls:1, reason:upstream_read_error, headers_sent:false
+code:504, eof_calls:1, reason:upstream_read_error, headers_sent:false, fallback_calls:1
 --- error_code: 504
 --- error_log
 failed to read response chunk: timeout
 
 
 
-=== TEST 10: downstream disconnect does not invoke EOF finalization
+=== TEST 10: upstream read error with EOF output returns a partial response
+--- config
+    location /t {
+        content_by_lua_block {
+            local base = require("apisix.plugins.ai-providers.base")
+            local eof_calls = 0
+            local abort_reason
+            local fake = {
+                name = "test-upstream-error-emitted-eof-filter",
+                lua_body_filter = function(_, _, _, body, eof, reason)
+                    if eof then
+                        eof_calls = eof_calls + 1
+                        abort_reason = reason
+                        return nil, "pending-error"
+                    end
+                    return nil, body
+                end,
+            }
+            local ctx = {
+                plugins = {fake, {}},
+                var = {},
+                llm_request_start_time = ngx.now(),
+            }
+            local res = {
+                headers = {},
+                body_reader = function()
+                    return nil, "timeout"
+                end,
+            }
+            local target_proto = {
+                parse_sse_event = function()
+                    return {type = "data"}
+                end,
+            }
+
+            local code = base.parse_streaming_response(
+                base, ctx, res, target_proto, nil,
+                {streaming_flush_interval_ms = 0})
+            ngx.say("|code:", code or "nil",
+                    ", eof_calls:", eof_calls,
+                    ", reason:", abort_reason,
+                    ", headers_sent:", ngx.headers_sent)
+        }
+    }
+--- response_body
+pending-error|code:nil, eof_calls:1, reason:upstream_read_error, headers_sent:true
+--- error_code: 200
+--- error_log
+failed to read response chunk: timeout
+
+
+
+=== TEST 11: upstream read error after a chunk returns a partial response
+--- config
+    location /t {
+        content_by_lua_block {
+            local base = require("apisix.plugins.ai-providers.base")
+            local eof_calls = 0
+            local abort_reason
+            local fake = {
+                name = "test-upstream-error-after-output-filter",
+                lua_body_filter = function(_, _, _, body, eof, reason)
+                    if eof then
+                        eof_calls = eof_calls + 1
+                        abort_reason = reason
+                    end
+                    return nil, body
+                end,
+            }
+            local ctx = {
+                plugins = {fake, {}},
+                var = {},
+                llm_request_start_time = ngx.now(),
+            }
+            local read_count = 0
+            local res = {
+                headers = {},
+                body_reader = function()
+                    read_count = read_count + 1
+                    if read_count == 1 then
+                        return "data: {}\n\n"
+                    end
+                    return nil, "timeout"
+                end,
+            }
+            local target_proto = {
+                parse_sse_event = function()
+                    return {type = "data"}
+                end,
+            }
+
+            local code = base.parse_streaming_response(
+                base, ctx, res, target_proto, nil,
+                {streaming_flush_interval_ms = 0})
+            ngx.say("|code:", code or "nil",
+                    ", eof_calls:", eof_calls,
+                    ", reason:", abort_reason,
+                    ", headers_sent:", ngx.headers_sent)
+        }
+    }
+--- response_body
+data: {}
+
+|code:nil, eof_calls:1, reason:upstream_read_error, headers_sent:true
+--- error_code: 200
+--- error_log
+failed to read response chunk: timeout
+
+
+
+=== TEST 12: downstream disconnect does not invoke EOF finalization
 --- config
     location /t {
         content_by_lua_block {
@@ -564,7 +677,7 @@ client disconnected during AI streaming
 
 
 
-=== TEST 11: aborted moderation EOF neither calls service nor fabricates terminator
+=== TEST 13: aborted moderation EOF neither calls service nor fabricates terminator
 --- config
     location /t {
         content_by_lua_block {
@@ -646,7 +759,7 @@ ok:true, err:nil, aborted_emitted:false, aborted_headers_sent:false, service_cal
 
 
 
-=== TEST 12: response byte limit without output returns 502 after one EOF
+=== TEST 14: response byte limit without output returns 502 after one EOF
 --- config
     location /t {
         content_by_lua_block {
@@ -712,7 +825,7 @@ aborting AI stream: max_response_bytes exceeded
 
 
 
-=== TEST 13: stream duration limit without output returns 504 after one EOF
+=== TEST 15: stream duration limit without output returns 504 after one EOF
 --- config
     location /t {
         content_by_lua_block {

--- a/src/apisix/t/bk-ai-response-filter-eof.t
+++ b/src/apisix/t/bk-ai-response-filter-eof.t
@@ -78,3 +78,101 @@ __DATA__
         }
     }
 --- response_body: payload:eof=true
+
+
+
+=== TEST 3: converter no-output error still finalizes response filters
+--- config
+    location /t {
+        content_by_lua_block {
+            local base = require("apisix.plugins.ai-providers.base")
+            local eof_calls = 0
+            local fake = {
+                name = "test-converter-eof-filter",
+                lua_body_filter = function(_, _, _, body, eof)
+                    if eof then
+                        eof_calls = eof_calls + 1
+                    end
+                    return nil, body
+                end,
+            }
+            local ctx = {
+                plugins = {fake, {}},
+                var = {},
+                llm_request_start_time = ngx.now(),
+            }
+            local chunks = {"data: {}\n\n"}
+            local chunk_index = 0
+            local res = {
+                headers = {},
+                body_reader = function()
+                    chunk_index = chunk_index + 1
+                    return chunks[chunk_index]
+                end,
+            }
+            local target_proto = {
+                parse_sse_event = function()
+                    return {type = "data"}
+                end,
+            }
+            local converter = {
+                convert_sse_events = function()
+                    return nil
+                end,
+            }
+
+            local code = base.parse_streaming_response(
+                base, ctx, res, target_proto, converter,
+                {streaming_flush_interval_ms = 0})
+            ngx.say("code:", code, ", eof_calls:", eof_calls)
+        }
+    }
+--- response_body
+code:502, eof_calls:1
+--- error_log
+streaming response completed without producing any output
+
+
+
+=== TEST 4: legacy stateful response filter sees empty per-chunk content at EOF
+--- config
+    location /t {
+        content_by_lua_block {
+            local base = require("apisix.plugins.ai-providers.base")
+            local seen = {}
+            local fake = {
+                name = "test-stateful-four-argument-filter",
+                lua_body_filter = function(_, ctx, _, _)
+                    seen[#seen + 1] = table.concat(
+                        ctx.llm_response_contents_in_chunk or {}, "")
+                    return nil, ""
+                end,
+            }
+            local ctx = {
+                plugins = {fake, {}},
+                var = {},
+                llm_request_start_time = ngx.now(),
+            }
+            local chunks = {"data: {}\n\n"}
+            local chunk_index = 0
+            local res = {
+                headers = {},
+                body_reader = function()
+                    chunk_index = chunk_index + 1
+                    return chunks[chunk_index]
+                end,
+            }
+            local target_proto = {
+                parse_sse_event = function()
+                    return {type = "data", texts = {"chunk"}}
+                end,
+            }
+
+            base.parse_streaming_response(
+                base, ctx, res, target_proto, nil,
+                {streaming_flush_interval_ms = 0})
+            ngx.say("calls:", #seen, ", seen:", table.concat(seen, "|"))
+        }
+    }
+--- response_body
+calls:2, seen:chunk|

--- a/src/apisix/t/bk-ai-response-filter-eof.t
+++ b/src/apisix/t/bk-ai-response-filter-eof.t
@@ -48,7 +48,7 @@ __DATA__
             }
             local api_ctx = {plugins = {fake, {}}, var = {}}
             local ok, err = plugin.lua_response_filter(
-                api_ctx, {}, "payload", true, false, true)
+                api_ctx, {}, "payload", true, false)
             if not ok then
                 ngx.say(err)
             end
@@ -70,14 +70,16 @@ __DATA__
                 end,
             }
             local api_ctx = {plugins = {fake, {}}, var = {}}
-            local ok, err = plugin.lua_response_filter(
+            local ok, err, emitted = plugin.lua_response_filter(
                 api_ctx, {}, "payload", true, false, true)
             if not ok then
                 ngx.say(err)
             end
+            ngx.say(":emitted=", emitted)
         }
     }
---- response_body: payload:eof=true
+--- response_body
+payload:eof=true:emitted=true
 
 
 
@@ -87,11 +89,13 @@ __DATA__
         content_by_lua_block {
             local base = require("apisix.plugins.ai-providers.base")
             local eof_calls = 0
+            local ctx_abort_reason
             local fake = {
                 name = "test-converter-eof-filter",
-                lua_body_filter = function(_, _, _, body, eof)
+                lua_body_filter = function(_, _, _, body, eof, abort_reason)
                     if eof then
                         eof_calls = eof_calls + 1
+                        ctx_abort_reason = abort_reason
                     end
                     return nil, body
                 end,
@@ -124,11 +128,18 @@ __DATA__
             local code = base.parse_streaming_response(
                 base, ctx, res, target_proto, converter,
                 {streaming_flush_interval_ms = 0})
-            ngx.say("code:", code, ", eof_calls:", eof_calls)
+            local headers_sent = ngx.headers_sent
+            if code and not headers_sent then
+                ngx.status = code
+            end
+            ngx.say("code:", code, ", eof_calls:", eof_calls,
+                    ", reason:", ctx_abort_reason,
+                    ", headers_sent:", headers_sent)
         }
     }
 --- response_body
-code:502, eof_calls:1
+code:502, eof_calls:1, reason:converter_no_output, headers_sent:false
+--- error_code: 502
 --- error_log
 streaming response completed without producing any output
 
@@ -195,7 +206,7 @@ calls:2, seen:chunk|
                 name = "test-capture-redaction-output",
                 lua_body_filter = function(_, _, _, body)
                     captured[#captured + 1] = body
-                    return nil, ""
+                    return nil, body
                 end,
             }
             local ctx = {
@@ -230,7 +241,7 @@ calls:2, seen:chunk|
                 end,
             }
 
-            base.parse_streaming_response(
+            local code = base.parse_streaming_response(
                 base, ctx, res, target_proto, nil,
                 {
                     streaming_flush_interval_ms = 0,
@@ -253,11 +264,13 @@ calls:2, seen:chunk|
                             and ctx._ai_redaction_namespace == nil
                             and ctx._ai_redaction_sse_restorer == nil
             ngx.say("occurrences:", occurrences, ", cleared:", cleared,
-                    ", unresolved:", ctx._ai_redaction_unresolved_count)
+                    ", unresolved:", ctx._ai_redaction_unresolved_count,
+                    ", code:", code or "nil")
         }
     }
---- response_body
-occurrences:1, cleared:true, unresolved:1
+--- response_body_like eval
+qr/occurrences:1, cleared:true, unresolved:1, code:nil/
+--- error_code: 200
 --- error_log
 aborting AI stream: max_response_bytes exceeded
 
@@ -279,7 +292,7 @@ aborting AI stream: max_response_bytes exceeded
                 name = "test-capture-redaction-output",
                 lua_body_filter = function(_, _, _, body)
                     captured[#captured + 1] = body
-                    return nil, ""
+                    return nil, body
                 end,
             }
             local ctx = {
@@ -314,7 +327,7 @@ aborting AI stream: max_response_bytes exceeded
                 end,
             }
 
-            base.parse_streaming_response(
+            local code = base.parse_streaming_response(
                 base, ctx, res, target_proto, nil,
                 {
                     streaming_flush_interval_ms = 0,
@@ -337,27 +350,60 @@ aborting AI stream: max_response_bytes exceeded
                             and ctx._ai_redaction_namespace == nil
                             and ctx._ai_redaction_sse_restorer == nil
             ngx.say("occurrences:", occurrences, ", cleared:", cleared,
-                    ", unresolved:", ctx._ai_redaction_unresolved_count)
+                    ", unresolved:", ctx._ai_redaction_unresolved_count,
+                    ", code:", code or "nil")
         }
     }
---- response_body
-occurrences:1, cleared:true, unresolved:1
+--- response_body_like eval
+qr/occurrences:1, cleared:true, unresolved:1, code:nil/
+--- error_code: 200
 --- error_log
 aborting AI stream: max_stream_duration_ms exceeded
 
 
 
-=== TEST 7: response byte limit without output returns 502 after one EOF
+=== TEST 7: empty EOF leaves headers uncommitted and reports no emitted bytes
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugin")
+            local fake = {
+                name = "test-empty-eof-filter",
+                lua_body_filter = function(_, _, _, body)
+                    return ngx.OK, body
+                end,
+            }
+            local api_ctx = {plugins = {fake, {}}, var = {}}
+            local before = ngx.headers_sent
+            local ok, err, emitted = plugin.lua_response_filter(
+                api_ctx, {}, "", true, false, true, "stream_limit")
+            local after = ngx.headers_sent
+            ngx.status = 502
+            ngx.say("ok:", ok, ", err:", err or "nil",
+                    ", emitted:", emitted,
+                    ", before:", before, ", after:", after)
+        }
+    }
+--- response_body
+ok:true, err:nil, emitted:false, before:false, after:false
+--- error_code: 502
+
+
+
+=== TEST 8: emitted limit EOF converts no-output error into partial output
 --- config
     location /t {
         content_by_lua_block {
             local base = require("apisix.plugins.ai-providers.base")
             local eof_calls = 0
+            local abort_reason
             local fake = {
-                name = "test-size-limit-eof-filter",
-                lua_body_filter = function(_, _, _, body, eof)
+                name = "test-emitted-limit-eof-filter",
+                lua_body_filter = function(_, _, _, body, eof, reason)
                     if eof then
                         eof_calls = eof_calls + 1
+                        abort_reason = reason
+                        return nil, "pending-eof"
                     end
                     return nil, body
                 end,
@@ -391,27 +437,294 @@ aborting AI stream: max_stream_duration_ms exceeded
             local code = base.parse_streaming_response(
                 base, ctx, res, target_proto, converter,
                 {streaming_flush_interval_ms = 0, max_response_bytes = 1})
-            ngx.say("code:", code, ", eof_calls:", eof_calls)
+            ngx.say("|code:", code or "nil",
+                    ", eof_calls:", eof_calls,
+                    ", reason:", abort_reason,
+                    ", headers_sent:", ngx.headers_sent)
         }
     }
 --- response_body
-code:502, eof_calls:1
+pending-eof|code:nil, eof_calls:1, reason:stream_limit, headers_sent:true
+--- error_code: 200
 --- error_log
 aborting AI stream: max_response_bytes exceeded
 
 
 
-=== TEST 8: stream duration limit without output returns 504 after one EOF
+=== TEST 9: upstream read error finalizes with an abnormal reason
 --- config
     location /t {
         content_by_lua_block {
             local base = require("apisix.plugins.ai-providers.base")
             local eof_calls = 0
+            local abort_reason
             local fake = {
-                name = "test-duration-limit-eof-filter",
-                lua_body_filter = function(_, _, _, body, eof)
+                name = "test-upstream-error-eof-filter",
+                lua_body_filter = function(_, _, _, body, eof, reason)
                     if eof then
                         eof_calls = eof_calls + 1
+                        abort_reason = reason
+                    end
+                    return nil, body
+                end,
+            }
+            local ctx = {
+                plugins = {fake, {}},
+                var = {},
+                llm_request_start_time = ngx.now(),
+            }
+            local res = {
+                headers = {},
+                body_reader = function()
+                    return nil, "timeout"
+                end,
+            }
+            local target_proto = {
+                parse_sse_event = function()
+                    return {type = "data"}
+                end,
+            }
+
+            local code = base.parse_streaming_response(
+                base, ctx, res, target_proto, nil,
+                {streaming_flush_interval_ms = 0})
+            local headers_sent = ngx.headers_sent
+            if code and not headers_sent then
+                ngx.status = code
+            end
+            ngx.say("code:", code, ", eof_calls:", eof_calls,
+                    ", reason:", abort_reason,
+                    ", headers_sent:", headers_sent)
+        }
+    }
+--- response_body
+code:504, eof_calls:1, reason:upstream_read_error, headers_sent:false
+--- error_code: 504
+--- error_log
+failed to read response chunk: timeout
+
+
+
+=== TEST 10: downstream disconnect does not invoke EOF finalization
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugin")
+            local base = require("apisix.plugins.ai-providers.base")
+            local original_filter = plugin.lua_response_filter
+            local calls = 0
+            local eof_calls = 0
+            plugin.lua_response_filter = function(_, _, _, _, _, eof)
+                calls = calls + 1
+                if eof then
+                    eof_calls = eof_calls + 1
+                end
+                return false, "closed"
+            end
+            local closed = 0
+            local read_count = 0
+            local res = {
+                headers = {},
+                _httpc = {
+                    close = function()
+                        closed = closed + 1
+                    end,
+                },
+                body_reader = function()
+                    read_count = read_count + 1
+                    if read_count == 1 then
+                        return "data: {}\n\n"
+                    end
+                end,
+            }
+            local ctx = {
+                plugins = {},
+                var = {},
+                llm_request_start_time = ngx.now(),
+            }
+            local target_proto = {
+                parse_sse_event = function()
+                    return {type = "data"}
+                end,
+            }
+
+            local code = base.parse_streaming_response(
+                base, ctx, res, target_proto, nil,
+                {streaming_flush_interval_ms = 0})
+            plugin.lua_response_filter = original_filter
+            ngx.say("code:", code or "nil", ", calls:", calls,
+                    ", eof_calls:", eof_calls, ", closed:", closed,
+                    ", done:", ctx.var.llm_request_done)
+        }
+    }
+--- response_body
+code:nil, calls:1, eof_calls:0, closed:1, done:true
+--- error_log
+client disconnected during AI streaming
+
+
+
+=== TEST 11: aborted moderation EOF neither calls service nor fabricates terminator
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugin")
+            local moderation = require("apisix.plugins.ai-aliyun-content-moderation")
+            local http = require("resty.http")
+            local original_new = http.new
+            local service_calls = 0
+            http.new = function()
+                service_calls = service_calls + 1
+                return {
+                    set_timeout = function() end,
+                    connect = function()
+                        return true
+                    end,
+                    request = function()
+                        return {
+                            status = 200,
+                            headers = {},
+                            read_body = function()
+                                return '{"Data":{"RiskLevel":"none"}}'
+                            end,
+                        }
+                    end,
+                    close = function() end,
+                }
+            end
+            local conf = {
+                endpoint = "https://moderation.example.com",
+                region_id = "cn-test",
+                access_key_id = "test-id",
+                access_key_secret = "test-secret",
+                check_response = true,
+                stream_check_mode = "final_packet",
+                response_check_length_limit = 5000,
+                response_check_service = "llm_response_moderation",
+                risk_level_bar = "high",
+                deny_code = 200,
+                timeout = 1000,
+                keepalive = false,
+                ssl_verify = false,
+            }
+            local ctx = {
+                var = {
+                    request_type = "ai_stream",
+                    llm_response_text = "safe response",
+                },
+                ai_client_protocol = "openai-chat",
+            }
+            local adapter = {
+                name = "test-real-moderation-adapter",
+                lua_body_filter = function(inner_conf, inner_ctx, headers,
+                                           body, eof, abort_reason)
+                    local _, new_body = moderation.lua_body_filter(
+                        inner_conf, inner_ctx, headers, body, eof, abort_reason)
+                    return nil, new_body or body
+                end,
+            }
+            ctx.plugins = {adapter, conf}
+
+            local ok, err, emitted = plugin.lua_response_filter(
+                ctx, {}, "", true, false, true, "stream_limit")
+            local aborted_headers_sent = ngx.headers_sent
+            local normal_code, normal_body = moderation.lua_body_filter(
+                conf, ctx, {}, "", true)
+            http.new = original_new
+            local normal_done = normal_body
+                                and normal_body:find("[DONE]", 1, true) ~= nil
+            ngx.say("ok:", ok, ", err:", err or "nil",
+                    ", aborted_emitted:", emitted,
+                    ", aborted_headers_sent:", aborted_headers_sent,
+                    ", service_calls:", service_calls,
+                    ", normal_code:", normal_code,
+                    ", normal_done:", normal_done)
+        }
+    }
+--- response_body
+ok:true, err:nil, aborted_emitted:false, aborted_headers_sent:false, service_calls:1, normal_code:0, normal_done:true
+
+
+
+=== TEST 12: response byte limit without output returns 502 after one EOF
+--- config
+    location /t {
+        content_by_lua_block {
+            local base = require("apisix.plugins.ai-providers.base")
+            local eof_calls = 0
+            local abort_reason
+            local fake = {
+                name = "test-size-limit-eof-filter",
+                lua_body_filter = function(_, _, _, body, eof, reason)
+                    if eof then
+                        eof_calls = eof_calls + 1
+                        abort_reason = reason
+                    end
+                    return nil, body
+                end,
+            }
+            local ctx = {
+                plugins = {fake, {}},
+                var = {route_id = "test-route"},
+                llm_request_start_time = ngx.now(),
+            }
+            local read_count = 0
+            local res = {
+                headers = {},
+                body_reader = function()
+                    read_count = read_count + 1
+                    if read_count == 1 then
+                        return "data: {}\n\n"
+                    end
+                end,
+            }
+            local target_proto = {
+                parse_sse_event = function()
+                    return {type = "data"}
+                end,
+            }
+            local converter = {
+                convert_sse_events = function()
+                    return nil
+                end,
+            }
+
+            local code = base.parse_streaming_response(
+                base, ctx, res, target_proto, converter,
+                {streaming_flush_interval_ms = 0, max_response_bytes = 1})
+            local headers_sent = ngx.headers_sent
+            local fallback_calls = 0
+            if code and not headers_sent then
+                fallback_calls = fallback_calls + 1
+                ngx.status = code
+            end
+            ngx.say("code:", code, ", eof_calls:", eof_calls,
+                    ", reason:", abort_reason,
+                    ", headers_sent:", headers_sent,
+                    ", fallback_calls:", fallback_calls)
+        }
+    }
+--- response_body
+code:502, eof_calls:1, reason:stream_limit, headers_sent:false, fallback_calls:1
+--- error_code: 502
+--- error_log
+aborting AI stream: max_response_bytes exceeded
+
+
+
+=== TEST 13: stream duration limit without output returns 504 after one EOF
+--- config
+    location /t {
+        content_by_lua_block {
+            local base = require("apisix.plugins.ai-providers.base")
+            local eof_calls = 0
+            local abort_reason
+            local fake = {
+                name = "test-duration-limit-eof-filter",
+                lua_body_filter = function(_, _, _, body, eof, reason)
+                    if eof then
+                        eof_calls = eof_calls + 1
+                        abort_reason = reason
                     end
                     return nil, body
                 end,
@@ -445,10 +758,20 @@ aborting AI stream: max_response_bytes exceeded
             local code = base.parse_streaming_response(
                 base, ctx, res, target_proto, converter,
                 {streaming_flush_interval_ms = 0, max_stream_duration_ms = 1})
-            ngx.say("code:", code, ", eof_calls:", eof_calls)
+            local headers_sent = ngx.headers_sent
+            local fallback_calls = 0
+            if code and not headers_sent then
+                fallback_calls = fallback_calls + 1
+                ngx.status = code
+            end
+            ngx.say("code:", code, ", eof_calls:", eof_calls,
+                    ", reason:", abort_reason,
+                    ", headers_sent:", headers_sent,
+                    ", fallback_calls:", fallback_calls)
         }
     }
 --- response_body
-code:504, eof_calls:1
+code:504, eof_calls:1, reason:stream_limit, headers_sent:false, fallback_calls:1
+--- error_code: 504
 --- error_log
 aborting AI stream: max_stream_duration_ms exceeded

--- a/src/apisix/t/bk-ai-response-filter-eof.t
+++ b/src/apisix/t/bk-ai-response-filter-eof.t
@@ -1,0 +1,80 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: existing four-argument response filter remains compatible
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugin")
+            local fake = {
+                name = "test-four-argument-filter",
+                lua_body_filter = function(_, _, _, body)
+                    return nil, body .. ":legacy"
+                end,
+            }
+            local api_ctx = {plugins = {fake, {}}, var = {}}
+            local ok, err = plugin.lua_response_filter(
+                api_ctx, {}, "payload", true, false, true)
+            if not ok then
+                ngx.say(err)
+            end
+        }
+    }
+--- response_body: payload:legacy
+
+
+
+=== TEST 2: response filter receives EOF marker
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugin")
+            local fake = {
+                name = "test-eof-filter",
+                lua_body_filter = function(_, _, _, body, eof)
+                    return nil, body .. ":eof=" .. tostring(eof)
+                end,
+            }
+            local api_ctx = {plugins = {fake, {}}, var = {}}
+            local ok, err = plugin.lua_response_filter(
+                api_ctx, {}, "payload", true, false, true)
+            if not ok then
+                ngx.say(err)
+            end
+        }
+    }
+--- response_body: payload:eof=true

--- a/src/apisix/t/bk-ai-response-filter-eof.t
+++ b/src/apisix/t/bk-ai-response-filter-eof.t
@@ -176,3 +176,279 @@ streaming response completed without producing any output
     }
 --- response_body
 calls:2, seen:chunk|
+
+
+
+=== TEST 5: response byte limit finalizes real redaction filter state
+--- config
+    location /t {
+        content_by_lua_block {
+            local base = require("apisix.plugins.ai-providers.base")
+            local core = require("apisix.core")
+            local redaction = require("apisix.plugins.bk-ai-sensitive-data-redaction")
+            local request_id = "dd9a210e-0296-445f-a2c6-335d8d45ceda"
+            local namespace = "__BK_REDACT_dd9a210e0296445fa2c6335d8d45ceda_"
+            local token = namespace .. "1__"
+            local prefix = token:sub(1, -2)
+            local captured = {}
+            local sink = {
+                name = "test-capture-redaction-output",
+                lua_body_filter = function(_, _, _, body)
+                    captured[#captured + 1] = body
+                    return nil, ""
+                end,
+            }
+            local ctx = {
+                plugins = {redaction, {}, sink, {}},
+                var = {request_type = "ai_stream", route_id = "test-route"},
+                ai_client_protocol = "openai-chat",
+                llm_request_start_time = ngx.now(),
+                _ai_redaction_request_id = request_id,
+                _ai_redaction_session_id = "test-session",
+                _ai_redaction_namespace = namespace,
+                _ai_redaction_mapping = {[token] = "sensitive-original"},
+            }
+            local chunk = "data: " .. assert(core.json.encode({
+                choices = {{
+                    index = 0,
+                    delta = {content = prefix},
+                }},
+            })) .. "\n\n"
+            local read_count = 0
+            local res = {
+                headers = {},
+                body_reader = function()
+                    read_count = read_count + 1
+                    if read_count == 1 then
+                        return chunk
+                    end
+                end,
+            }
+            local target_proto = {
+                parse_sse_event = function()
+                    return {type = "data"}
+                end,
+            }
+
+            base.parse_streaming_response(
+                base, ctx, res, target_proto, nil,
+                {
+                    streaming_flush_interval_ms = 0,
+                    max_response_bytes = #chunk - 1,
+                })
+
+            local output = table.concat(captured)
+            local occurrences = 0
+            local position = 1
+            while true do
+                local found = output:find(prefix, position, true)
+                if not found then
+                    break
+                end
+                occurrences = occurrences + 1
+                position = found + #prefix
+            end
+            local cleared = ctx._ai_redaction_mapping == nil
+                            and ctx._ai_redaction_session_id == nil
+                            and ctx._ai_redaction_namespace == nil
+                            and ctx._ai_redaction_sse_restorer == nil
+            ngx.say("occurrences:", occurrences, ", cleared:", cleared,
+                    ", unresolved:", ctx._ai_redaction_unresolved_count)
+        }
+    }
+--- response_body
+occurrences:1, cleared:true, unresolved:1
+--- error_log
+aborting AI stream: max_response_bytes exceeded
+
+
+
+=== TEST 6: stream duration limit finalizes real redaction filter state
+--- config
+    location /t {
+        content_by_lua_block {
+            local base = require("apisix.plugins.ai-providers.base")
+            local core = require("apisix.core")
+            local redaction = require("apisix.plugins.bk-ai-sensitive-data-redaction")
+            local request_id = "a9d58e99-86bf-4165-a621-640db1df1671"
+            local namespace = "__BK_REDACT_a9d58e9986bf4165a621640db1df1671_"
+            local token = namespace .. "1__"
+            local prefix = token:sub(1, -2)
+            local captured = {}
+            local sink = {
+                name = "test-capture-redaction-output",
+                lua_body_filter = function(_, _, _, body)
+                    captured[#captured + 1] = body
+                    return nil, ""
+                end,
+            }
+            local ctx = {
+                plugins = {redaction, {}, sink, {}},
+                var = {request_type = "ai_stream", route_id = "test-route"},
+                ai_client_protocol = "openai-chat",
+                llm_request_start_time = ngx.now() - 1,
+                _ai_redaction_request_id = request_id,
+                _ai_redaction_session_id = "test-session",
+                _ai_redaction_namespace = namespace,
+                _ai_redaction_mapping = {[token] = "sensitive-original"},
+            }
+            local chunk = "data: " .. assert(core.json.encode({
+                choices = {{
+                    index = 0,
+                    delta = {content = prefix},
+                }},
+            })) .. "\n\n"
+            local read_count = 0
+            local res = {
+                headers = {},
+                body_reader = function()
+                    read_count = read_count + 1
+                    if read_count == 1 then
+                        return chunk
+                    end
+                end,
+            }
+            local target_proto = {
+                parse_sse_event = function()
+                    return {type = "data"}
+                end,
+            }
+
+            base.parse_streaming_response(
+                base, ctx, res, target_proto, nil,
+                {
+                    streaming_flush_interval_ms = 0,
+                    max_stream_duration_ms = 1,
+                })
+
+            local output = table.concat(captured)
+            local occurrences = 0
+            local position = 1
+            while true do
+                local found = output:find(prefix, position, true)
+                if not found then
+                    break
+                end
+                occurrences = occurrences + 1
+                position = found + #prefix
+            end
+            local cleared = ctx._ai_redaction_mapping == nil
+                            and ctx._ai_redaction_session_id == nil
+                            and ctx._ai_redaction_namespace == nil
+                            and ctx._ai_redaction_sse_restorer == nil
+            ngx.say("occurrences:", occurrences, ", cleared:", cleared,
+                    ", unresolved:", ctx._ai_redaction_unresolved_count)
+        }
+    }
+--- response_body
+occurrences:1, cleared:true, unresolved:1
+--- error_log
+aborting AI stream: max_stream_duration_ms exceeded
+
+
+
+=== TEST 7: response byte limit without output returns 502 after one EOF
+--- config
+    location /t {
+        content_by_lua_block {
+            local base = require("apisix.plugins.ai-providers.base")
+            local eof_calls = 0
+            local fake = {
+                name = "test-size-limit-eof-filter",
+                lua_body_filter = function(_, _, _, body, eof)
+                    if eof then
+                        eof_calls = eof_calls + 1
+                    end
+                    return nil, body
+                end,
+            }
+            local ctx = {
+                plugins = {fake, {}},
+                var = {route_id = "test-route"},
+                llm_request_start_time = ngx.now(),
+            }
+            local read_count = 0
+            local res = {
+                headers = {},
+                body_reader = function()
+                    read_count = read_count + 1
+                    if read_count == 1 then
+                        return "data: {}\n\n"
+                    end
+                end,
+            }
+            local target_proto = {
+                parse_sse_event = function()
+                    return {type = "data"}
+                end,
+            }
+            local converter = {
+                convert_sse_events = function()
+                    return nil
+                end,
+            }
+
+            local code = base.parse_streaming_response(
+                base, ctx, res, target_proto, converter,
+                {streaming_flush_interval_ms = 0, max_response_bytes = 1})
+            ngx.say("code:", code, ", eof_calls:", eof_calls)
+        }
+    }
+--- response_body
+code:502, eof_calls:1
+--- error_log
+aborting AI stream: max_response_bytes exceeded
+
+
+
+=== TEST 8: stream duration limit without output returns 504 after one EOF
+--- config
+    location /t {
+        content_by_lua_block {
+            local base = require("apisix.plugins.ai-providers.base")
+            local eof_calls = 0
+            local fake = {
+                name = "test-duration-limit-eof-filter",
+                lua_body_filter = function(_, _, _, body, eof)
+                    if eof then
+                        eof_calls = eof_calls + 1
+                    end
+                    return nil, body
+                end,
+            }
+            local ctx = {
+                plugins = {fake, {}},
+                var = {route_id = "test-route"},
+                llm_request_start_time = ngx.now() - 1,
+            }
+            local read_count = 0
+            local res = {
+                headers = {},
+                body_reader = function()
+                    read_count = read_count + 1
+                    if read_count == 1 then
+                        return "data: {}\n\n"
+                    end
+                end,
+            }
+            local target_proto = {
+                parse_sse_event = function()
+                    return {type = "data"}
+                end,
+            }
+            local converter = {
+                convert_sse_events = function()
+                    return nil
+                end,
+            }
+
+            local code = base.parse_streaming_response(
+                base, ctx, res, target_proto, converter,
+                {streaming_flush_interval_ms = 0, max_stream_duration_ms = 1})
+            ngx.say("code:", code, ", eof_calls:", eof_calls)
+        }
+    }
+--- response_body
+code:504, eof_calls:1
+--- error_log
+aborting AI stream: max_stream_duration_ms exceeded

--- a/src/apisix/t/bk-ai-sensitive-data-redaction.t
+++ b/src/apisix/t/bk-ai-sensitive-data-redaction.t
@@ -29,6 +29,267 @@ add_block_preprocessor(sub {
     if (!defined $block->request) {
         $block->set_value("request", "GET /t");
     }
+
+    my $http_config = $block->http_config // <<'_EOC_';
+        server {
+            listen 6725;
+
+            location /redact {
+                content_by_lua_block {
+                    local core = require("apisix.core")
+
+                    ngx.req.read_body()
+                    local payload = assert(core.json.decode(ngx.req.get_body_data()))
+                    local body = payload.body
+                    local content
+                    local install
+                    if type(body.input) == "string" then
+                        content = body.input
+                        install = function(value)
+                            body.input = value
+                        end
+                    else
+                        content = body.messages[1].content
+                        install = function(value)
+                            body.messages[1].content = value
+                        end
+                    end
+
+                    local original = assert(content:match("1%d%d%d%d%d%d%d%d%d%d"))
+                    local token = payload.placeholder_namespace .. "1__"
+                    install(assert(content:gsub(original, token, 1)))
+
+                    local state = ngx.shared["plugin-limit-conn"]
+                    state:incr("ai-redaction-call-count", 1, 0)
+                    state:set("session-" .. payload.request_id, payload.session_id or "")
+                    state:set("namespace-" .. payload.request_id,
+                              payload.placeholder_namespace)
+
+                    ngx.header.content_type = "application/json"
+                    ngx.print(assert(core.json.encode({
+                        body = body,
+                        replacements = {
+                            {
+                                placeholder = token,
+                                original = original,
+                            },
+                        },
+                    })))
+                }
+            }
+        }
+
+        server {
+            listen 6726;
+
+            location /chat {
+                content_by_lua_block {
+                    local core = require("apisix.core")
+
+                    ngx.req.read_body()
+                    local request = assert(core.json.decode(ngx.req.get_body_data()))
+                    local content = request.messages[1].content
+                    assert(not content:match("1%d%d%d%d%d%d%d%d%d%d"))
+                    local token = assert(content:match(
+                        "(__BK_REDACT_[0-9a-f]+_%d+__)"
+                    ))
+                    local split_at = math.floor(#token / 2)
+                    local function emit(frame, transport_split)
+                        ngx.print(frame:sub(1, transport_split))
+                        ngx.flush(true)
+                        ngx.print(frame:sub(transport_split + 1))
+                        ngx.flush(true)
+                    end
+
+                    ngx.header.content_type = "text/event-stream"
+                    emit("data: " .. core.json.encode({
+                        choices = {{index = 0, delta = {
+                            content = "echo: " .. token:sub(1, split_at),
+                        }}},
+                    }) .. "\n\n", 23)
+                    emit("data: " .. core.json.encode({
+                        choices = {{index = 0, delta = {
+                            content = token:sub(split_at + 1),
+                        }}},
+                    }) .. "\n\n", 29)
+                    emit("data: " .. core.json.encode({
+                        choices = {{index = 0, delta = {tool_calls = {{
+                            index = 0,
+                            ["function"] = {arguments =
+                                "{\"phone\":\"" .. token:sub(1, split_at)},
+                        }}}}},
+                    }) .. "\n\n", 41)
+                    emit("data: " .. core.json.encode({
+                        choices = {{index = 0, delta = {tool_calls = {{
+                            index = 0,
+                            ["function"] = {arguments =
+                                token:sub(split_at + 1) .. "\"}"},
+                        }}}}},
+                    }) .. "\n\n", 37)
+                    ngx.print("data: [DONE]\n\n")
+                    ngx.flush(true)
+                }
+            }
+
+            location /responses {
+                content_by_lua_block {
+                    local core = require("apisix.core")
+
+                    ngx.req.read_body()
+                    local request = assert(core.json.decode(ngx.req.get_body_data()))
+                    assert(not request.input:match("1%d%d%d%d%d%d%d%d%d%d"))
+                    local token = assert(request.input:match(
+                        "(__BK_REDACT_[0-9a-f]+_%d+__)"
+                    ))
+                    local split_at = math.floor(#token / 2)
+                    local function emit(frame, transport_split)
+                        ngx.print(frame:sub(1, transport_split))
+                        ngx.flush(true)
+                        ngx.print(frame:sub(transport_split + 1))
+                        ngx.flush(true)
+                    end
+
+                    ngx.header.content_type = "text/event-stream"
+                    emit("event: response.output_text.delta\ndata: " ..
+                         core.json.encode({
+                             type = "response.output_text.delta",
+                             item_id = "msg_1",
+                             delta = token:sub(1, split_at),
+                         }) .. "\n\n", 23)
+                    emit("event: response.output_text.delta\ndata: " ..
+                         core.json.encode({
+                             type = "response.output_text.delta",
+                             item_id = "msg_1",
+                             delta = token:sub(split_at + 1),
+                         }) .. "\n\n", 29)
+                    emit("event: response.function_call_arguments.delta\ndata: " ..
+                         core.json.encode({
+                             type = "response.function_call_arguments.delta",
+                             item_id = "call_1",
+                             delta = "{\"phone\":\"" .. token .. "\"}",
+                         }) .. "\n\n", 41)
+                    emit("event: response.completed\ndata: " ..
+                         core.json.encode({type = "response.completed"}) ..
+                         "\n\n", 19)
+                }
+            }
+
+            location /anthropic {
+                content_by_lua_block {
+                    local core = require("apisix.core")
+
+                    ngx.req.read_body()
+                    local request = assert(core.json.decode(ngx.req.get_body_data()))
+                    local content = request.messages[1].content
+                    assert(not content:match("1%d%d%d%d%d%d%d%d%d%d"))
+                    local token = assert(content:match(
+                        "(__BK_REDACT_[0-9a-f]+_%d+__)"
+                    ))
+                    local split_at = math.floor(#token / 2)
+                    local function emit(frame, transport_split)
+                        ngx.print(frame:sub(1, transport_split))
+                        ngx.flush(true)
+                        ngx.print(frame:sub(transport_split + 1))
+                        ngx.flush(true)
+                    end
+
+                    ngx.header.content_type = "text/event-stream"
+                    emit("event: content_block_delta\ndata: " .. core.json.encode({
+                        type = "content_block_delta",
+                        index = 0,
+                        delta = {
+                            type = "text_delta",
+                            text = token:sub(1, split_at),
+                        },
+                    }) .. "\n\n", 17)
+                    emit("event: content_block_delta\ndata: " .. core.json.encode({
+                        type = "content_block_delta",
+                        index = 0,
+                        delta = {
+                            type = "text_delta",
+                            text = token:sub(split_at + 1),
+                        },
+                    }) .. "\n\n", 31)
+                    emit("event: content_block_delta\ndata: " .. core.json.encode({
+                        type = "content_block_delta",
+                        index = 1,
+                        delta = {
+                            type = "input_json_delta",
+                            partial_json = "{\"phone\":\"" .. token .. "\"}",
+                        },
+                    }) .. "\n\n", 37)
+                    emit("event: message_stop\ndata: " ..
+                         core.json.encode({type = "message_stop"}) .. "\n\n", 13)
+                }
+            }
+
+            location /chat-no-terminal {
+                content_by_lua_block {
+                    local core = require("apisix.core")
+
+                    ngx.req.read_body()
+                    local request = assert(core.json.decode(ngx.req.get_body_data()))
+                    local token = assert(request.messages[1].content:match(
+                        "(__BK_REDACT_[0-9a-f]+_%d+__)"
+                    ))
+                    ngx.header.content_type = "text/event-stream"
+                    ngx.print("data: " .. core.json.encode({
+                        choices = {{index = 0, delta = {content = token}}},
+                    }) .. "\n\n")
+                    ngx.flush(true)
+                }
+            }
+
+            location /chat-incomplete {
+                content_by_lua_block {
+                    local core = require("apisix.core")
+
+                    ngx.req.read_body()
+                    local request = assert(core.json.decode(ngx.req.get_body_data()))
+                    local token = assert(request.messages[1].content:match(
+                        "(__BK_REDACT_[0-9a-f]+_%d+__)"
+                    ))
+                    ngx.header.content_type = "text/event-stream"
+                    ngx.print("data: " .. core.json.encode({
+                        choices = {{index = 0, delta = {
+                            content = token:sub(1, #token - 2),
+                        }}},
+                    }) .. "\n\n")
+                    ngx.flush(true)
+                }
+            }
+
+            location /chat-malformed {
+                content_by_lua_block {
+                    local core = require("apisix.core")
+
+                    ngx.req.read_body()
+                    local request = assert(core.json.decode(ngx.req.get_body_data()))
+                    local token = assert(request.messages[1].content:match(
+                        "(__BK_REDACT_[0-9a-f]+_%d+__)"
+                    ))
+                    ngx.header.content_type = "text/event-stream"
+                    ngx.print("data: {\"broken\":\"" .. token .. "\"\n\n")
+                    ngx.flush(true)
+                    ngx.print("data: " .. core.json.encode({
+                        choices = {{index = 0, delta = {content = token}}},
+                    }) .. "\n\ndata: [DONE]\n\n")
+                    ngx.flush(true)
+                }
+            }
+
+            location /should-not-call {
+                content_by_lua_block {
+                    ngx.shared["plugin-limit-conn"]:incr(
+                        "ai-llm-rejected-call-count", 1, 0
+                    )
+                    ngx.status = 500
+                }
+            }
+        }
+_EOC_
+
+    $block->set_value("http_config", $http_config);
 });
 
 run_tests;
@@ -229,3 +490,621 @@ response-restored
 state-cleared
 --- no_error_log
 [error]
+
+
+
+=== TEST 3: configure supported streaming and fail-closed routes
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin").test
+
+            local state = ngx.shared["plugin-limit-conn"]
+            state:set("ai-redaction-call-count", 0)
+            state:set("ai-llm-rejected-call-count", 0)
+            local post_filter = [[return function(_, ctx)
+                if ctx._ai_redaction_request_id ~= nil and
+                        ctx.var.request_type == "ai_stream" and
+                        ctx._ai_redaction_mapping == nil and
+                        ctx._ai_redaction_session_id == nil and
+                        ctx._ai_redaction_namespace == nil and
+                        ctx._ai_redaction_sse_restorer == nil then
+                    ngx.shared["plugin-limit-conn"]:set(
+                        "cleanup-" .. ctx._ai_redaction_request_id,
+                        tostring(ctx._ai_redaction_restored_count or 0) .. ":" ..
+                        tostring(ctx._ai_redaction_unresolved_count or 0)
+                    )
+                end
+            end]]
+
+            local function stream_plugins(provider, endpoint, model)
+                return {
+                    ["request-id"] = {
+                        header_name = "X-Request-ID",
+                        include_in_response = false,
+                        algorithm = "uuid",
+                    },
+                    ["ai-proxy"] = {
+                        provider = provider,
+                        auth = {
+                            header = {Authorization = "Bearer test-token"},
+                        },
+                        options = {model = model},
+                        override = {endpoint = endpoint},
+                        ssl_verify = false,
+                        streaming_flush_interval_ms = 0,
+                    },
+                    ["bk-ai-sensitive-data-redaction"] = {
+                        endpoint = "http://127.0.0.1:6725/redact",
+                        ssl_verify = false,
+                        keepalive = false,
+                    },
+                    ["serverless-post-function"] = {
+                        phase = "body_filter",
+                        functions = {post_filter},
+                    },
+                }
+            end
+
+            local routes = {
+                {
+                    id = 2,
+                    value = {
+                        uri = "/redact-stream",
+                        plugins = stream_plugins(
+                            "openai", "http://127.0.0.1:6726/chat", "gpt-4o"
+                        ),
+                    },
+                },
+                {
+                    id = 3,
+                    value = {
+                        uri = "/redact/v1/responses",
+                        plugins = stream_plugins(
+                            "openai", "http://127.0.0.1:6726/responses", "gpt-4o"
+                        ),
+                    },
+                },
+                {
+                    id = 4,
+                    value = {
+                        uri = "/redact/v1/messages",
+                        plugins = stream_plugins(
+                            "anthropic",
+                            "http://127.0.0.1:6726/anthropic",
+                            "claude-3-5-sonnet-20241022"
+                        ),
+                    },
+                },
+                {
+                    id = 5,
+                    value = {
+                        uri = "/redact-stream-no-terminal",
+                        plugins = stream_plugins(
+                            "openai",
+                            "http://127.0.0.1:6726/chat-no-terminal",
+                            "gpt-4o"
+                        ),
+                    },
+                },
+                {
+                    id = 6,
+                    value = {
+                        uri = "/redact-stream-incomplete",
+                        plugins = stream_plugins(
+                            "openai",
+                            "http://127.0.0.1:6726/chat-incomplete",
+                            "gpt-4o"
+                        ),
+                    },
+                },
+                {
+                    id = 7,
+                    value = {
+                        uri = "/redact-stream-malformed",
+                        plugins = stream_plugins(
+                            "openai",
+                            "http://127.0.0.1:6726/chat-malformed",
+                            "gpt-4o"
+                        ),
+                    },
+                },
+                {
+                    id = 8,
+                    value = {
+                        uri = "/raw/converse",
+                        plugins = {
+                            ["request-id"] = {
+                                header_name = "X-Request-ID",
+                                include_in_response = false,
+                                algorithm = "uuid",
+                            },
+                            ["ai-proxy"] = {
+                                provider = "bedrock",
+                                auth = {aws = {
+                                    access_key_id = "test-access-key",
+                                    secret_access_key = "test-secret-key",
+                                }},
+                                provider_conf = {region = "us-east-1"},
+                                options = {
+                                    model =
+                                        "anthropic.claude-3-5-sonnet-20241022-v2:0",
+                                },
+                                override = {
+                                    endpoint =
+                                        "http://127.0.0.1:6726/should-not-call",
+                                },
+                                ssl_verify = false,
+                            },
+                            ["bk-ai-sensitive-data-redaction"] = {
+                                endpoint = "http://127.0.0.1:6725/redact",
+                                ssl_verify = false,
+                                keepalive = false,
+                            },
+                        },
+                    },
+                },
+                {
+                    id = 9,
+                    value = {
+                        uri = "/passthrough-stream",
+                        plugins = stream_plugins(
+                            "openai",
+                            "http://127.0.0.1:6726/should-not-call",
+                            "gpt-4o"
+                        ),
+                    },
+                },
+            }
+
+            for _, route in ipairs(routes) do
+                local code, body = t(
+                    "/apisix/admin/routes/" .. route.id,
+                    ngx.HTTP_PUT,
+                    assert(core.json.encode(route.value))
+                )
+                assert(code < 300, "failed to configure streaming route")
+            end
+            ngx.say("passed")
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 4: OpenAI Chat restores text and tool JSON across events and chunks
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local http = require("resty.http")
+            local sse = require("apisix.plugins.ai-transport.sse")
+            local request_id = "da584df5-7bd5-4590-98e0-8f92a89f9494"
+            local phone = "13800138000"
+            local response = assert(http.new():request_uri(
+                "http://127.0.0.1:" .. ngx.var.server_port .. "/redact-stream", {
+                    method = "POST",
+                    keepalive = false,
+                    headers = {
+                        ["Content-Type"] = "application/json",
+                        ["X-Request-ID"] = request_id,
+                    },
+                    body = assert(core.json.encode({
+                        model = "gpt-4o",
+                        stream = true,
+                        messages = {{role = "user", content = "phone: " .. phone}},
+                    })),
+                }
+            ))
+            assert(response.status == 200, "unexpected response status")
+            assert(
+                not response.body:find("__BK_REDACT_", 1, true),
+                "placeholder leaked"
+            )
+
+            local events = sse.decode(response.body)
+            local text = ""
+            local arguments = ""
+            for _, event in ipairs(events) do
+                if event.data ~= "[DONE]" then
+                    local data = assert(core.json.decode(event.data))
+                    local delta = data.choices[1].delta
+                    text = text .. (delta.content or "")
+                    local tool_calls = delta.tool_calls
+                    if tool_calls then
+                        arguments = arguments ..
+                            tool_calls[1]["function"].arguments
+                    end
+                end
+            end
+            assert(text == "echo: " .. phone)
+            assert(assert(core.json.decode(arguments)).phone == phone)
+            assert(events[#events].data == "[DONE]")
+            assert(
+                ngx.shared["plugin-limit-conn"]:get("cleanup-" .. request_id) ==
+                "2:0"
+            )
+            ngx.say("openai-chat-restored")
+        }
+    }
+--- response_body
+openai-chat-restored
+--- no_error_log
+13800138000
+__BK_REDACT_
+
+
+
+=== TEST 5: OpenAI Responses preserves metadata and restores function arguments
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local http = require("resty.http")
+            local sse = require("apisix.plugins.ai-transport.sse")
+            local request_id = "dddf9a86-4c1f-4a0b-99f5-76c667daf174"
+            local phone = "13900139000"
+            local response = assert(http.new():request_uri(
+                "http://127.0.0.1:" .. ngx.var.server_port ..
+                "/redact/v1/responses", {
+                    method = "POST",
+                    keepalive = false,
+                    headers = {
+                        ["Content-Type"] = "application/json",
+                        ["X-Request-ID"] = request_id,
+                    },
+                    body = assert(core.json.encode({
+                        model = "gpt-4o",
+                        stream = true,
+                        input = "phone: " .. phone,
+                    })),
+                }
+            ))
+            assert(response.status == 200, "unexpected response status")
+            assert(not response.body:find("__BK_REDACT_", 1, true))
+
+            local events = sse.decode(response.body)
+            local text = ""
+            for index = 1, 2 do
+                assert(
+                    events[index].type == "response.output_text.delta",
+                    "unexpected text event type at " .. index
+                )
+                local data = assert(core.json.decode(events[index].data))
+                assert(data.type == "response.output_text.delta", "data type changed")
+                assert(data.item_id == "msg_1", "item ID changed")
+                text = text .. data.delta
+            end
+            local arguments_event = events[3]
+            assert(
+                arguments_event.type == "response.function_call_arguments.delta",
+                "function event type changed"
+            )
+            local arguments_data = assert(core.json.decode(arguments_event.data))
+            assert(arguments_data.item_id == "call_1", "function item ID changed")
+            assert(
+                assert(core.json.decode(arguments_data.delta)).phone == phone,
+                "function arguments were not restored"
+            )
+            assert(text == phone, "response text was not restored")
+            assert(events[4].type == "response.completed", "terminal event changed")
+            assert(
+                assert(core.json.decode(events[4].data)).type == "response.completed",
+                "terminal data changed"
+            )
+            local cleanup = ngx.shared["plugin-limit-conn"]:get(
+                "cleanup-" .. request_id
+            )
+            assert(cleanup == "2:0", "unexpected cleanup counts: " .. tostring(cleanup))
+            ngx.say("openai-responses-restored")
+        }
+    }
+--- response_body
+openai-responses-restored
+--- no_error_log
+13900139000
+__BK_REDACT_
+
+
+
+=== TEST 6: Anthropic Messages preserves event names and restores input JSON
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local http = require("resty.http")
+            local sse = require("apisix.plugins.ai-transport.sse")
+            local request_id = "12186e3f-5e09-4f89-b8d3-998976151c96"
+            local phone = "13700137000"
+            local response = assert(http.new():request_uri(
+                "http://127.0.0.1:" .. ngx.var.server_port ..
+                "/redact/v1/messages", {
+                    method = "POST",
+                    keepalive = false,
+                    headers = {
+                        ["Content-Type"] = "application/json",
+                        ["X-Request-ID"] = request_id,
+                    },
+                    body = assert(core.json.encode({
+                        model = "claude-3-5-sonnet-20241022",
+                        max_tokens = 64,
+                        stream = true,
+                        messages = {{role = "user", content = "phone: " .. phone}},
+                    })),
+                }
+            ))
+            assert(response.status == 200, "unexpected response status")
+            assert(
+                not response.body:find("__BK_REDACT_", 1, true),
+                "placeholder leaked"
+            )
+
+            local events = sse.decode(response.body)
+            local text = ""
+            for index = 1, 2 do
+                assert(
+                    events[index].type == "content_block_delta",
+                    "unexpected text event type at " .. index
+                )
+                local data = assert(core.json.decode(events[index].data))
+                assert(data.type == "content_block_delta", "data type changed")
+                assert(data.index == 0, "content index changed")
+                text = text .. data.delta.text
+            end
+            local input_event = assert(core.json.decode(events[3].data))
+            assert(events[3].type == "content_block_delta", "input event type changed")
+            assert(input_event.index == 1, "input index changed")
+            assert(input_event.delta.type == "input_json_delta", "delta type changed")
+            assert(
+                assert(core.json.decode(input_event.delta.partial_json)).phone == phone,
+                "input JSON was not restored"
+            )
+            assert(text == phone, "anthropic text was not restored")
+            assert(events[4].type == "message_stop", "terminal event changed")
+            assert(
+                assert(core.json.decode(events[4].data)).type == "message_stop",
+                "terminal data changed"
+            )
+            local cleanup = ngx.shared["plugin-limit-conn"]:get(
+                "cleanup-" .. request_id
+            )
+            assert(cleanup == "2:0", "unexpected cleanup counts: " .. tostring(cleanup))
+            ngx.say("anthropic-restored")
+        }
+    }
+--- response_body
+anthropic-restored
+--- no_error_log
+13700137000
+__BK_REDACT_
+
+
+
+=== TEST 7: concurrent and sequential requests keep request mappings isolated
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local http = require("resty.http")
+            local state = ngx.shared["plugin-limit-conn"]
+            local session_id = "24395b38-bf3f-426c-a632-10df20ec69c8"
+            local request_id_1 = "b49d62d7-f3dc-4c9b-b08e-0a15325b30f2"
+            local request_id_2 = "454380f9-3786-43e9-81ea-fdd320dceae1"
+            local request_id_3 = "b02cb0e9-44ef-43c6-a9c6-feb7ed231865"
+            local phone_1 = "13600136000"
+            local phone_2 = "13500135000"
+            local phone_3 = "13400134000"
+            local before_calls = state:get("ai-redaction-call-count") or 0
+
+            local function invoke(request_id, phone)
+                return assert(http.new():request_uri(
+                    "http://127.0.0.1:" .. ngx.var.server_port ..
+                    "/redact-stream", {
+                        method = "POST",
+                        keepalive = false,
+                        headers = {
+                            ["Content-Type"] = "application/json",
+                            ["X-Request-ID"] = request_id,
+                            ["X-AI-Session-ID"] = session_id,
+                        },
+                        body = assert(core.json.encode({
+                            model = "gpt-4o",
+                            stream = true,
+                            messages = {{role = "user", content = phone}},
+                        })),
+                    }
+                ))
+            end
+
+            local thread1 = ngx.thread.spawn(invoke, request_id_1, phone_1)
+            local thread2 = ngx.thread.spawn(invoke, request_id_2, phone_2)
+            local ok1, response1 = ngx.thread.wait(thread1)
+            local ok2, response2 = ngx.thread.wait(thread2)
+            assert(ok1 and ok2)
+            assert(response1.status == 200, "first concurrent request failed")
+            assert(response2.status == 200, "second concurrent request failed")
+            assert(response1.body:find(phone_1, 1, true))
+            assert(not response1.body:find(phone_2, 1, true))
+            assert(response2.body:find(phone_2, 1, true))
+            assert(not response2.body:find(phone_1, 1, true))
+            assert(not response1.body:find("__BK_REDACT_", 1, true))
+            assert(not response2.body:find("__BK_REDACT_", 1, true))
+
+            local response3 = invoke(request_id_3, phone_3)
+            assert(response3.status == 200, "sequential request failed")
+            assert(response3.body:find(phone_3, 1, true))
+            assert(not response3.body:find(phone_1, 1, true))
+            assert(not response3.body:find(phone_2, 1, true))
+            assert(not response3.body:find("__BK_REDACT_", 1, true))
+
+            assert(state:get("session-" .. request_id_1) == session_id)
+            assert(state:get("session-" .. request_id_2) == session_id)
+            assert(state:get("session-" .. request_id_3) == session_id)
+            local namespace1 = state:get("namespace-" .. request_id_1)
+            local namespace2 = state:get("namespace-" .. request_id_2)
+            local namespace3 = state:get("namespace-" .. request_id_3)
+            assert(namespace1 ~= namespace2)
+            assert(namespace1 ~= namespace3)
+            assert(namespace2 ~= namespace3)
+            assert(state:get("ai-redaction-call-count") == before_calls + 3)
+            assert(state:get("cleanup-" .. request_id_1) == "2:0")
+            assert(state:get("cleanup-" .. request_id_2) == "2:0")
+            assert(state:get("cleanup-" .. request_id_3) == "2:0")
+            ngx.say("request-isolation-preserved")
+        }
+    }
+--- response_body
+request-isolation-preserved
+--- no_error_log
+13600136000
+13500135000
+13400134000
+__BK_REDACT_
+
+
+
+=== TEST 8: EOF finalizes state and malformed frames recover fail-closed
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local http = require("resty.http")
+            local state = ngx.shared["plugin-limit-conn"]
+
+            local function invoke(path, request_id, phone)
+                return assert(http.new():request_uri(
+                    "http://127.0.0.1:" .. ngx.var.server_port .. path, {
+                        method = "POST",
+                        keepalive = false,
+                        headers = {
+                            ["Content-Type"] = "application/json",
+                            ["X-Request-ID"] = request_id,
+                        },
+                        body = assert(core.json.encode({
+                            model = "gpt-4o",
+                            stream = true,
+                            messages = {{role = "user", content = phone}},
+                        })),
+                    }
+                ))
+            end
+
+            local no_terminal_id = "0deff9d6-48fc-46dc-a95c-28c18376986f"
+            local no_terminal_phone = "13300133000"
+            local no_terminal = invoke(
+                "/redact-stream-no-terminal",
+                no_terminal_id,
+                no_terminal_phone
+            )
+            assert(no_terminal.status == 200, "no-terminal request failed")
+            assert(no_terminal.body:find(no_terminal_phone, 1, true))
+            assert(not no_terminal.body:find("[DONE]", 1, true))
+            assert(not no_terminal.body:find("__BK_REDACT_", 1, true))
+            assert(state:get("cleanup-" .. no_terminal_id) == "1:0")
+
+            local incomplete_id = "f84e0370-339b-4bd4-90ef-1e08ceee1482"
+            local incomplete_phone = "13200132000"
+            local incomplete = invoke(
+                "/redact-stream-incomplete", incomplete_id, incomplete_phone
+            )
+            assert(incomplete.status == 200, "incomplete-prefix request failed")
+            local incomplete_namespace = state:get("namespace-" .. incomplete_id)
+            assert(incomplete.body:find(incomplete_namespace .. "1", 1, true))
+            assert(not incomplete.body:find(incomplete_phone, 1, true))
+            assert(state:get("cleanup-" .. incomplete_id) == "0:1")
+
+            local malformed_id = "518e2cd5-1e70-47f8-b0be-713614ca4df8"
+            local malformed_phone = "13100131000"
+            local malformed = invoke(
+                "/redact-stream-malformed", malformed_id, malformed_phone
+            )
+            assert(malformed.status == 200, "malformed-frame request failed")
+            local malformed_token = state:get("namespace-" .. malformed_id) .. "1__"
+            assert(malformed.body:find(
+                "data: {\"broken\":\"" .. malformed_token .. "\"\n\n",
+                1,
+                true
+            ))
+            assert(malformed.body:find(malformed_phone, 1, true))
+            assert(state:get("cleanup-" .. malformed_id) == "1:0")
+            ngx.say("eof-and-malformed-safe")
+        }
+    }
+--- response_body
+eof-and-malformed-safe
+--- no_error_log
+13300133000
+13200132000
+13100131000
+
+
+
+=== TEST 9: raw EventStream and passthrough streaming reject before calls
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local http = require("resty.http")
+            local state = ngx.shared["plugin-limit-conn"]
+            local bedrock_id = "ae2208a5-4341-486f-a3f5-f894a22cf499"
+            local passthrough_id = "79f5595e-1405-4287-91cc-085a55293b2e"
+            state:delete("namespace-" .. bedrock_id)
+            state:delete("namespace-" .. passthrough_id)
+            state:set("ai-llm-rejected-call-count", 0)
+
+            local bedrock = assert(http.new():request_uri(
+                "http://127.0.0.1:" .. ngx.var.server_port .. "/raw/converse", {
+                    method = "POST",
+                    keepalive = false,
+                    headers = {
+                        ["Content-Type"] = "application/json",
+                        ["X-Request-ID"] = bedrock_id,
+                    },
+                    body = assert(core.json.encode({
+                        model = "anthropic.claude-3-5-sonnet-20241022-v2:0",
+                        stream = true,
+                        messages = {{
+                            role = "user",
+                            content = {{text = "phone: 13000130000"}},
+                        }},
+                    })),
+                }
+            ))
+            assert(bedrock.status == 400, "raw EventStream request was not rejected")
+            assert(bedrock.body:find("bedrock-converse", 1, true))
+
+            local passthrough = assert(http.new():request_uri(
+                "http://127.0.0.1:" .. ngx.var.server_port ..
+                "/passthrough-stream", {
+                    method = "POST",
+                    keepalive = false,
+                    headers = {
+                        ["Content-Type"] = "application/json",
+                        ["X-Request-ID"] = passthrough_id,
+                    },
+                    body = assert(core.json.encode({
+                        model = "custom-model",
+                        stream = true,
+                        prompt = "phone: 12900129000",
+                    })),
+                }
+            ))
+            assert(
+                passthrough.status == 400,
+                "passthrough streaming request was not rejected"
+            )
+            assert(passthrough.body:find("passthrough", 1, true))
+            assert(state:get("namespace-" .. bedrock_id) == nil)
+            assert(state:get("namespace-" .. passthrough_id) == nil)
+            assert(state:get("ai-llm-rejected-call-count") == 0)
+            ngx.say("unsupported-streams-rejected")
+        }
+    }
+--- response_body
+unsupported-streams-rejected
+--- no_error_log
+13000130000
+12900129000
+__BK_REDACT_

--- a/src/apisix/t/bk-ai-sensitive-data-redaction.t
+++ b/src/apisix/t/bk-ai-sensitive-data-redaction.t
@@ -189,23 +189,67 @@ add_block_preprocessor(sub {
                          core.json.encode({
                              type = "response.output_text.delta",
                              item_id = "msg_1",
+                             output_index = 0,
+                             content_index = 0,
                              delta = token:sub(1, split_at),
                          }) .. "\n\n", 23)
                     emit("event: response.output_text.delta\ndata: " ..
                          core.json.encode({
                              type = "response.output_text.delta",
                              item_id = "msg_1",
-                             delta = token:sub(split_at + 1),
+                             output_index = 0,
+                             content_index = 1,
+                             delta = token:sub(1, split_at),
                          }) .. "\n\n", 29)
+                    emit("event: response.output_text.delta\ndata: " ..
+                         core.json.encode({
+                             type = "response.output_text.delta",
+                             item_id = "msg_1",
+                             output_index = 0,
+                             content_index = 0,
+                             delta = token:sub(split_at + 1),
+                         }) .. "\n\n", 31)
+                    emit("event: response.output_text.delta\ndata: " ..
+                         core.json.encode({
+                             type = "response.output_text.delta",
+                             item_id = "msg_1",
+                             output_index = 0,
+                             content_index = 1,
+                             delta = token:sub(split_at + 1),
+                         }) .. "\n\n", 33)
                     emit("event: response.function_call_arguments.delta\ndata: " ..
                          core.json.encode({
                              type = "response.function_call_arguments.delta",
                              item_id = "call_1",
+                             output_index = 1,
                              delta = "{\"phone\":\"" .. token .. "\"}",
                          }) .. "\n\n", 41)
                     emit("event: response.completed\ndata: " ..
                          core.json.encode({type = "response.completed"}) ..
                          "\n\n", 19)
+                }
+            }
+
+            location /chat-overflow {
+                content_by_lua_block {
+                    local core = require("apisix.core")
+
+                    ngx.req.read_body()
+                    local request = assert(core.json.decode(ngx.req.get_body_data()))
+                    local token = assert(request.messages[1].content:match(
+                        "(__BK_REDACT_[0-9a-f]+_%d+__)"
+                    ))
+                    local prefix = token:sub(1, #token - 1)
+                    ngx.header.content_type = "text/event-stream"
+                    for index = 0, 1024 do
+                        ngx.print("data: " .. core.json.encode({
+                            choices = {{
+                                index = index,
+                                delta = {content = prefix},
+                            }},
+                        }) .. "\n\n")
+                        ngx.flush(true)
+                    end
                 }
             }
 
@@ -694,6 +738,17 @@ state-cleared
                         ),
                     },
                 },
+                {
+                    id = 10,
+                    value = {
+                        uri = "/redact-stream-overflow",
+                        plugins = stream_plugins(
+                            "openai",
+                            "http://127.0.0.1:6726/chat-overflow",
+                            "gpt-4o"
+                        ),
+                    },
+                },
             }
 
             for _, route in ipairs(routes) do
@@ -804,8 +859,8 @@ __BK_REDACT_
             assert(not response.body:find("__BK_REDACT_", 1, true))
 
             local events = sse.decode(response.body)
-            local text = ""
-            for index = 1, 2 do
+            local text = {[0] = "", [1] = ""}
+            for index = 1, 4 do
                 assert(
                     events[index].type == "response.output_text.delta",
                     "unexpected text event type at " .. index
@@ -813,29 +868,36 @@ __BK_REDACT_
                 local data = assert(core.json.decode(events[index].data))
                 assert(data.type == "response.output_text.delta", "data type changed")
                 assert(data.item_id == "msg_1", "item ID changed")
-                text = text .. data.delta
+                assert(data.output_index == 0, "output index changed")
+                assert(
+                    data.content_index == 0 or data.content_index == 1,
+                    "content index changed"
+                )
+                text[data.content_index] = text[data.content_index] .. data.delta
             end
-            local arguments_event = events[3]
+            local arguments_event = events[5]
             assert(
                 arguments_event.type == "response.function_call_arguments.delta",
                 "function event type changed"
             )
             local arguments_data = assert(core.json.decode(arguments_event.data))
             assert(arguments_data.item_id == "call_1", "function item ID changed")
+            assert(arguments_data.output_index == 1, "function output index changed")
             assert(
                 assert(core.json.decode(arguments_data.delta)).phone == phone,
                 "function arguments were not restored"
             )
-            assert(text == phone, "response text was not restored")
-            assert(events[4].type == "response.completed", "terminal event changed")
+            assert(text[0] == phone, "first response part was not restored")
+            assert(text[1] == phone, "second response part was not restored")
+            assert(events[6].type == "response.completed", "terminal event changed")
             assert(
-                assert(core.json.decode(events[4].data)).type == "response.completed",
+                assert(core.json.decode(events[6].data)).type == "response.completed",
                 "terminal data changed"
             )
             local cleanup = ngx.shared["plugin-limit-conn"]:get(
                 "cleanup-" .. request_id
             )
-            assert(cleanup == "2:0", "unexpected cleanup counts: " .. tostring(cleanup))
+            assert(cleanup == "3:0", "unexpected cleanup counts: " .. tostring(cleanup))
             ngx.say("openai-responses-restored")
         }
     }
@@ -1176,3 +1238,51 @@ unsupported-streams-rejected
 13000130000
 12900129000
 __BK_REDACT_
+
+
+
+=== TEST 10: streaming state overflow latches masked passthrough
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local http = require("resty.http")
+            local state = ngx.shared["plugin-limit-conn"]
+            local request_id = "21739770-bcc7-44c4-94ee-d3932c16d80b"
+            local phone = "12800128000"
+            local response = assert(http.new():request_uri(
+                "http://127.0.0.1:" .. ngx.var.server_port ..
+                "/redact-stream-overflow", {
+                    method = "POST",
+                    keepalive = false,
+                    headers = {
+                        ["Content-Type"] = "application/json",
+                        ["X-Request-ID"] = request_id,
+                    },
+                    body = assert(core.json.encode({
+                        model = "gpt-4o",
+                        stream = true,
+                        messages = {{role = "user", content = "phone: " .. phone}},
+                    })),
+                }
+            ))
+            assert(response.status == 200, "overflow request failed")
+            assert(not response.body:find(phone, 1, true), "original leaked")
+            local namespace = state:get("namespace-" .. request_id)
+            assert(namespace, "missing request namespace")
+            assert(
+                response.body:find(namespace .. "1_", 1, true),
+                "masked prefix was not preserved"
+            )
+            local cleanup = state:get("cleanup-" .. request_id)
+            assert(cleanup, "overflow state was not cleared")
+            assert(cleanup ~= "0:1025", "overflow was deferred until EOF")
+            ngx.say("stream-overflow-masked")
+        }
+    }
+--- response_body
+stream-overflow-masked
+--- error_log
+failed to restore masked SSE response
+--- no_error_log
+12800128000

--- a/src/apisix/t/bk-ai-sensitive-data-redaction.t
+++ b/src/apisix/t/bk-ai-sensitive-data-redaction.t
@@ -40,7 +40,8 @@ add_block_preprocessor(sub {
 
                     ngx.req.read_body()
                     local payload = assert(core.json.decode(ngx.req.get_body_data()))
-                    local body = payload.body
+                    assert(type(payload.body) == "string")
+                    local body = assert(core.json.decode(payload.body))
                     local content
                     local install
                     if type(body.input) == "string" then
@@ -67,7 +68,7 @@ add_block_preprocessor(sub {
 
                     ngx.header.content_type = "application/json"
                     ngx.print(assert(core.json.encode({
-                        body = body,
+                        body = assert(core.json.encode(body)),
                         replacements = {
                             {
                                 placeholder = token,
@@ -408,12 +409,14 @@ passed
 
                 ngx.req.read_body()
                 local payload = assert(core.json.decode(ngx.req.get_body_data()))
-                assert(payload.body.messages[1].content == "phone: 13800138000")
+                assert(type(payload.body) == "string")
+                local body = assert(core.json.decode(payload.body))
+                assert(body.messages[1].content == "phone: 13800138000")
                 local token = payload.placeholder_namespace .. "1__"
-                payload.body.messages[1].content = "phone: " .. token
+                body.messages[1].content = "phone: " .. token
                 ngx.header.content_type = "application/json"
                 ngx.print(assert(core.json.encode({
-                    body = payload.body,
+                    body = assert(core.json.encode(body)),
                     replacements = {
                         {
                             placeholder = token,

--- a/src/apisix/t/bk-ai-sensitive-data-redaction.t
+++ b/src/apisix/t/bk-ai-sensitive-data-redaction.t
@@ -253,6 +253,28 @@ add_block_preprocessor(sub {
                 }
             }
 
+            location /chat-metadata-overflow {
+                content_by_lua_block {
+                    local core = require("apisix.core")
+
+                    ngx.req.read_body()
+                    local request = assert(core.json.decode(ngx.req.get_body_data()))
+                    local token = assert(request.messages[1].content:match(
+                        "(__BK_REDACT_[0-9a-f]+_%d+__)"
+                    ))
+                    local prefix = token:sub(1, #token - 1)
+                    ngx.header.content_type = "text/event-stream"
+                    ngx.print("event: " .. string.rep("e", 33000) .. "\ndata: " ..
+                              core.json.encode({
+                                  choices = {{
+                                      index = 0,
+                                      delta = {content = prefix},
+                                  }},
+                              }) .. "\n\n")
+                    ngx.flush(true)
+                }
+            }
+
             location /anthropic {
                 content_by_lua_block {
                     local core = require("apisix.core")
@@ -745,6 +767,17 @@ state-cleared
                         plugins = stream_plugins(
                             "openai",
                             "http://127.0.0.1:6726/chat-overflow",
+                            "gpt-4o"
+                        ),
+                    },
+                },
+                {
+                    id = 11,
+                    value = {
+                        uri = "/redact-stream-metadata-overflow",
+                        plugins = stream_plugins(
+                            "openai",
+                            "http://127.0.0.1:6726/chat-metadata-overflow",
                             "gpt-4o"
                         ),
                     },
@@ -1286,3 +1319,49 @@ stream-overflow-masked
 failed to restore masked SSE response
 --- no_error_log
 12800128000
+
+
+
+=== TEST 11: streaming metadata overflow latches masked passthrough
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local http = require("resty.http")
+            local state = ngx.shared["plugin-limit-conn"]
+            local request_id = "61e064bd-398c-4770-83da-f2e2c76ef619"
+            local phone = "12700127000"
+            local response = assert(http.new():request_uri(
+                "http://127.0.0.1:" .. ngx.var.server_port ..
+                "/redact-stream-metadata-overflow", {
+                    method = "POST",
+                    keepalive = false,
+                    headers = {
+                        ["Content-Type"] = "application/json",
+                        ["X-Request-ID"] = request_id,
+                    },
+                    body = assert(core.json.encode({
+                        model = "gpt-4o",
+                        stream = true,
+                        messages = {{role = "user", content = "phone: " .. phone}},
+                    })),
+                }
+            ))
+            assert(response.status == 200, "metadata overflow request failed")
+            assert(not response.body:find(phone, 1, true), "original leaked")
+            local namespace = state:get("namespace-" .. request_id)
+            assert(namespace, "missing request namespace")
+            assert(
+                response.body:find(namespace .. "1_", 1, true),
+                "masked prefix was not preserved"
+            )
+            assert(state:get("cleanup-" .. request_id), "overflow state was not cleared")
+            ngx.say("stream-metadata-overflow-masked")
+        }
+    }
+--- response_body
+stream-metadata-overflow-masked
+--- error_log
+failed to restore masked SSE response
+--- no_error_log
+12700127000

--- a/src/apisix/t/bk-ai-sensitive-data-redaction.t
+++ b/src/apisix/t/bk-ai-sensitive-data-redaction.t
@@ -41,24 +41,18 @@ add_block_preprocessor(sub {
                     ngx.req.read_body()
                     local payload = assert(core.json.decode(ngx.req.get_body_data()))
                     assert(type(payload.body) == "string")
+                    local raw = payload.body
                     local body = assert(core.json.decode(payload.body))
                     local content
-                    local install
                     if type(body.input) == "string" then
                         content = body.input
-                        install = function(value)
-                            body.input = value
-                        end
                     else
                         content = body.messages[1].content
-                        install = function(value)
-                            body.messages[1].content = value
-                        end
                     end
 
                     local original = assert(content:match("1%d%d%d%d%d%d%d%d%d%d"))
                     local token = payload.placeholder_namespace .. "1__"
-                    install(assert(content:gsub(original, token, 1)))
+                    raw = raw:gsub(original, token, 1)
 
                     local state = ngx.shared["plugin-limit-conn"]
                     state:incr("ai-redaction-call-count", 1, 0)
@@ -68,7 +62,7 @@ add_block_preprocessor(sub {
 
                     ngx.header.content_type = "application/json"
                     ngx.print(assert(core.json.encode({
-                        body = assert(core.json.encode(body)),
+                        body = raw,
                         replacements = {
                             {
                                 placeholder = token,
@@ -410,13 +404,14 @@ passed
                 ngx.req.read_body()
                 local payload = assert(core.json.decode(ngx.req.get_body_data()))
                 assert(type(payload.body) == "string")
+                local raw = payload.body
                 local body = assert(core.json.decode(payload.body))
                 assert(body.messages[1].content == "phone: 13800138000")
                 local token = payload.placeholder_namespace .. "1__"
-                body.messages[1].content = "phone: " .. token
+                raw = raw:gsub("13800138000", token, 1)
                 ngx.header.content_type = "application/json"
                 ngx.print(assert(core.json.encode({
-                    body = assert(core.json.encode(body)),
+                    body = raw,
                     replacements = {
                         {
                             placeholder = token,

--- a/src/apisix/t/bk-ai-sensitive-data-redaction.t
+++ b/src/apisix/t/bk-ai-sensitive-data-redaction.t
@@ -93,6 +93,40 @@ add_block_preprocessor(sub {
                     local token = assert(content:match(
                         "(__BK_REDACT_[0-9a-f]+_%d+__)"
                     ))
+                    local overlap_role
+                    if content:find("overlap-first", 1, true) then
+                        overlap_role = "first"
+                    elseif content:find("overlap-second", 1, true) then
+                        overlap_role = "second"
+                    end
+                    local state = ngx.shared["plugin-limit-conn"]
+                    if overlap_role then
+                        state:incr("ai-redaction-overlap-arrived", 1, 0)
+                        if overlap_role == "second" then
+                            state:set("ai-redaction-overlap-second-waiting", 1)
+                        end
+
+                        local deadline = ngx.now() + 3
+                        while state:get("ai-redaction-overlap-arrived") < 2
+                                or (overlap_role == "first" and
+                                    state:get(
+                                        "ai-redaction-overlap-second-waiting"
+                                    ) ~= 1) do
+                            assert(ngx.now() < deadline, "overlap arrival timed out")
+                            ngx.sleep(0.001)
+                        end
+                        if overlap_role == "second" then
+                            while state:get(
+                                    "ai-redaction-overlap-release-second"
+                                  ) ~= 1 do
+                                assert(
+                                    ngx.now() < deadline,
+                                    "overlap release timed out"
+                                )
+                                ngx.sleep(0.001)
+                            end
+                        end
+                    end
                     local split_at = math.floor(#token / 2)
                     local function emit(frame, transport_split)
                         ngx.print(frame:sub(1, transport_split))
@@ -128,6 +162,12 @@ add_block_preprocessor(sub {
                     }) .. "\n\n", 37)
                     ngx.print("data: [DONE]\n\n")
                     ngx.flush(true)
+                    if overlap_role then
+                        state:set(
+                            "ai-redaction-overlap-" .. overlap_role .. "-finished",
+                            1
+                        )
+                    end
                 }
             }
 
@@ -897,8 +937,19 @@ __BK_REDACT_
             local phone_2 = "13500135000"
             local phone_3 = "13400134000"
             local before_calls = state:get("ai-redaction-call-count") or 0
+            state:delete("ai-redaction-overlap-arrived")
+            state:delete("ai-redaction-overlap-second-waiting")
+            state:delete("ai-redaction-overlap-release-second")
+            state:delete("ai-redaction-overlap-first-finished")
+            state:delete("ai-redaction-overlap-second-finished")
+            state:delete("cleanup-" .. request_id_1)
+            state:delete("cleanup-" .. request_id_2)
 
-            local function invoke(request_id, phone)
+            local function invoke(request_id, phone, overlap_role)
+                local content = phone
+                if overlap_role then
+                    content = overlap_role .. " " .. content
+                end
                 return assert(http.new():request_uri(
                     "http://127.0.0.1:" .. ngx.var.server_port ..
                     "/redact-stream", {
@@ -912,17 +963,36 @@ __BK_REDACT_
                         body = assert(core.json.encode({
                             model = "gpt-4o",
                             stream = true,
-                            messages = {{role = "user", content = phone}},
+                            messages = {{role = "user", content = content}},
                         })),
                     }
                 ))
             end
 
-            local thread1 = ngx.thread.spawn(invoke, request_id_1, phone_1)
-            local thread2 = ngx.thread.spawn(invoke, request_id_2, phone_2)
+            local thread1 = ngx.thread.spawn(
+                invoke, request_id_1, phone_1, "overlap-first"
+            )
+            local thread2 = ngx.thread.spawn(
+                invoke, request_id_2, phone_2, "overlap-second"
+            )
             local ok1, response1 = ngx.thread.wait(thread1)
+            assert(ok1)
+            assert(state:get("ai-redaction-overlap-arrived") == 2)
+            assert(state:get("ai-redaction-overlap-second-waiting") == 1)
+            assert(state:get("ai-redaction-overlap-first-finished") == 1)
+            assert(state:get("ai-redaction-overlap-second-finished") == nil)
+            assert(state:get("session-" .. request_id_1) == session_id)
+            assert(state:get("session-" .. request_id_2) == session_id)
+            assert(
+                state:get("namespace-" .. request_id_1) ~=
+                state:get("namespace-" .. request_id_2)
+            )
+            assert(state:get("cleanup-" .. request_id_1) == "2:0")
+            assert(state:get("cleanup-" .. request_id_2) == nil)
+            state:set("ai-redaction-overlap-release-second", 1)
             local ok2, response2 = ngx.thread.wait(thread2)
-            assert(ok1 and ok2)
+            assert(ok2)
+            assert(state:get("ai-redaction-overlap-second-finished") == 1)
             assert(response1.status == 200, "first concurrent request failed")
             assert(response2.status == 200, "second concurrent request failed")
             assert(response1.body:find(phone_1, 1, true))

--- a/src/apisix/t/bk-ai-sensitive-data-redaction.t
+++ b/src/apisix/t/bk-ai-sensitive-data-redaction.t
@@ -1,0 +1,231 @@
+#
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+#
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+no_shuffle();
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!defined $block->request) {
+        $block->set_value("request", "GET /t");
+    }
+});
+
+run_tests;
+
+__DATA__
+
+=== TEST 1: configure ai-proxy with request redaction and response restoration
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local t = require("lib.test_admin").test
+
+            ngx.shared["plugin-limit-conn"]:delete("ai-redaction-e2e-state")
+            local route = {
+                uri = "/redaction-chat",
+                plugins = {
+                    ["ai-proxy"] = {
+                        provider = "openai",
+                        auth = {
+                            header = {Authorization = "Bearer test-token"},
+                        },
+                        options = {model = "gpt-4o"},
+                        override = {endpoint = "http://127.0.0.1:6726"},
+                        ssl_verify = false,
+                    },
+                    ["bk-ai-sensitive-data-redaction"] = {
+                        endpoint = "http://127.0.0.1:6725/redact",
+                        ssl_verify = false,
+                        keepalive = false,
+                    },
+                    ["serverless-post-function"] = {
+                        phase = "body_filter",
+                        functions = {
+                            [[return function(_, ctx)
+                                local cleared =
+                                    ctx._ai_redaction_session_id == nil and
+                                    ctx._ai_redaction_namespace == nil and
+                                    ctx._ai_redaction_mapping == nil and
+                                    ctx._ai_redaction_sse_restorer == nil and
+                                    ctx._ai_redaction_request_id ~= nil and
+                                    ctx._ai_redaction_restored_count == 2
+                                ngx.shared["plugin-limit-conn"]:set(
+                                    "ai-redaction-e2e-state",
+                                    cleared and "cleared" or "retained"
+                                )
+                            end]],
+                        },
+                    },
+                },
+            }
+            local code, body = t(
+                "/apisix/admin/routes/1",
+                ngx.HTTP_PUT,
+                assert(core.json.encode(route))
+            )
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- response_body
+passed
+
+
+
+=== TEST 2: raw value reaches redactor, LLM sees only token, and caller gets original
+--- http_config
+    server {
+        listen 6725;
+
+        location /redact {
+            content_by_lua_block {
+                local core = require("apisix.core")
+
+                ngx.req.read_body()
+                local payload = assert(core.json.decode(ngx.req.get_body_data()))
+                assert(payload.body.messages[1].content == "phone: 13800138000")
+                local token = payload.placeholder_namespace .. "1__"
+                payload.body.messages[1].content = "phone: " .. token
+                ngx.header.content_type = "application/json"
+                ngx.print(assert(core.json.encode({
+                    body = payload.body,
+                    replacements = {
+                        {
+                            placeholder = token,
+                            original = "13800138000",
+                        },
+                    },
+                })))
+            }
+        }
+    }
+
+    server {
+        listen 6726;
+
+        location / {
+            content_by_lua_block {
+                local core = require("apisix.core")
+
+                ngx.req.read_body()
+                local request = assert(core.json.decode(ngx.req.get_body_data()))
+                local masked = request.messages[1].content
+                assert(not masked:find("13800138000", 1, true))
+                assert(masked:find("__BK_REDACT_", 1, true))
+                local response = {
+                    id = "chatcmpl-redaction",
+                    object = "chat.completion",
+                    choices = {
+                        {
+                            index = 0,
+                            message = {
+                                role = "assistant",
+                                content = "echo: " .. masked,
+                                tool_calls = {
+                                    {
+                                        id = "call_1",
+                                        type = "function",
+                                        ["function"] = {
+                                            name = "save_contact",
+                                            arguments = core.json.encode({phone = masked}),
+                                        },
+                                    },
+                                },
+                            },
+                            finish_reason = "stop",
+                        },
+                    },
+                    usage = {
+                        prompt_tokens = 1,
+                        completion_tokens = 1,
+                        total_tokens = 2,
+                    },
+                }
+                ngx.header.content_type = "application/json"
+                ngx.print(assert(core.json.encode(response)))
+            }
+        }
+    }
+--- config
+    location /t {
+        content_by_lua_block {
+            local core = require("apisix.core")
+            local http = require("resty.http")
+
+            local httpc = http.new()
+            assert(httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = 1984,
+            }))
+            local res = assert(httpc:request({
+                method = "POST",
+                path = "/redaction-chat",
+                headers = {
+                    ["Content-Type"] = "application/json",
+                    ["Connection"] = "close",
+                },
+                body = assert(core.json.encode({
+                    model = "gpt-4o",
+                    stream = false,
+                    messages = {
+                        {role = "user", content = "phone: 13800138000"},
+                    },
+                })),
+            }))
+            local response_body = assert(res:read_body())
+            assert(res.status == 200, response_body)
+            local response = assert(core.json.decode(response_body))
+            assert(
+                response.choices[1].message.content ==
+                "echo: phone: 13800138000"
+            )
+            local arguments = assert(core.json.decode(
+                response.choices[1].message.tool_calls[1]["function"].arguments
+            ))
+            assert(arguments.phone == "phone: 13800138000")
+            assert(not response_body:find("__BK_REDACT_", 1, true))
+
+            local state
+            for _ = 1, 20 do
+                state = ngx.shared["plugin-limit-conn"]:get(
+                    "ai-redaction-e2e-state"
+                )
+                if state then
+                    break
+                end
+                ngx.sleep(0.001)
+            end
+            ngx.say("response-restored")
+            ngx.say("state-", state or "missing")
+        }
+    }
+--- response_body
+response-restored
+state-cleared
+--- no_error_log
+[error]

--- a/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
+++ b/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
@@ -115,6 +115,48 @@ describe(
                 end
 
                 it(
+                    "rejects an object-shaped replacements table", function()
+                        local mapping, err = restorer.validate_mapping(
+                            namespace,
+                            body,
+                            {
+                                placeholder = token,
+                                original = "13800138000",
+                            },
+                            10,
+                            1024
+                        )
+
+                        assert.is_nil(mapping)
+                        assert.is_equal("replacements must be an array", err)
+                    end
+                )
+
+                it(
+                    "rejects a sparse replacements table", function()
+                        local mapping, err = restorer.validate_mapping(
+                            namespace,
+                            body,
+                            {
+                                [1] = {
+                                    placeholder = token,
+                                    original = "13800138000",
+                                },
+                                [3] = {
+                                    placeholder = namespace .. "2__",
+                                    original = "13900139000",
+                                },
+                            },
+                            10,
+                            1024
+                        )
+
+                        assert.is_nil(mapping)
+                        assert.is_equal("replacements must be an array", err)
+                    end
+                )
+
+                it(
                     "rejects mappings above the entry limit", function()
                         local mapping, err = restorer.validate_mapping(
                             namespace,

--- a/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
+++ b/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
@@ -18,6 +18,8 @@
 
 local core = require("apisix.core")
 local restorer = require("apisix.plugins.bk-ai-sensitive-data-redaction.restorer")
+local sse = require("apisix.plugins.bk-ai-sensitive-data-redaction.sse")
+local sse_codec = require("apisix.plugins.ai-transport.sse")
 
 describe(
     "bk-ai-sensitive-data-redaction restorer", function()
@@ -348,6 +350,278 @@ describe(
                         assert.is_equal("", first)
                         assert.is_equal(prefix, final_out)
                         assert.is_equal(0, count)
+                    end
+                )
+            end
+        )
+
+        context(
+            "SSE restoration", function()
+                it(
+                    "restores an OpenAI Chat placeholder split across events", function()
+                        local processor = assert(sse.new(
+                            "openai-chat", {[token] = "13800138000"}, namespace
+                        ))
+                        local event1 =
+                            "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"phone " ..
+                            token:sub(1, 30) .. "\"}}]}\n\n"
+                        local event2 =
+                            "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"" ..
+                            token:sub(31) .. "\"}}]}\n\n"
+
+                        local out1 = processor:feed(event1 .. event2:sub(1, 20), false)
+                        local out2 = processor:feed(
+                            event2:sub(21) .. "data: [DONE]\n\n", false
+                        )
+
+                        assert.is_truthy(out1:find("phone ", 1, true))
+                        assert.is_falsy(out1:find("13800138000", 1, true))
+                        assert.is_truthy(out2:find("13800138000", 1, true))
+                        assert.is_truthy(out2:find("data: [DONE]", 1, true))
+                    end
+                )
+
+                it(
+                    "preserves keepalive comments byte-for-byte", function()
+                        local processor = assert(sse.new("openai-chat", {}, namespace))
+
+                        local output = processor:feed(": keepalive\n\n", false)
+
+                        assert.is_equal(": keepalive\n\n", output)
+                    end
+                )
+
+                it(
+                    "preserves unmodified CRLF frames byte-for-byte", function()
+                        local processor = assert(sse.new(
+                            "openai-chat", {[token] = "13800138000"}, namespace
+                        ))
+                        local frame =
+                            "data: {\"choices\":[{\"index\":0," ..
+                            "\"delta\":{\"content\":\"hello\"}}]}\r\n\r\n"
+
+                        local output = processor:feed(frame, false)
+
+                        assert.is_equal(frame, output)
+                    end
+                )
+
+                it(
+                    "restores OpenAI Chat tool arguments as JSON fragments", function()
+                        local original = "a\"b"
+                        local processor = assert(sse.new(
+                            "openai-chat", {[token] = original}, namespace
+                        ))
+                        local first_arguments = "{\"phone\":\"" .. token:sub(1, 30)
+                        local second_arguments = token:sub(31) .. "\"}"
+                        local event1 = "data: " .. core.json.encode({
+                            choices = {
+                                {
+                                    index = 0,
+                                    delta = {
+                                        tool_calls = {
+                                            {
+                                                index = 3,
+                                                ["function"] = {arguments = first_arguments},
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        }) .. "\n\n"
+                        local event2 = "data: " .. core.json.encode({
+                            choices = {
+                                {
+                                    index = 0,
+                                    delta = {
+                                        tool_calls = {
+                                            {
+                                                index = 3,
+                                                ["function"] = {arguments = second_arguments},
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        }) .. "\n\n"
+
+                        local output = processor:feed(event1 .. event2, false)
+                        local events = sse_codec.decode(output)
+                        local first = core.json.decode(events[1].data)
+                        local second = core.json.decode(events[2].data)
+                        local arguments =
+                            first.choices[1].delta.tool_calls[1]["function"].arguments ..
+                            second.choices[1].delta.tool_calls[1]["function"].arguments
+
+                        assert.is_equal(original, core.json.decode(arguments).phone)
+                    end
+                )
+
+                it(
+                    "restores OpenAI Responses text and function arguments", function()
+                        local original = "a\"b"
+                        local processor = assert(sse.new(
+                            "openai-responses", {[token] = original}, namespace
+                        ))
+                        local text_event =
+                            "event: response.output_text.delta\n" ..
+                            "data: " .. core.json.encode({
+                                type = "response.output_text.delta",
+                                item_id = "msg_1",
+                                delta = token,
+                            }) .. "\n\n"
+                        local arguments_event =
+                            "event: response.function_call_arguments.delta\n" ..
+                            "data: " .. core.json.encode({
+                                type = "response.function_call_arguments.delta",
+                                item_id = "call_1",
+                                delta = "{\"phone\":\"" .. token .. "\"}",
+                            }) .. "\n\n"
+
+                        local output = processor:feed(text_event .. arguments_event, false)
+                        local events = sse_codec.decode(output)
+                        local text_data = core.json.decode(events[1].data)
+                        local arguments_data = core.json.decode(events[2].data)
+
+                        assert.is_equal(original, text_data.delta)
+                        assert.is_equal(original, core.json.decode(arguments_data.delta).phone)
+                    end
+                )
+
+                it(
+                    "restores Anthropic text and input JSON deltas", function()
+                        local original = "a\"b"
+                        local processor = assert(sse.new(
+                            "anthropic-messages", {[token] = original}, namespace
+                        ))
+                        local text_event =
+                            "event: content_block_delta\n" ..
+                            "data: " .. core.json.encode({
+                                type = "content_block_delta",
+                                index = 0,
+                                delta = {type = "text_delta", text = token},
+                            }) .. "\n\n"
+                        local input_event =
+                            "event: content_block_delta\n" ..
+                            "data: " .. core.json.encode({
+                                type = "content_block_delta",
+                                index = 1,
+                                delta = {
+                                    type = "input_json_delta",
+                                    partial_json = "{\"phone\":\"" .. token .. "\"}",
+                                },
+                            }) .. "\n\n"
+
+                        local output = processor:feed(text_event .. input_event, false)
+                        local events = sse_codec.decode(output)
+                        local text_data = core.json.decode(events[1].data)
+                        local input_data = core.json.decode(events[2].data)
+
+                        assert.is_equal(original, text_data.delta.text)
+                        assert.is_equal(
+                            original, core.json.decode(input_data.delta.partial_json).phone
+                        )
+                    end
+                )
+
+                it(
+                    "flushes unresolved OpenAI Responses text before a terminal event", function()
+                        local processor = assert(sse.new(
+                            "openai-responses", {[token] = "13800138000"}, namespace
+                        ))
+                        local prefix = token:sub(1, 30)
+                        local delta_event =
+                            "event: response.output_text.delta\n" ..
+                            "data: " .. core.json.encode({
+                                type = "response.output_text.delta",
+                                item_id = "msg_1",
+                                delta = prefix,
+                            }) .. "\n\n"
+                        local terminal_event =
+                            "event: response.completed\n" ..
+                            "data: {\"type\":\"response.completed\"}\n\n"
+
+                        local first = processor:feed(delta_event, false)
+                        local output, restored_count, unresolved_count =
+                            processor:feed(terminal_event, false)
+                        local events = sse_codec.decode(output)
+                        local flushed = core.json.decode(events[1].data)
+
+                        assert.is_falsy(first:find(prefix, 1, true))
+                        assert.is_equal(prefix, flushed.delta)
+                        assert.is_equal("response.output_text.delta", flushed.type)
+                        assert.is_equal("msg_1", flushed.item_id)
+                        assert.is_equal("response.completed", events[2].type)
+                        assert.is_equal(0, restored_count)
+                        assert.is_equal(1, unresolved_count)
+                    end
+                )
+
+                it(
+                    "flushes pending logical outputs in their arrival order", function()
+                        local processor = assert(sse.new(
+                            "openai-chat", {[token] = "13800138000"}, namespace
+                        ))
+                        local frames = {}
+                        for index = 0, 5 do
+                            frames[#frames + 1] = "data: " .. core.json.encode({
+                                choices = {
+                                    {
+                                        index = index,
+                                        delta = {content = token:sub(1, 30)},
+                                    },
+                                },
+                            }) .. "\n\n"
+                        end
+                        processor:feed(table.concat(frames), false)
+
+                        local output = processor:feed("data: [DONE]\n\n", false)
+                        local events = sse_codec.decode(output)
+
+                        for index = 0, 5 do
+                            local data = core.json.decode(events[index + 1].data)
+                            assert.is_equal(index, data.choices[1].index)
+                        end
+                        assert.is_equal("[DONE]", events[7].data)
+                    end
+                )
+
+                it(
+                    "processes a final unterminated frame at transport EOF", function()
+                        local processor = assert(sse.new(
+                            "anthropic-messages", {[token] = "13800138000"}, namespace
+                        ))
+                        local event =
+                            "event: content_block_delta\n" ..
+                            "data: " .. core.json.encode({
+                                type = "content_block_delta",
+                                index = 0,
+                                delta = {type = "text_delta", text = token},
+                            })
+
+                        local output, restored_count, unresolved_count =
+                            processor:feed(event, true)
+                        local data = core.json.decode(sse_codec.decode(output)[1].data)
+
+                        assert.is_equal("13800138000", data.delta.text)
+                        assert.is_equal(1, restored_count)
+                        assert.is_equal(0, unresolved_count)
+                    end
+                )
+
+                it(
+                    "returns exact errors for unsupported streaming protocols", function()
+                        local processor, err = sse.new("bedrock-converse", {}, namespace)
+                        local unknown, unknown_err = sse.new("passthrough", {}, namespace)
+
+                        assert.is_nil(processor)
+                        assert.is_equal(
+                            "raw AWS EventStream restoration is not supported", err
+                        )
+                        assert.is_nil(unknown)
+                        assert.is_equal(
+                            "streaming protocol passthrough is not supported", unknown_err
+                        )
                     end
                 )
             end

--- a/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
+++ b/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
@@ -382,6 +382,37 @@ describe(
                 )
 
                 it(
+                    "restores Chat content when nullable delta fields are JSON null",
+                    function()
+                        local processor = assert(sse.new(
+                            "openai-chat", {[token] = "13800138000"}, namespace
+                        ))
+                        local frame = "data: " .. core.json.encode({
+                            choices = {
+                                {
+                                    index = 0,
+                                    delta = {
+                                        content = token,
+                                        refusal = core.json.null,
+                                    },
+                                },
+                            },
+                        }) .. "\n\n"
+
+                        local output, restored_count = processor:feed(frame, false)
+                        local data = core.json.decode(sse_codec.decode(output)[1].data)
+
+                        assert.is_equal(
+                            "13800138000", data.choices[1].delta.content
+                        )
+                        assert.is_equal(1, restored_count)
+                        assert.is_equal(
+                            core.json.null, data.choices[1].delta.refusal
+                        )
+                    end
+                )
+
+                it(
                     "preserves keepalive comments byte-for-byte", function()
                         local processor = assert(sse.new("openai-chat", {}, namespace))
 

--- a/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
+++ b/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
@@ -197,6 +197,29 @@ describe(
                         assert.is_equal("mapping byte limit exceeded", err)
                     end
                 )
+
+                it(
+                    "finds a valid token overlapping a malformed namespace occurrence",
+                    function()
+                        local reviewer_value = namespace .. namespace:sub(2) .. "1__"
+
+                        local mapping, err = restorer.validate_mapping(
+                            namespace,
+                            {content = reviewer_value},
+                            {
+                                {
+                                    placeholder = token,
+                                    original = "13800138000",
+                                },
+                            },
+                            10,
+                            1024
+                        )
+
+                        assert.is_nil(err)
+                        assert.is_equal("13800138000", mapping[token])
+                    end
+                )
             end
         )
 
@@ -254,6 +277,98 @@ describe(
                         local expected = '{"' .. token ..
                                          '":"restored","unknown":"' .. unknown ..
                                          '","malformed":"' .. malformed .. '"}'
+
+                        local restored, count = restorer.restore_json_text(
+                            raw, {[token] = "restored"}, namespace
+                        )
+
+                        assert.is_equal(expected, restored)
+                        assert.is_equal(1, count)
+                    end
+                )
+
+                it(
+                    "accepts a supplementary Unicode pair in keys and values", function()
+                        local raw = '{"\\uD83D\\uDE00":"\\uD83D\\uDE00",' ..
+                                    '"content":"' .. token .. '"}'
+                        local expected = '{"\\uD83D\\uDE00":"\\uD83D\\uDE00",' ..
+                                         '"content":"restored"}'
+
+                        local restored, count = restorer.restore_json_text(
+                            raw, {[token] = "restored"}, namespace
+                        )
+
+                        assert.is_equal(expected, restored)
+                        assert.is_equal(1, count)
+                    end
+                )
+
+                it(
+                    "rejects invalid surrogate escapes in keys and values", function()
+                        local cases = {
+                            '{"\\uD800":"value"}',
+                            '{"key":"\\uD800"}',
+                            '{"key":"\\uDC00"}',
+                            '{"key":"\\uD800\\u0041"}',
+                        }
+
+                        for _, raw in ipairs(cases) do
+                            local restored, err = restorer.restore_json_text(
+                                raw, {}, namespace
+                            )
+
+                            assert.is_nil(restored)
+                            assert.is_equal("invalid JSON", err)
+                        end
+                    end
+                )
+
+                it(
+                    "rejects invalid raw UTF-8 in keys and values", function()
+                        local invalid = string.char(0x80)
+                        local cases = {
+                            '{"' .. invalid .. '":"value"}',
+                            '{"key":"' .. invalid .. '"}',
+                        }
+
+                        for _, raw in ipairs(cases) do
+                            local restored, err = restorer.restore_json_text(
+                                raw, {}, namespace
+                            )
+
+                            assert.is_nil(restored)
+                            assert.is_equal("invalid JSON", err)
+                            assert.is_falsy(err:find(invalid, 1, true))
+                        end
+                    end
+                )
+
+                it(
+                    "restores escaped tokens and preserves escaped unknown values", function()
+                        local unknown = namespace .. "9__"
+                        local escaped_token = "\\u005f" .. token:sub(2)
+                        local escaped_unknown = "\\u005f" .. unknown:sub(2)
+                        local raw = '{"known":"' .. escaped_token ..
+                                    '","unknown":"' .. escaped_unknown .. '"}'
+                        local expected = '{"known":"restored","unknown":"' ..
+                                         escaped_unknown .. '"}'
+
+                        local restored, count = restorer.restore_json_text(
+                            raw, {[token] = "restored"}, namespace
+                        )
+
+                        assert.is_equal(expected, restored)
+                        assert.is_equal(1, count)
+                    end
+                )
+
+                it(
+                    "restores a token overlapping a malformed namespace occurrence",
+                    function()
+                        local reviewer_value = namespace .. namespace:sub(2) .. "1__"
+                        local raw = '{"value":"' .. reviewer_value .. '"}'
+                        local expected = '{"value":"' .. namespace:sub(1, -2) ..
+                                         'restored"}'
 
                         local restored, count = restorer.restore_json_text(
                             raw, {[token] = "restored"}, namespace
@@ -432,6 +547,26 @@ describe(
                         assert.is_equal("", first)
                         assert.is_equal(prefix, final_out)
                         assert.is_equal(0, count)
+                    end
+                )
+
+                it(
+                    "restores overlapping tokens in text and JSON fragment modes", function()
+                        local reviewer_value = namespace .. namespace:sub(2) .. "1__"
+                        local expected_prefix = namespace:sub(1, -2)
+                        local stream = restorer.new_stream({[token] = "a\"b"}, namespace)
+
+                        local text, text_count = stream:feed(
+                            "text", reviewer_value, "text", true
+                        )
+                        local fragment, fragment_count = stream:feed(
+                            "fragment", reviewer_value, "json_fragment", true
+                        )
+
+                        assert.is_equal(expected_prefix .. "a\"b", text)
+                        assert.is_equal(1, text_count)
+                        assert.is_equal(expected_prefix .. "a\\\"b", fragment)
+                        assert.is_equal(1, fragment_count)
                     end
                 )
             end

--- a/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
+++ b/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
@@ -673,6 +673,86 @@ describe(
                 )
 
                 it(
+                    "restores a placeholder when a complete frame ends at EOF",
+                    function()
+                        local processor = assert(sse.new(
+                            "openai-chat", {[token] = "13800138000"}, namespace
+                        ))
+                        local frame = "data: " .. core.json.encode({
+                            choices = {
+                                {
+                                    index = 0,
+                                    delta = {content = "answer=" .. token},
+                                },
+                            },
+                        }) .. "\n\n"
+
+                        local first = processor:feed(
+                            frame:sub(1, #frame - 1), false
+                        )
+                        local final, restored_count, unresolved_count =
+                            processor:feed(frame:sub(#frame), true)
+
+                        assert.is_equal("", first)
+                        assert.is_truthy(final:find("answer=13800138000", 1, true))
+                        assert.is_equal(1, restored_count)
+                        assert.is_equal(0, unresolved_count)
+                    end
+                )
+
+                it(
+                    "keeps an incomplete placeholder prefix masked at EOF", function()
+                        local processor = assert(sse.new(
+                            "openai-chat", {[token] = "13800138000"}, namespace
+                        ))
+                        local prefix = namespace:sub(1, #namespace - 1)
+                        local frame = "data: " .. core.json.encode({
+                            choices = {
+                                {
+                                    index = 0,
+                                    delta = {content = prefix},
+                                },
+                            },
+                        }) .. "\n\n"
+
+                        local output, restored_count, unresolved_count =
+                            processor:feed(frame, true)
+
+                        assert.is_falsy(output:find("13800138000", 1, true))
+                        assert.is_truthy(output:find(prefix, 1, true))
+                        assert.is_equal(0, restored_count)
+                        assert.is_equal(1, unresolved_count)
+                    end
+                )
+
+                it(
+                    "passes malformed data through masked and restores the next frame",
+                    function()
+                        local processor = assert(sse.new(
+                            "openai-chat", {[token] = "13800138000"}, namespace
+                        ))
+                        local malformed = "data: {\"masked\":\"" .. token .. "\"\n\n"
+                        local valid = "data: " .. core.json.encode({
+                            choices = {
+                                {
+                                    index = 0,
+                                    delta = {content = token},
+                                },
+                            },
+                        }) .. "\n\n"
+
+                        local output, restored_count, unresolved_count =
+                            processor:feed(malformed .. valid, false)
+
+                        assert.is_equal(malformed, output:sub(1, #malformed))
+                        assert.is_truthy(output:find(token, 1, true))
+                        assert.is_truthy(output:find("13800138000", 1, true))
+                        assert.is_equal(1, restored_count)
+                        assert.is_equal(0, unresolved_count)
+                    end
+                )
+
+                it(
                     "bounds incomplete frame buffering at one MiB", function()
                         local limit = 1024 * 1024
                         local at_limit = string.rep("x", limit)

--- a/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
+++ b/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
@@ -538,7 +538,6 @@ describe(
                                 delta = prefix,
                             }) .. "\n\n"
                         local terminal_event =
-                            "event: response.completed\n" ..
                             "data: {\"type\":\"response.completed\"}\n\n"
 
                         local first = processor:feed(delta_event, false)
@@ -551,8 +550,72 @@ describe(
                         assert.is_equal(prefix, flushed.delta)
                         assert.is_equal("response.output_text.delta", flushed.type)
                         assert.is_equal("msg_1", flushed.item_id)
-                        assert.is_equal("response.completed", events[2].type)
+                        assert.is_equal(
+                            "response.completed", core.json.decode(events[2].data).type
+                        )
                         assert.is_equal(0, restored_count)
+                        assert.is_equal(1, unresolved_count)
+                    end
+                )
+
+                it(
+                    "flushes pending text before a plain-text named terminal frame", function()
+                        local processor = assert(sse.new(
+                            "openai-responses", {[token] = "13800138000"}, namespace
+                        ))
+                        local prefix = token:sub(1, 30)
+                        local delta_event =
+                            "event: response.output_text.delta\n" ..
+                            "data: " .. core.json.encode({
+                                type = "response.output_text.delta",
+                                item_id = "msg_1",
+                                delta = prefix,
+                            }) .. "\n\n"
+                        local terminal_event =
+                            "event: response.failed\n" ..
+                            "data: upstream failed\n\n"
+                        processor:feed(delta_event, false)
+
+                        local output, restored_count, unresolved_count =
+                            processor:feed(terminal_event, false)
+                        local events = sse_codec.decode(output)
+                        local flushed = core.json.decode(events[1].data)
+
+                        assert.is_equal(prefix, flushed.delta)
+                        assert.is_equal("response.output_text.delta", flushed.type)
+                        assert.is_equal("response.failed", events[2].type)
+                        assert.is_equal("upstream failed", events[2].data)
+                        assert.is_equal(terminal_event, output:sub(-#terminal_event))
+                        assert.is_equal(0, restored_count)
+                        assert.is_equal(1, unresolved_count)
+                    end
+                )
+
+                it(
+                    "flushes pending text before an empty named terminal frame", function()
+                        local processor = assert(sse.new(
+                            "anthropic-messages", {[token] = "13800138000"}, namespace
+                        ))
+                        local prefix = token:sub(1, 30)
+                        local delta_event =
+                            "event: content_block_delta\n" ..
+                            "data: " .. core.json.encode({
+                                type = "content_block_delta",
+                                index = 0,
+                                delta = {type = "text_delta", text = prefix},
+                            }) .. "\n\n"
+                        local terminal_event = "event: message_stop\ndata:\n\n"
+                        processor:feed(delta_event, false)
+
+                        local output, _, unresolved_count =
+                            processor:feed(terminal_event, false)
+                        local events = sse_codec.decode(output)
+                        local flushed = core.json.decode(events[1].data)
+
+                        assert.is_equal(prefix, flushed.delta.text)
+                        assert.is_equal("message_stop", events[2].type)
+                        assert.is_equal("", events[2].data)
+                        assert.is_equal(terminal_event, output:sub(-#terminal_event))
                         assert.is_equal(1, unresolved_count)
                     end
                 )
@@ -606,6 +669,48 @@ describe(
                         assert.is_equal("13800138000", data.delta.text)
                         assert.is_equal(1, restored_count)
                         assert.is_equal(0, unresolved_count)
+                    end
+                )
+
+                it(
+                    "bounds incomplete frame buffering at one MiB", function()
+                        local limit = 1024 * 1024
+                        local at_limit = string.rep("x", limit)
+                        local at_limit_processor = assert(sse.new(
+                            "openai-chat", {[token] = "13800138000"}, namespace
+                        ))
+
+                        local held = at_limit_processor:feed(at_limit, false)
+                        local completed = at_limit_processor:feed("\n\n", false)
+
+                        assert.is_equal("", held)
+                        assert.is_equal(at_limit .. "\n\n", completed)
+
+                        local above_limit = string.rep("x", limit + 1)
+                        local processor = assert(sse.new(
+                            "openai-chat", {[token] = "13800138000"}, namespace
+                        ))
+
+                        local emitted, restored_count, unresolved_count =
+                            processor:feed(above_limit, false)
+
+                        assert.is_equal(above_limit, emitted)
+                        assert.is_equal(0, restored_count)
+                        assert.is_equal(0, unresolved_count)
+
+                        local valid_event = "data: " .. core.json.encode({
+                            choices = {
+                                {
+                                    index = 0,
+                                    delta = {content = token},
+                                },
+                            },
+                        }) .. "\n\n"
+                        local output, later_count = processor:feed(valid_event, false)
+                        local data = core.json.decode(sse_codec.decode(output)[1].data)
+
+                        assert.is_equal("13800138000", data.choices[1].delta.content)
+                        assert.is_equal(1, later_count)
                     end
                 )
 

--- a/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
+++ b/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
@@ -753,6 +753,41 @@ describe(
                 )
 
                 it(
+                    "passes structurally invalid Chat data through and restores the next frame",
+                    function()
+                        local processor = assert(sse.new(
+                            "openai-chat", {[token] = "13800138000"}, namespace
+                        ))
+                        local malformed_data =
+                            '{"choices":[1],"masked":"' .. token .. '"}'
+                        local malformed = "data: " .. malformed_data .. "\n\n"
+                        local valid = "data: " .. core.json.encode({
+                            choices = {
+                                {
+                                    index = 0,
+                                    delta = {content = token},
+                                },
+                            },
+                        }) .. "\n\n"
+
+                        local ok, output, restored_count, unresolved_count =
+                            pcall(processor.feed, processor, malformed .. valid, false)
+
+                        assert.is_true(ok)
+                        local events = sse_codec.decode(output)
+                        assert.is_equal(malformed_data, events[1].data)
+                        assert.is_truthy(events[1].data:find(token, 1, true))
+                        assert.is_falsy(events[1].data:find("13800138000", 1, true))
+                        local restored = core.json.decode(events[2].data)
+                        assert.is_equal(
+                            "13800138000", restored.choices[1].delta.content
+                        )
+                        assert.is_equal(1, restored_count)
+                        assert.is_equal(0, unresolved_count)
+                    end
+                )
+
+                it(
                     "bounds incomplete frame buffering at one MiB", function()
                         local limit = 1024 * 1024
                         local at_limit = string.rep("x", limit)

--- a/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
+++ b/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
@@ -201,76 +201,158 @@ describe(
         )
 
         context(
-            "restore_json", function()
+            "restore_json_text", function()
                 it(
-                    "restores repeated placeholders in nested response strings", function()
+                    "preserves numeric lexemes and unchanged JSON bytes", function()
+                        local raw = '{ "large":9007199254740993, "negative_zero":-0, ' ..
+                                    '"exponent":1.2300e+40, "content":"' .. token .. '" }'
+                        local expected =
+                            '{ "large":9007199254740993, "negative_zero":-0, ' ..
+                            '"exponent":1.2300e+40, "content":"restored" }'
+
+                        local restored, count = restorer.restore_json_text(
+                            raw, {[token] = "restored"}, namespace
+                        )
+
+                        assert.is_equal(expected, restored)
+                        assert.is_equal(1, count)
+                    end
+                )
+
+                it(
+                    "preserves numeric lexemes in embedded function arguments", function()
+                        local arguments =
+                            '{ "large":9007199254740993, "negative_zero":-0, ' ..
+                            '"exponent":1.2300e+40, "phone":"' .. token .. '" }'
+                        local restored_arguments =
+                            '{ "large":9007199254740993, "negative_zero":-0, ' ..
+                            '"exponent":1.2300e+40, "phone":"restored" }'
+                        local raw = '{"arguments":' ..
+                                    assert(core.json.encode(arguments)) .. ',"order":1}'
+                        local expected = '{"arguments":' ..
+                                         assert(core.json.encode(restored_arguments)) ..
+                                         ',"order":1}'
+
+                        local restored, count = restorer.restore_json_text(
+                            raw, {[token] = "restored"}, namespace
+                        )
+
+                        assert.is_equal(expected, restored)
+                        assert.is_equal(1, count)
+                        local decoded = assert(core.json.decode(restored))
+                        assert.is_table(core.json.decode(decoded.arguments))
+                    end
+                )
+
+                it(
+                    "restores string values but not object keys or unknown tokens", function()
                         local unknown = namespace .. "9__"
-                        local response = {
-                            choices = {
-                                {
-                                    message = {
-                                        content = "phone=" .. token .. ", again=" .. token,
-                                        tool_calls = {
-                                            {
-                                                type = "function",
-                                                ["function"] = {
-                                                    name = "save_contact",
-                                                    arguments = core.json.encode({
-                                                        name = "a\"b",
-                                                        phone = token,
-                                                    }),
-                                                },
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                            untouched = unknown,
+                        local malformed = namespace .. "01__"
+                        local raw = '{"' .. token .. '":"' .. token ..
+                                    '","unknown":"' .. unknown .. '","malformed":"' ..
+                                    malformed .. '"}'
+                        local expected = '{"' .. token ..
+                                         '":"restored","unknown":"' .. unknown ..
+                                         '","malformed":"' .. malformed .. '"}'
+
+                        local restored, count = restorer.restore_json_text(
+                            raw, {[token] = "restored"}, namespace
+                        )
+
+                        assert.is_equal(expected, restored)
+                        assert.is_equal(1, count)
+                    end
+                )
+
+                it(
+                    "rejects malformed trailing and over-depth JSON without content errors",
+                    function()
+                        local cases = {
+                            '{"content":"' .. token .. '"',
+                            '{"content":"' .. token .. '"} trailing',
+                            string.rep("[", 129) .. '"' .. token .. '"' ..
+                                string.rep("]", 129),
                         }
 
-                        local restored, count = restorer.restore_json(
-                            response, {[token] = "13800138000"}
-                        )
+                        for _, raw in ipairs(cases) do
+                            local restored, err = restorer.restore_json_text(
+                                raw, {[token] = "sensitive-original"}, namespace
+                            )
 
-                        assert.is_equal(3, count)
-                        assert.is_equal(
-                            "phone=13800138000, again=13800138000",
-                            restored.choices[1].message.content
-                        )
-                        local arguments = core.json.decode(
-                            restored.choices[1].message.tool_calls[1]["function"].arguments
-                        )
-                        assert.is_equal("a\"b", arguments.name)
-                        assert.is_equal("13800138000", arguments.phone)
-                        assert.is_equal(unknown, restored.untouched)
+                            assert.is_nil(restored)
+                            assert.is_string(err)
+                            assert.is_falsy(err:find(token, 1, true))
+                            assert.is_falsy(err:find("sensitive-original", 1, true))
+                        end
                     end
                 )
 
                 it(
-                    "preserves quotes and newlines in nested JSON originals", function()
-                        local original = "first line\n\"quoted\""
-                        local value = core.json.encode({value = token})
-
-                        local restored, count = restorer.restore_json(value, {[token] = original})
-
-                        assert.is_equal(1, count)
-                        assert.is_equal(original, core.json.decode(restored).value)
-                    end
-                )
-
-                it(
-                    "does not rescan replacement output", function()
+                    "restores adjacent complex originals without rescanning output", function()
                         local next_token = namespace .. "2__"
-                        local restored, count = restorer.restore_json(
-                            token,
+                        local original =
+                            "quote \" backslash \\ newline\nUnicode 中文 token " .. next_token
+                        local raw = '{"value":' ..
+                                    assert(core.json.encode(token .. token .. next_token)) .. '}'
+                        local expected = '{"value":' ..
+                                         assert(core.json.encode(
+                                             original .. original .. "second"
+                                         )) .. '}'
+
+                        local restored, count = restorer.restore_json_text(
+                            raw,
                             {
-                                [token] = next_token,
-                                [next_token] = "must-not-be-used",
-                            }
+                                [token] = original,
+                                [next_token] = "second",
+                            },
+                            namespace
                         )
 
-                        assert.is_equal(1, count)
-                        assert.is_equal(next_token, restored)
+                        assert.is_equal(expected, restored)
+                        assert.is_equal(3, count)
+                    end
+                )
+
+                it(
+                    "restores the default 1000-entry mapping within a bounded time", function()
+                        local replacements = {}
+                        local masked_parts = {}
+                        local restored_parts = {}
+                        for index = 1, 1000 do
+                            local current_token = namespace .. index .. "__"
+                            local original = "value-" .. index
+                            replacements[index] = {
+                                placeholder = current_token,
+                                original = original,
+                            }
+                            masked_parts[index] = current_token
+                            restored_parts[index] = original
+                        end
+                        local masked_text = table.concat(masked_parts, ",")
+                        local raw = assert(core.json.encode({content = masked_text}))
+                        local started_at = os.clock()
+
+                        local validated = assert(restorer.validate_mapping(
+                            namespace,
+                            {content = masked_text},
+                            replacements,
+                            1000,
+                            1024 * 1024
+                        ))
+                        local restored, count = restorer.restore_json_text(
+                            raw, validated, namespace
+                        )
+                        local elapsed = os.clock() - started_at
+
+                        assert.is_true(
+                            elapsed < 0.2,
+                            "1000-entry restoration took " .. elapsed .. " seconds"
+                        )
+                        assert.is_equal(1000, count)
+                        assert.is_equal(
+                            table.concat(restored_parts, ","),
+                            assert(core.json.decode(restored)).content
+                        )
                     end
                 )
             end

--- a/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
+++ b/src/apisix/tests/bk-ai-sensitive-data-redaction/test-restorer.lua
@@ -1,0 +1,314 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+
+local core = require("apisix.core")
+local restorer = require("apisix.plugins.bk-ai-sensitive-data-redaction.restorer")
+
+describe(
+    "bk-ai-sensitive-data-redaction restorer", function()
+        local namespace = "__BK_REDACT_da584df57bd5459098e08f92a89f9494_"
+        local token = namespace .. "1__"
+        local body = {
+            messages = {
+                {
+                    role = "user",
+                    content = "phone: " .. token,
+                },
+            },
+        }
+
+        context(
+            "validate_mapping", function()
+                it(
+                    "accepts a valid request-scoped mapping", function()
+                        local mapping, err = restorer.validate_mapping(
+                            namespace,
+                            body,
+                            {
+                                {
+                                    placeholder = token,
+                                    original = "13800138000",
+                                },
+                            },
+                            10,
+                            1024
+                        )
+
+                        assert.is_nil(err)
+                        assert.is_equal("13800138000", mapping[token])
+                    end
+                )
+
+                local invalid_cases = {
+                    {
+                        name = "rejects duplicate placeholders",
+                        replacements = {
+                            {
+                                placeholder = token,
+                                original = "13800138000",
+                            },
+                            {
+                                placeholder = token,
+                                original = "13900139000",
+                            },
+                        },
+                        expected_err = "duplicate placeholder",
+                    },
+                    {
+                        name = "rejects placeholders from another request namespace",
+                        replacements = {
+                            {
+                                placeholder = "__BK_REDACT_other_1__",
+                                original = "13800138000",
+                            },
+                        },
+                        expected_err = "placeholder is outside request namespace",
+                    },
+                    {
+                        name = "rejects placeholders absent from the masked body",
+                        replacements = {
+                            {
+                                placeholder = namespace .. "2__",
+                                original = "not-present",
+                            },
+                        },
+                        expected_err = "placeholder is absent from masked body",
+                    },
+                    {
+                        name = "rejects non-string original values",
+                        replacements = {
+                            {
+                                placeholder = token,
+                                original = {},
+                            },
+                        },
+                        expected_err = "invalid mapping entry",
+                    },
+                }
+
+                for _, case in ipairs(invalid_cases) do
+                    it(
+                        case.name, function()
+                            local mapping, err = restorer.validate_mapping(
+                                namespace, body, case.replacements, 10, 1024
+                            )
+
+                            assert.is_nil(mapping)
+                            assert.is_equal(case.expected_err, err)
+                        end
+                    )
+                end
+
+                it(
+                    "rejects mappings above the entry limit", function()
+                        local mapping, err = restorer.validate_mapping(
+                            namespace,
+                            body,
+                            {
+                                {
+                                    placeholder = token,
+                                    original = "13800138000",
+                                },
+                            },
+                            0,
+                            1024
+                        )
+
+                        assert.is_nil(mapping)
+                        assert.is_equal("mapping entry limit exceeded", err)
+                    end
+                )
+
+                it(
+                    "rejects mappings above the byte limit", function()
+                        local mapping, err = restorer.validate_mapping(
+                            namespace,
+                            body,
+                            {
+                                {
+                                    placeholder = token,
+                                    original = "13800138000",
+                                },
+                            },
+                            10,
+                            #token
+                        )
+
+                        assert.is_nil(mapping)
+                        assert.is_equal("mapping byte limit exceeded", err)
+                    end
+                )
+            end
+        )
+
+        context(
+            "restore_json", function()
+                it(
+                    "restores repeated placeholders in nested response strings", function()
+                        local unknown = namespace .. "9__"
+                        local response = {
+                            choices = {
+                                {
+                                    message = {
+                                        content = "phone=" .. token .. ", again=" .. token,
+                                        tool_calls = {
+                                            {
+                                                type = "function",
+                                                ["function"] = {
+                                                    name = "save_contact",
+                                                    arguments = core.json.encode({
+                                                        name = "a\"b",
+                                                        phone = token,
+                                                    }),
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                            untouched = unknown,
+                        }
+
+                        local restored, count = restorer.restore_json(
+                            response, {[token] = "13800138000"}
+                        )
+
+                        assert.is_equal(3, count)
+                        assert.is_equal(
+                            "phone=13800138000, again=13800138000",
+                            restored.choices[1].message.content
+                        )
+                        local arguments = core.json.decode(
+                            restored.choices[1].message.tool_calls[1]["function"].arguments
+                        )
+                        assert.is_equal("a\"b", arguments.name)
+                        assert.is_equal("13800138000", arguments.phone)
+                        assert.is_equal(unknown, restored.untouched)
+                    end
+                )
+
+                it(
+                    "preserves quotes and newlines in nested JSON originals", function()
+                        local original = "first line\n\"quoted\""
+                        local value = core.json.encode({value = token})
+
+                        local restored, count = restorer.restore_json(value, {[token] = original})
+
+                        assert.is_equal(1, count)
+                        assert.is_equal(original, core.json.decode(restored).value)
+                    end
+                )
+
+                it(
+                    "does not rescan replacement output", function()
+                        local next_token = namespace .. "2__"
+                        local restored, count = restorer.restore_json(
+                            token,
+                            {
+                                [token] = next_token,
+                                [next_token] = "must-not-be-used",
+                            }
+                        )
+
+                        assert.is_equal(1, count)
+                        assert.is_equal(next_token, restored)
+                    end
+                )
+            end
+        )
+
+        context(
+            "stream restoration", function()
+                it(
+                    "restores split text and JSON-fragment placeholders", function()
+                        local stream = restorer.new_stream({[token] = "a\"b"}, namespace)
+
+                        local out1, count1 = stream:feed(
+                            "choice:0:content", "phone: " .. token:sub(1, 28), "text", false
+                        )
+                        local out2, count2 = stream:feed(
+                            "choice:0:content", token:sub(29), "text", false
+                        )
+                        local arg1, arg_count1 = stream:feed(
+                            "choice:0:tool:0",
+                            "{\"name\":\"" .. token:sub(1, 31),
+                            "json_fragment",
+                            false
+                        )
+                        local arg2, arg_count2 = stream:feed(
+                            "choice:0:tool:0",
+                            token:sub(32) .. "\"}",
+                            "json_fragment",
+                            false
+                        )
+
+                        assert.is_equal("phone: ", out1)
+                        assert.is_equal(0, count1)
+                        assert.is_equal("a\"b", out2)
+                        assert.is_equal(1, count2)
+                        assert.is_equal("{\"name\":\"", arg1)
+                        assert.is_equal(0, arg_count1)
+                        assert.is_equal("a\\\"b\"}", arg2)
+                        assert.is_equal(1, arg_count2)
+                    end
+                )
+
+                it(
+                    "keeps pending placeholder prefixes isolated by logical key", function()
+                        local stream = restorer.new_stream({[token] = "restored"}, namespace)
+                        local split_at = #token - 3
+
+                        local first_a = stream:feed(
+                            "choice:0:content", "a=" .. token:sub(1, split_at), "text", false
+                        )
+                        local first_b, count_b = stream:feed(
+                            "choice:1:content", "b=" .. token, "text", false
+                        )
+                        local second_a, count_a = stream:feed(
+                            "choice:0:content", token:sub(split_at + 1), "text", false
+                        )
+
+                        assert.is_equal("a=", first_a)
+                        assert.is_equal("b=restored", first_b)
+                        assert.is_equal(1, count_b)
+                        assert.is_equal("restored", second_a)
+                        assert.is_equal(1, count_a)
+                    end
+                )
+
+                it(
+                    "flushes an incomplete namespace prefix unchanged on final input", function()
+                        local stream = restorer.new_stream({[token] = "restored"}, namespace)
+                        local prefix = namespace:sub(1, #namespace - 4)
+
+                        local first = stream:feed(
+                            "choice:1:content", prefix, "text", false
+                        )
+                        local final_out, count = stream:feed(
+                            "choice:1:content", "", "text", true
+                        )
+
+                        assert.is_equal("", first)
+                        assert.is_equal(prefix, final_out)
+                        assert.is_equal(0, count)
+                    end
+                )
+            end
+        )
+    end
+)

--- a/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
@@ -27,6 +27,7 @@ describe(
         local behavior
         local observed
         local request_body
+        local raw_request_body
         local request_headers
         local installed_body
 
@@ -58,6 +59,7 @@ describe(
             })
             ctx.picked_ai_instance = {provider = "openai"}
             ctx.ai_client_protocol = "openai-chat"
+            ctx.ai_target_protocol = "openai-chat"
             for key, value in pairs(overrides or {}) do
                 if key == "var" then
                     for var_name, var_value in pairs(value) do
@@ -71,11 +73,11 @@ describe(
         end
 
         local function success_value(payload)
-            local masked_body = assert(core.json.decode(assert(core.json.encode(payload.body))))
+            local masked_body = assert(core.json.decode(payload.body))
             local token = payload.placeholder_namespace .. "1__"
             masked_body.messages[1].content = "phone: " .. token
             return {
-                body = masked_body,
+                body = assert(core.json.encode(masked_body)),
                 replacements = {
                     {
                         placeholder = token,
@@ -89,9 +91,25 @@ describe(
             return assert(core.json.encode(success_value(payload)))
         end
 
+        local function mutate_success_response(payload, mutate)
+            local value = success_value(payload)
+            local body = assert(core.json.decode(value.body))
+            mutate(body, value)
+            value.body = assert(core.json.encode(body))
+            return assert(core.json.encode(value))
+        end
+
         local function assert_no_request_mutation()
             assert.is_nil(installed_body)
             assert.stub(ngx.req.set_body_data).was_not_called()
+        end
+
+        local function run_filter(ctx, conf, body)
+            local code, err = plugin.access(conf or config(), ctx)
+            if code then
+                return code, err
+            end
+            return ctx.ai_final_request_body_filter(body or raw_request_body)
         end
 
         before_each(
@@ -108,6 +126,7 @@ describe(
                     metadata = {source = "final-client-body"},
                 }
                 request_headers = {}
+                raw_request_body = assert(core.json.encode(request_body))
                 installed_body = nil
                 behavior = {
                     connect_ok = true,
@@ -134,6 +153,20 @@ describe(
                             return nil, behavior.body_error
                         end
                         return request_body
+                    end
+                )
+                stub(
+                    core.request, "get_body", function(max_size)
+                        observed.body_limit = max_size
+                        if behavior.body_error then
+                            return nil, behavior.body_error.message or behavior.body_error
+                        end
+                        if max_size and #raw_request_body > max_size then
+                            return nil, "request size " .. #raw_request_body ..
+                                        " is greater than the maximum size " .. max_size ..
+                                        " allowed"
+                        end
+                        return raw_request_body
                     end
                 )
                 stub(
@@ -226,9 +259,288 @@ describe(
         after_each(
             function()
                 core.request.get_json_request_body_table:revert()
+                core.request.get_body:revert()
                 core.request.header:revert()
                 ngx.req.set_body_data:revert()
                 http.new:revert()
+            end
+        )
+
+        context(
+            "final request body callback contract", function()
+                local function register_filter(ctx, conf)
+                    local code, err = plugin.access(conf or config(), ctx)
+                    assert.is_nil(code)
+                    assert.is_nil(err)
+                    assert.is_function(ctx.ai_final_request_body_filter)
+                    return ctx.ai_final_request_body_filter
+                end
+
+                it(
+                    "registers request identity without I/O or request-body mutation",
+                    function()
+                        local request_id = "da584df5-7bd5-4590-98e0-8f92a89f9494"
+                        local ctx = request_context({
+                            var = {apisix_request_id = request_id},
+                        })
+
+                        register_filter(ctx)
+
+                        assert.is_equal(0, observed.new_count)
+                        assert.is_equal(0, observed.request_count)
+                        assert.is_equal(request_id, ctx._ai_redaction_request_id)
+                        assert.is_equal(
+                            "__BK_REDACT_da584df57bd5459098e08f92a89f9494_",
+                            ctx._ai_redaction_namespace
+                        )
+                        assert.is_equal(
+                            "phone: 13800138000", request_body.messages[1].content
+                        )
+                        assert_no_request_mutation()
+                    end
+                )
+
+                it(
+                    "rejects an existing final-body callback instead of replacing it",
+                    function()
+                        local existing = function(body)
+                            return body
+                        end
+                        local ctx = request_context({
+                            ai_final_request_body_filter = existing,
+                        })
+
+                        local code, err = plugin.access(config(), ctx)
+
+                        assert.is_equal(500, code)
+                        assert.is_equal(
+                            "AI final request body filter is already registered", err
+                        )
+                        assert.is_equal(existing, ctx.ai_final_request_body_filter)
+                        assert.is_equal(0, observed.request_count)
+                    end
+                )
+
+                it(
+                    "sends and returns raw JSON strings while preserving numeric lexemes",
+                    function()
+                        local ctx = request_context({
+                            ai_target_protocol = "openai-chat",
+                            var = {
+                                apisix_request_id =
+                                    "da584df5-7bd5-4590-98e0-8f92a89f9494",
+                            },
+                        })
+                        local namespace =
+                            "__BK_REDACT_da584df57bd5459098e08f92a89f9494_"
+                        local token = namespace .. "1__"
+                        local final_body =
+                            '{"model":"gpt-4o","stream":false,' ..
+                            '"large":9007199254740993,' ..
+                            '"long":123456789012345678901234567890,' ..
+                            '"negative_zero":-0,"exponent":1.2300e+40,' ..
+                            '"messages":[{"role":"user",' ..
+                            '"content":"phone: 13800138000"}]}'
+                        behavior.response_builder = function(payload)
+                            assert.is_equal(final_body, payload.body)
+                            return assert(core.json.encode({
+                                body = final_body:gsub("13800138000", token, 1),
+                                replacements = {{
+                                    placeholder = token,
+                                    original = "13800138000",
+                                }},
+                            }))
+                        end
+
+                        local filter = register_filter(ctx)
+                        local masked, err, status = filter(final_body)
+
+                        assert.is_nil(err)
+                        assert.is_nil(status)
+                        assert.is_string(observed.payload.body)
+                        assert.is_equal(
+                            final_body:gsub("13800138000", token, 1), masked
+                        )
+                        assert.is_truthy(masked:find("9007199254740993", 1, true))
+                        assert.is_truthy(masked:find(
+                            "123456789012345678901234567890", 1, true
+                        ))
+                        assert.is_truthy(masked:find("-0", 1, true))
+                        assert.is_truthy(masked:find("1.2300e+40", 1, true))
+                        assert.is_same({[token] = "13800138000"},
+                                       ctx._ai_redaction_mapping)
+                        assert_no_request_mutation()
+                    end
+                )
+
+                it(
+                    "finds escaped placeholder spellings in the raw masked JSON",
+                    function()
+                        local ctx = request_context({
+                            ai_target_protocol = "openai-chat",
+                            var = {
+                                apisix_request_id =
+                                    "da584df5-7bd5-4590-98e0-8f92a89f9494",
+                            },
+                        })
+                        local namespace =
+                            "__BK_REDACT_da584df57bd5459098e08f92a89f9494_"
+                        local token = namespace .. "1__"
+                        behavior.response_builder = function()
+                            return '{"body":"{\\"model\\":\\"gpt-4o\\",' ..
+                                   '\\"stream\\":false,\\"messages\\":[{' ..
+                                   '\\"role\\":\\"user\\",\\"content\\":' ..
+                                   '\\"\\u005f' .. token:sub(2) .. '\\"}]}",' ..
+                                   '"replacements":[{"placeholder":' ..
+                                   assert(core.json.encode(token)) .. ',' ..
+                                   '"original":"secret"}]}'
+                        end
+
+                        local masked, err = register_filter(ctx)(raw_request_body)
+
+                        assert.is_nil(err)
+                        assert.is_string(masked)
+                        assert.is_equal("secret", ctx._ai_redaction_mapping[token])
+                    end
+                )
+
+                it(
+                    "clears an earlier attempt before replacing it only after validation",
+                    function()
+                        local ctx = request_context({
+                            ai_target_protocol = "openai-chat",
+                            var = {
+                                apisix_request_id =
+                                    "da584df5-7bd5-4590-98e0-8f92a89f9494",
+                            },
+                        })
+                        local filter = register_filter(ctx)
+                        local namespace = ctx._ai_redaction_namespace
+                        local first = namespace .. "1__"
+                        local second = namespace .. "2__"
+                        behavior.response_builder = function(payload)
+                            local token = observed.request_count == 1 and first or second
+                            return assert(core.json.encode({
+                                body = payload.body:gsub("13800138000", token, 1),
+                                replacements = {{
+                                    placeholder = token,
+                                    original = observed.request_count == 1 and
+                                               "first-secret" or "second-secret",
+                                }},
+                            }))
+                        end
+
+                        assert.is_string(filter(raw_request_body))
+                        ctx._ai_redaction_sse_restorer = {stale = true}
+                        ctx._ai_redaction_stream_passthrough = true
+                        assert.is_string(filter(raw_request_body))
+
+                        assert.is_nil(ctx._ai_redaction_mapping[first])
+                        assert.is_equal("second-secret", ctx._ai_redaction_mapping[second])
+                        assert.is_nil(ctx._ai_redaction_sse_restorer)
+                        assert.is_nil(ctx._ai_redaction_stream_passthrough)
+
+                        behavior.response_builder = function()
+                            return '{"body":"not-json","replacements":[]}'
+                        end
+                        local masked, err, status = filter(raw_request_body)
+                        assert.is_nil(masked)
+                        assert.is_same({
+                            message = "redaction service body must be valid JSON",
+                        }, err)
+                        assert.is_equal(502, status)
+                        assert.is_nil(ctx._ai_redaction_mapping)
+                    end
+                )
+
+                for _, case in ipairs({
+                    {
+                        name = "a non-string input",
+                        body = {},
+                        status = 400,
+                        message = "final AI request body must be a JSON object string",
+                    },
+                    {
+                        name = "malformed input JSON",
+                        body = "{",
+                        status = 400,
+                        message = "final AI request body must be valid JSON",
+                    },
+                    {
+                        name = "a non-object input",
+                        body = "[]",
+                        status = 400,
+                        message = "final AI request body must be a JSON object string",
+                    },
+                }) do
+                    it(
+                        "rejects " .. case.name .. " without a service call", function()
+                            local ctx = request_context({
+                                ai_target_protocol = "openai-chat",
+                            })
+
+                            local masked, err, status = register_filter(ctx)(case.body)
+
+                            assert.is_nil(masked)
+                            assert.is_same({message = case.message}, err)
+                            assert.is_equal(case.status, status)
+                            assert.is_equal(0, observed.request_count)
+                        end
+                    )
+                end
+
+                it(
+                    "uses the raw-string response envelope cap including its quotes",
+                    function()
+                        local ctx = request_context({
+                            ai_target_protocol = "openai-chat",
+                        })
+                        -- 29 fixed bytes + 6*200 body + 6*20 mapping + 33*2 = 1415.
+                        behavior.response_headers["Content-Length"] = "1416"
+                        behavior.response_builder = function()
+                            return "{}"
+                        end
+
+                        local masked, err, status = register_filter(ctx, config({
+                            max_request_body_bytes = 200,
+                            max_mapping_bytes = 20,
+                            max_mapping_entries = 2,
+                        }))(raw_request_body)
+
+                        assert.is_nil(masked)
+                        assert.is_same({
+                            message = "redaction service response size limit exceeded",
+                        }, err)
+                        assert.is_equal(502, status)
+                        assert.is_equal(0, observed.body_reader_count)
+                    end
+                )
+
+                it(
+                    "clamps a worst-case escaped response at the 64 MiB ceiling",
+                    function()
+                        local ctx = request_context({
+                            ai_target_protocol = "openai-chat",
+                        })
+                        behavior.response_headers["Content-Length"] = "67108865"
+                        behavior.response_builder = function()
+                            return "{}"
+                        end
+
+                        local masked, err, status = register_filter(ctx, config({
+                            max_request_body_bytes = 67108864,
+                            max_mapping_bytes = 67108864,
+                            max_mapping_entries = 1000000,
+                        }))(raw_request_body)
+
+                        assert.is_nil(masked)
+                        assert.is_same({
+                            message = "redaction service response size limit exceeded",
+                        }, err)
+                        assert.is_equal(502, status)
+                        assert.is_equal(0, observed.body_reader_count)
+                    end
+                )
             end
         )
 
@@ -359,10 +671,11 @@ describe(
                         })
                         request_headers["X-AI-Session-Id"] = session_id
 
-                        local code, err = plugin.access(config(), ctx)
+                        local masked, err, code = run_filter(ctx)
 
-                        assert.is_nil(code)
+                        assert.is_string(masked)
                         assert.is_nil(err)
+                        assert.is_nil(code)
                         assert.is_equal(1, observed.request_count)
                         assert.is_equal(apisix_request_id, observed.payload.request_id)
                         assert.is_equal(session_id, observed.payload.session_id)
@@ -380,7 +693,7 @@ describe(
                                 },
                             },
                             metadata = {source = "final-client-body"},
-                        }, observed.payload.body)
+                        }, assert(core.json.decode(observed.payload.body)))
                         assert.is_equal(apisix_request_id, ctx._ai_redaction_request_id)
                         assert.is_equal(session_id, ctx._ai_redaction_session_id)
                     end
@@ -396,9 +709,9 @@ describe(
                             },
                         })
 
-                        local code = plugin.access(config(), ctx)
+                        local masked = run_filter(ctx)
 
-                        assert.is_nil(code)
+                        assert.is_string(masked)
                         assert.is_equal(1, observed.request_count)
                         assert.is_equal(bk_request_id, observed.payload.request_id)
                     end
@@ -413,9 +726,9 @@ describe(
                             },
                         })
 
-                        local code = plugin.access(config(), ctx)
+                        local masked = run_filter(ctx)
 
-                        assert.is_nil(code)
+                        assert.is_string(masked)
                         assert.is_equal(1, observed.request_count)
                         local uuid_v4_pattern =
                             [[^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-]] ..
@@ -439,9 +752,9 @@ describe(
                             },
                         })
 
-                        local code = plugin.access(config(), ctx)
+                        local masked = run_filter(ctx)
 
-                        assert.is_nil(code)
+                        assert.is_string(masked)
                         assert.is_equal(1, observed.request_count)
                         assert.is_nil(observed.payload.session_id)
                         assert.is_nil(ctx._ai_redaction_session_id)
@@ -467,9 +780,9 @@ describe(
                     "sends authentication and connection settings once", function()
                         local ctx = request_context()
 
-                        local code = plugin.access(config(), ctx)
+                        local masked = run_filter(ctx)
 
-                        assert.is_nil(code)
+                        assert.is_string(masked)
                         assert.is_equal(1, observed.new_count)
                         assert.is_equal(1, observed.connect_count)
                         assert.is_equal(1, observed.request_count)
@@ -508,9 +821,9 @@ describe(
                         local conf = config({keepalive = false})
                         conf.auth_value = nil
 
-                        local code = plugin.access(conf, ctx)
+                        local masked = run_filter(ctx, conf)
 
-                        assert.is_nil(code)
+                        assert.is_string(masked)
                         assert.is_equal(1, observed.request_count)
                         assert.is_equal(0, observed.keepalive_count)
                         assert.is_equal(1, observed.close_count)
@@ -532,13 +845,14 @@ describe(
                         behavior.keepalive_ok = false
                         behavior.keepalive_error = "pool rejected connection"
 
-                        local code, err = plugin.access(config(), ctx)
+                        local masked, err, code = run_filter(ctx)
 
-                        assert.is_nil(code)
+                        assert.is_string(masked)
                         assert.is_nil(err)
+                        assert.is_nil(code)
                         assert.is_equal(1, observed.keepalive_count)
                         assert.is_equal(1, observed.close_count)
-                        assert.is_not_nil(installed_body)
+                        assert_no_request_mutation()
                     end
                 )
             end
@@ -571,7 +885,7 @@ describe(
                 end
 
                 it(
-                    "allows supported SSE client protocol with a Bedrock provider", function()
+                    "registers supported SSE client protocol without service I/O", function()
                         local ctx = request_context({
                             picked_ai_instance = {provider = "bedrock"},
                             ai_client_protocol = "openai-chat",
@@ -582,7 +896,8 @@ describe(
                         local code = plugin.access(config(), ctx)
 
                         assert.is_nil(code)
-                        assert.is_equal(1, observed.request_count)
+                        assert.is_function(ctx.ai_final_request_body_filter)
+                        assert.is_equal(0, observed.request_count)
                     end
                 )
 
@@ -621,18 +936,19 @@ describe(
                 )
 
                 it(
-                    "rechecks the final cached JSON body against the configured limit", function()
+                    "checks the original raw JSON body against the configured limit", function()
                         local ctx = request_context()
-                        request_body.messages[1].content = string.rep("x", 128)
+                        raw_request_body = '{"messages":[{"role":"user","content":"' ..
+                                           string.rep("x", 128) .. '"}]}'
 
                         local code, err = plugin.access(
                             config({max_request_body_bytes = 64}), ctx
                         )
 
                         assert.is_equal(413, code)
-                        assert.is_same({
-                            message = "request body is greater than the maximum size",
-                        }, err)
+                        assert.is_truthy(err.message:find(
+                            "is greater than the maximum size 64", 1, true
+                        ))
                         assert.is_equal(64, observed.body_limit)
                         assert.is_equal(0, observed.request_count)
                         assert_no_request_mutation()
@@ -683,7 +999,7 @@ describe(
                     local ctx = request_context()
                     local original = assert(core.json.encode(request_body))
 
-                    local code, err = plugin.access(config(), ctx)
+                    local _, err, code = run_filter(ctx)
 
                     assert.is_equal(502, code)
                     assert.is_same({message = expected_message}, err)
@@ -760,18 +1076,52 @@ describe(
                     end
                 )
 
+                for _, case in ipairs({
+                    {
+                        name = "a non-string response body",
+                        response = function(payload)
+                            local value = success_value(payload)
+                            value.body = assert(core.json.decode(value.body))
+                            return assert(core.json.encode(value))
+                        end,
+                        message = "redaction service body must be a raw JSON string",
+                    },
+                    {
+                        name = "malformed response body text",
+                        response = function()
+                            return '{"body":"{","replacements":[]}'
+                        end,
+                        message = "redaction service body must be valid JSON",
+                    },
+                    {
+                        name = "non-object response body text",
+                        response = function()
+                            return '{"body":"[]","replacements":[]}'
+                        end,
+                        message = "redaction service body must be an object",
+                    },
+                }) do
+                    it(
+                        "rejects " .. case.name, function()
+                            behavior.response_builder = case.response
+
+                            assert_502_without_mutation(case.message)
+                        end
+                    )
+                end
+
                 it(
                     "rejects an oversized declared response before reading it", function()
                         local ctx = request_context()
-                        -- Wire cap = 27 + 6*200 body bytes + 6*20 mapping bytes
-                        --            + 33*2 mapping entries = 1413 bytes.
-                        behavior.response_headers["Content-Length"] = "1414"
+                        -- Wire cap = 29 + 6*200 body bytes + 6*20 mapping bytes
+                        --            + 33*2 mapping entries = 1415 bytes.
+                        behavior.response_headers["Content-Length"] = "1416"
 
-                        local code, err = plugin.access(config({
+                        local _, err, code = run_filter(ctx, config({
                             max_request_body_bytes = 200,
                             max_mapping_bytes = 20,
                             max_mapping_entries = 2,
-                        }), ctx)
+                        }))
 
                         assert.is_equal(502, code)
                         assert.is_same({
@@ -781,9 +1131,8 @@ describe(
                         assert.is_equal(0, observed.read_body_count)
                         assert.is_equal(0, observed.keepalive_count)
                         assert.is_equal(1, observed.close_count)
-                        assert.is_nil(ctx._ai_redaction_request_id)
-                        assert.is_nil(ctx._ai_redaction_session_id)
-                        assert.is_nil(ctx._ai_redaction_namespace)
+                        assert.is_not_nil(ctx._ai_redaction_request_id)
+                        assert.is_not_nil(ctx._ai_redaction_namespace)
                         assert.is_nil(ctx._ai_redaction_mapping)
                         assert.is_nil(ctx.ai_request_body_changed)
                         assert_no_request_mutation()
@@ -794,13 +1143,13 @@ describe(
                     "does not reject a declared response at the exact derived cap",
                     function()
                         local ctx = request_context()
-                        behavior.response_headers["Content-Length"] = "1413"
+                        behavior.response_headers["Content-Length"] = "1415"
 
-                        local code, err = plugin.access(config({
+                        local _, err, code = run_filter(ctx, config({
                             max_request_body_bytes = 200,
                             max_mapping_bytes = 20,
                             max_mapping_entries = 2,
-                        }), ctx)
+                        }))
 
                         assert.is_equal(502, code)
                         assert.is_same({
@@ -810,9 +1159,8 @@ describe(
                         assert.is_equal(0, observed.read_body_count)
                         assert.is_equal(1, observed.keepalive_count)
                         assert.is_equal(0, observed.close_count)
-                        assert.is_nil(ctx._ai_redaction_request_id)
-                        assert.is_nil(ctx._ai_redaction_session_id)
-                        assert.is_nil(ctx._ai_redaction_namespace)
+                        assert.is_not_nil(ctx._ai_redaction_request_id)
+                        assert.is_not_nil(ctx._ai_redaction_namespace)
                         assert.is_nil(ctx._ai_redaction_mapping)
                         assert.is_nil(ctx.ai_request_body_changed)
                         assert_no_request_mutation()
@@ -823,21 +1171,21 @@ describe(
                     "bounds reader allocations when one wire chunk exceeds the cap",
                     function()
                         local ctx = request_context()
-                        -- Wire cap = 27 + 6*1400 body bytes + 6*1 mapping byte
-                        --            + 33*1 mapping entry = 8466 bytes.
-                        behavior.response_body = string.rep("a", 8467)
+                        -- Wire cap = 29 + 6*1400 body bytes + 6*1 mapping byte
+                        --            + 33*1 mapping entry = 8468 bytes.
+                        behavior.response_body = string.rep("a", 8469)
 
-                        local code, err = plugin.access(config({
+                        local _, err, code = run_filter(ctx, config({
                             max_request_body_bytes = 1400,
                             max_mapping_bytes = 1,
                             max_mapping_entries = 1,
-                        }), ctx)
+                        }))
 
                         assert.is_equal(502, code)
                         assert.is_same({
                             message = "redaction service response size limit exceeded",
                         }, err)
-                        assert.is_same({8192, 275}, observed.body_reader_sizes)
+                        assert.is_same({8192, 277}, observed.body_reader_sizes)
                         for _, read_size in ipairs(observed.body_reader_sizes) do
                             assert.is_true(read_size > 0)
                             assert.is_true(read_size <= 8192)
@@ -847,9 +1195,8 @@ describe(
                         assert.is_equal(0, observed.read_body_count)
                         assert.is_equal(0, observed.keepalive_count)
                         assert.is_equal(1, observed.close_count)
-                        assert.is_nil(ctx._ai_redaction_request_id)
-                        assert.is_nil(ctx._ai_redaction_session_id)
-                        assert.is_nil(ctx._ai_redaction_namespace)
+                        assert.is_not_nil(ctx._ai_redaction_request_id)
+                        assert.is_not_nil(ctx._ai_redaction_namespace)
                         assert.is_nil(ctx._ai_redaction_mapping)
                         assert.is_nil(ctx.ai_request_body_changed)
                         assert_no_request_mutation()
@@ -860,20 +1207,19 @@ describe(
                     "rejects a decoded masked body above the request-body limit", function()
                         local ctx = request_context()
                         behavior.response_builder = function(payload)
-                            local value = success_value(payload)
-                            value.body.padding = string.rep("x", 256)
-                            return assert(core.json.encode(value))
+                            return mutate_success_response(payload, function(body)
+                                body.padding = string.rep("x", 256)
+                            end)
                         end
 
-                        local code, err = plugin.access(config({
+                        local _, err, code = run_filter(ctx, config({
                             max_request_body_bytes = 200,
-                        }), ctx)
+                        }))
 
                         assert.is_equal(502, code)
                         assert.is_same({message = "masked body size limit exceeded"}, err)
-                        assert.is_nil(ctx._ai_redaction_request_id)
-                        assert.is_nil(ctx._ai_redaction_session_id)
-                        assert.is_nil(ctx._ai_redaction_namespace)
+                        assert.is_not_nil(ctx._ai_redaction_request_id)
+                        assert.is_not_nil(ctx._ai_redaction_namespace)
                         assert.is_nil(ctx._ai_redaction_mapping)
                         assert.is_nil(ctx.ai_request_body_changed)
                         assert_no_request_mutation()
@@ -883,11 +1229,11 @@ describe(
                 it(
                     "rejects a masked body with another protocol", function()
                         behavior.response_builder = function(payload)
-                            local value = success_value(payload)
-                            value.body.messages = nil
-                            value.body.input = "phone: " ..
-                                               payload.placeholder_namespace .. "1__"
-                            return assert(core.json.encode(value))
+                            return mutate_success_response(payload, function(body)
+                                body.messages = nil
+                                body.input = "phone: " ..
+                                             payload.placeholder_namespace .. "1__"
+                            end)
                         end
 
                         assert_502_without_mutation(
@@ -899,9 +1245,9 @@ describe(
                 it(
                     "rejects a changed model", function()
                         behavior.response_builder = function(payload)
-                            local value = success_value(payload)
-                            value.body.model = "other-model"
-                            return assert(core.json.encode(value))
+                            return mutate_success_response(payload, function(body)
+                                body.model = "other-model"
+                            end)
                         end
 
                         assert_502_without_mutation(
@@ -913,9 +1259,9 @@ describe(
                 it(
                     "rejects a changed stream flag", function()
                         behavior.response_builder = function(payload)
-                            local value = success_value(payload)
-                            value.body.stream = true
-                            return assert(core.json.encode(value))
+                            return mutate_success_response(payload, function(body)
+                                body.stream = true
+                            end)
                         end
 
                         assert_502_without_mutation(
@@ -929,8 +1275,10 @@ describe(
                         behavior.response_builder = function(payload)
                             local value = success_value(payload)
                             local foreign = "__BK_REDACT_" .. string.rep("0", 32) .. "_1__"
-                            value.body.messages[1].content = foreign
                             value.replacements[1].placeholder = foreign
+                            local body = assert(core.json.decode(value.body))
+                            body.messages[1].content = foreign
+                            value.body = assert(core.json.encode(body))
                             return assert(core.json.encode(value))
                         end
 
@@ -943,9 +1291,9 @@ describe(
                 it(
                     "rejects a declared placeholder absent from the masked body", function()
                         behavior.response_builder = function(payload)
-                            local value = success_value(payload)
-                            value.body.messages[1].content = "no placeholder"
-                            return assert(core.json.encode(value))
+                            return mutate_success_response(payload, function(body)
+                                body.messages[1].content = "no placeholder"
+                            end)
                         end
 
                         assert_502_without_mutation(
@@ -959,8 +1307,10 @@ describe(
                         behavior.response_builder = function(payload)
                             local value = success_value(payload)
                             local second = payload.placeholder_namespace .. "2__"
-                            value.body.messages[1].content =
-                                value.body.messages[1].content .. " " .. second
+                            local body = assert(core.json.decode(value.body))
+                            body.messages[1].content =
+                                body.messages[1].content .. " " .. second
+                            value.body = assert(core.json.encode(body))
                             value.replacements[2] = {
                                 placeholder = second,
                                 original = "second-secret",
@@ -969,8 +1319,8 @@ describe(
                         end
                         local ctx = request_context()
 
-                        local code, err = plugin.access(
-                            config({max_mapping_entries = 1}), ctx
+                        local _, err, code = run_filter(
+                            ctx, config({max_mapping_entries = 1})
                         )
 
                         assert.is_equal(502, code)
@@ -984,8 +1334,8 @@ describe(
                     "rejects mappings above the byte limit", function()
                         local ctx = request_context()
 
-                        local code, err = plugin.access(
-                            config({max_mapping_bytes = 1}), ctx
+                        local _, err, code = run_filter(
+                            ctx, config({max_mapping_bytes = 1})
                         )
 
                         assert.is_equal(502, code)
@@ -1023,23 +1373,25 @@ describe(
                             "__BK_REDACT_da584df57bd5459098e08f92a89f9494_"
                         local token = namespace .. "1__"
 
-                        local code, err = plugin.access(config(), ctx)
+                        local masked_body, err, code = run_filter(ctx)
 
-                        assert.is_nil(code)
+                        assert.is_string(masked_body)
                         assert.is_nil(err)
+                        assert.is_nil(code)
                         assert.is_equal(1, observed.request_count)
-                        local masked = assert(core.json.decode(installed_body))
+                        local masked = assert(core.json.decode(masked_body))
                         assert.is_equal("phone: " .. token, masked.messages[1].content)
                         assert.is_equal(
-                            "phone: " .. token, request_body.messages[1].content
+                            "phone: 13800138000", request_body.messages[1].content
                         )
                         assert.is_equal("gpt-4o", masked.model)
                         assert.is_false(masked.stream)
                         assert.is_equal(request_id, ctx._ai_redaction_request_id)
                         assert.is_equal(namespace, ctx._ai_redaction_namespace)
                         assert.is_same({[token] = "13800138000"}, ctx._ai_redaction_mapping)
-                        assert.is_true(ctx.ai_request_body_changed)
+                        assert.is_nil(ctx.ai_request_body_changed)
                         assert.is_nil(ctx._ai_redaction_sse_restorer)
+                        assert_no_request_mutation()
                     end
                 )
             end

--- a/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
@@ -110,6 +110,7 @@ describe(
                 installed_body = nil
                 behavior = {
                     connect_ok = true,
+                    response_headers = {},
                     response_status = 200,
                     response_builder = success_response,
                 }
@@ -118,6 +119,8 @@ describe(
                     connect_count = 0,
                     request_count = 0,
                     read_count = 0,
+                    body_reader_count = 0,
+                    read_body_count = 0,
                     keepalive_count = 0,
                     close_count = 0,
                 }
@@ -162,9 +165,28 @@ describe(
 
                                 observed.payload = assert(core.json.decode(options.body))
                                 local raw = behavior.response_builder(observed.payload)
+                                local chunks = behavior.response_chunks or {raw}
+                                local chunk_index = 0
                                 return {
                                     status = behavior.response_status,
+                                    headers = behavior.response_headers,
+                                    body_reader = function()
+                                        observed.body_reader_count =
+                                            observed.body_reader_count + 1
+                                        if behavior.read_error then
+                                            observed.read_count = observed.read_count + 1
+                                            return nil, behavior.read_error
+                                        end
+
+                                        chunk_index = chunk_index + 1
+                                        local chunk = chunks[chunk_index]
+                                        if chunk then
+                                            observed.read_count = observed.read_count + 1
+                                        end
+                                        return chunk
+                                    end,
                                     read_body = function()
+                                        observed.read_body_count = observed.read_body_count + 1
                                         observed.read_count = observed.read_count + 1
                                         if behavior.read_error then
                                             return nil, behavior.read_error
@@ -240,6 +262,18 @@ describe(
                         conf = {auth_header = "X-Token\r\nInjected"},
                     },
                     {
+                        name = "a literal authentication value containing CRLF",
+                        conf = {auth_value = "secret\r\nInjected: true"},
+                    },
+                    {
+                        name = "a literal authentication value containing NUL",
+                        conf = {auth_value = "secret\0tail"},
+                    },
+                    {
+                        name = "a literal authentication value containing DEL",
+                        conf = {auth_value = "secret\127tail"},
+                    },
+                    {
                         name = "an unsafe session header name",
                         conf = {session_id_header = "Bad Header"},
                     },
@@ -254,6 +288,46 @@ describe(
                         end
                     )
                 end
+
+                for _, header_name in ipairs({
+                    "Content-Length",
+                    "transfer-encoding",
+                    "CONNECTION",
+                    "Keep-Alive",
+                    "Proxy-Authenticate",
+                    "proxy-authorization",
+                    "TE",
+                    "Trailer",
+                    "Upgrade",
+                    "Host",
+                    "content-type",
+                }) do
+                    it(
+                        "rejects forbidden authentication header " .. header_name,
+                        function()
+                            local ok = plugin.check_schema(config({
+                                auth_header = header_name,
+                            }))
+
+                            assert.is_false(ok)
+                        end
+                    )
+                end
+
+                it(
+                    "accepts Authorization, X-* headers, and secret references", function()
+                        local authorization_ok = plugin.check_schema(config({
+                            auth_header = "Authorization",
+                        }))
+                        local custom_ok = plugin.check_schema(config({
+                            auth_header = "X-Redaction-Token",
+                            auth_value = "$secret://vault/redaction/token",
+                        }))
+
+                        assert.is_true(authorization_ok)
+                        assert.is_true(custom_ok)
+                    end
+                )
             end
         )
 
@@ -428,10 +502,31 @@ describe(
                         assert.is_equal(1, observed.request_count)
                         assert.is_equal(0, observed.keepalive_count)
                         assert.is_equal(1, observed.close_count)
-                        assert.is_false(observed.connect_options.pool_size)
+                        assert.is_nil(observed.connect_options.pool_size)
                         assert.is_nil(
                             observed.request_options.headers["X-Redaction-Token"]
                         )
+                    end
+                )
+
+                it(
+                    "closes safely when returning a connection to the pool fails", function()
+                        local ctx = request_context({
+                            var = {
+                                apisix_request_id =
+                                    "da584df5-7bd5-4590-98e0-8f92a89f9494",
+                            },
+                        })
+                        behavior.keepalive_ok = false
+                        behavior.keepalive_error = "pool rejected connection"
+
+                        local code, err = plugin.access(config(), ctx)
+
+                        assert.is_nil(code)
+                        assert.is_nil(err)
+                        assert.is_equal(1, observed.keepalive_count)
+                        assert.is_equal(1, observed.close_count)
+                        assert.is_not_nil(installed_body)
                     end
                 )
             end
@@ -545,6 +640,26 @@ describe(
                         assert_no_request_mutation()
                     end
                 )
+
+                it(
+                    "rejects a resolved authentication value containing CRLF", function()
+                        local ctx = request_context()
+                        local conf = config({
+                            auth_value = "resolved-secret\r\nInjected: true",
+                        })
+
+                        local code, err = plugin.access(conf, ctx)
+
+                        assert.is_equal(500, code)
+                        assert.is_equal(
+                            "invalid redaction service authentication configuration",
+                            err
+                        )
+                        assert.is_equal(0, observed.new_count)
+                        assert.is_equal(0, observed.request_count)
+                        assert_no_request_mutation()
+                    end
+                )
             end
         )
 
@@ -630,6 +745,123 @@ describe(
                         )
 
                         assert.is_equal(1, observed.request_count)
+                    end
+                )
+
+                it(
+                    "rejects an oversized declared response before reading it", function()
+                        local ctx = request_context()
+                        -- Wire cap = 27 + 6*200 body bytes + 6*20 mapping bytes
+                        --            + 33*2 mapping entries = 1413 bytes.
+                        behavior.response_headers["Content-Length"] = "1414"
+
+                        local code, err = plugin.access(config({
+                            max_request_body_bytes = 200,
+                            max_mapping_bytes = 20,
+                            max_mapping_entries = 2,
+                        }), ctx)
+
+                        assert.is_equal(502, code)
+                        assert.is_same({
+                            message = "redaction service response size limit exceeded",
+                        }, err)
+                        assert.is_equal(0, observed.body_reader_count)
+                        assert.is_equal(0, observed.read_body_count)
+                        assert.is_equal(0, observed.keepalive_count)
+                        assert.is_equal(1, observed.close_count)
+                        assert.is_nil(ctx._ai_redaction_request_id)
+                        assert.is_nil(ctx._ai_redaction_session_id)
+                        assert.is_nil(ctx._ai_redaction_namespace)
+                        assert.is_nil(ctx._ai_redaction_mapping)
+                        assert.is_nil(ctx.ai_request_body_changed)
+                        assert_no_request_mutation()
+                    end
+                )
+
+                it(
+                    "does not reject a declared response at the exact derived cap",
+                    function()
+                        local ctx = request_context()
+                        behavior.response_headers["Content-Length"] = "1413"
+
+                        local code, err = plugin.access(config({
+                            max_request_body_bytes = 200,
+                            max_mapping_bytes = 20,
+                            max_mapping_entries = 2,
+                        }), ctx)
+
+                        assert.is_equal(502, code)
+                        assert.is_same({
+                            message = "mapping byte limit exceeded",
+                        }, err)
+                        assert.is_equal(2, observed.body_reader_count)
+                        assert.is_equal(0, observed.read_body_count)
+                        assert.is_equal(1, observed.keepalive_count)
+                        assert.is_equal(0, observed.close_count)
+                        assert.is_nil(ctx._ai_redaction_request_id)
+                        assert.is_nil(ctx._ai_redaction_session_id)
+                        assert.is_nil(ctx._ai_redaction_namespace)
+                        assert.is_nil(ctx._ai_redaction_mapping)
+                        assert.is_nil(ctx.ai_request_body_changed)
+                        assert_no_request_mutation()
+                    end
+                )
+
+                it(
+                    "closes a chunked response when its accumulated body exceeds the cap",
+                    function()
+                        local ctx = request_context()
+                        -- The same 1413-byte derived cap is crossed by the second chunk.
+                        behavior.response_chunks = {
+                            string.rep("a", 1000),
+                            string.rep("b", 414),
+                        }
+
+                        local code, err = plugin.access(config({
+                            max_request_body_bytes = 200,
+                            max_mapping_bytes = 20,
+                            max_mapping_entries = 2,
+                        }), ctx)
+
+                        assert.is_equal(502, code)
+                        assert.is_same({
+                            message = "redaction service response size limit exceeded",
+                        }, err)
+                        assert.is_equal(2, observed.read_count)
+                        assert.is_equal(2, observed.body_reader_count)
+                        assert.is_equal(0, observed.read_body_count)
+                        assert.is_equal(0, observed.keepalive_count)
+                        assert.is_equal(1, observed.close_count)
+                        assert.is_nil(ctx._ai_redaction_request_id)
+                        assert.is_nil(ctx._ai_redaction_session_id)
+                        assert.is_nil(ctx._ai_redaction_namespace)
+                        assert.is_nil(ctx._ai_redaction_mapping)
+                        assert.is_nil(ctx.ai_request_body_changed)
+                        assert_no_request_mutation()
+                    end
+                )
+
+                it(
+                    "rejects a decoded masked body above the request-body limit", function()
+                        local ctx = request_context()
+                        behavior.response_builder = function(payload)
+                            local value = success_value(payload)
+                            value.body.padding = string.rep("x", 256)
+                            return assert(core.json.encode(value))
+                        end
+
+                        local code, err = plugin.access(config({
+                            max_request_body_bytes = 200,
+                        }), ctx)
+
+                        assert.is_equal(502, code)
+                        assert.is_same({message = "masked body size limit exceeded"}, err)
+                        assert.is_nil(ctx._ai_redaction_request_id)
+                        assert.is_nil(ctx._ai_redaction_session_id)
+                        assert.is_nil(ctx._ai_redaction_namespace)
+                        assert.is_nil(ctx._ai_redaction_mapping)
+                        assert.is_nil(ctx.ai_request_body_changed)
+                        assert_no_request_mutation()
                     end
                 )
 

--- a/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
@@ -1045,6 +1045,78 @@ describe(
         )
 
         context(
+            "stream response restoration", function()
+                it(
+                    "restores split SSE placeholders and clears state only at EOF",
+                    function()
+                        local request_id = "da584df5-7bd5-4590-98e0-8f92a89f9494"
+                        local namespace =
+                            "__BK_REDACT_da584df57bd5459098e08f92a89f9494_"
+                        local known = namespace .. "1__"
+                        local split_at = math.floor(#known / 2)
+                        local ctx = request_context({
+                            var = {request_type = "ai_stream"},
+                            _ai_redaction_request_id = request_id,
+                            _ai_redaction_session_id =
+                                "24395b38-bf3f-426c-a632-10df20ec69c8",
+                            _ai_redaction_namespace = namespace,
+                            _ai_redaction_mapping = {[known] = "13800138000"},
+                        })
+                        local event1 = "data: " .. assert(core.json.encode({
+                            choices = {
+                                {
+                                    index = 0,
+                                    delta = {content = "phone: " .. known:sub(1, split_at)},
+                                },
+                            },
+                        })) .. "\n\n"
+                        local event2 = "data: " .. assert(core.json.encode({
+                            choices = {
+                                {
+                                    index = 0,
+                                    delta = {content = known:sub(split_at + 1)},
+                                },
+                            },
+                        })) .. "\n\ndata: [DONE]\n\n"
+
+                        local code1, output1 = plugin.lua_body_filter(
+                            config(), ctx, {}, event1, false
+                        )
+                        local processor = ctx._ai_redaction_sse_restorer
+                        local code2, output2 = plugin.lua_body_filter(
+                            config(), ctx, {}, event2, false
+                        )
+
+                        assert.is_nil(code1)
+                        assert.is_nil(code2)
+                        assert.is_not_nil(processor)
+                        assert.is_equal(processor, ctx._ai_redaction_sse_restorer)
+                        assert.is_falsy(output1:find(known, 1, true))
+                        assert.is_truthy(output2:find("13800138000", 1, true))
+                        assert.is_truthy(output2:find("data: [DONE]", 1, true))
+                        assert.is_same({[known] = "13800138000"}, ctx._ai_redaction_mapping)
+                        assert.is_equal(1, ctx._ai_redaction_restored_count)
+                        assert.is_equal(0, ctx._ai_redaction_unresolved_count)
+
+                        local code3, output3 = plugin.lua_body_filter(
+                            config(), ctx, {}, "", true
+                        )
+
+                        assert.is_nil(code3)
+                        assert.is_equal("", output3)
+                        assert.is_equal(request_id, ctx._ai_redaction_request_id)
+                        assert.is_nil(ctx._ai_redaction_session_id)
+                        assert.is_nil(ctx._ai_redaction_namespace)
+                        assert.is_nil(ctx._ai_redaction_mapping)
+                        assert.is_nil(ctx._ai_redaction_sse_restorer)
+                        assert.is_equal(1, ctx._ai_redaction_restored_count)
+                        assert.is_equal(0, ctx._ai_redaction_unresolved_count)
+                    end
+                )
+            end
+        )
+
+        context(
             "non-stream response restoration", function()
                 before_each(
                     function()

--- a/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
@@ -1632,8 +1632,77 @@ describe(
                         assert.is_nil(next(processor.stream.states))
                         assert.is_nil(next(processor.keys))
                         assert.is_same({}, processor.key_order)
+                        assert.is_equal(0, processor.metadata_bytes)
+                        assert.is_nil(next(processor.key_metadata_bytes))
                     end
                 )
+
+                it(
+                    "bounds aggregate response item metadata", function()
+                        local processor = assert(sse_restorer.new(
+                            "openai-responses", {[token] = "secret"}, namespace
+                        ))
+                        local prefix = token:sub(1, -2)
+                        local first = response_frame("response.output_text.delta", {
+                            item_id = string.rep("a", 18000),
+                            content_index = 0,
+                            delta = prefix,
+                        })
+                        local second = response_frame("response.output_text.delta", {
+                            item_id = string.rep("b", 18000),
+                            content_index = 0,
+                            delta = prefix,
+                        })
+
+                        assert.is_string(processor:feed(first, false))
+                        local ok = pcall(processor.feed, processor, second, false)
+
+                        assert.is_false(ok)
+                        assert.is_equal(1, processor.stream.active_count)
+                        assert.is_true(processor.metadata_bytes <= 64 * 1024)
+                        processor:fail_closed("")
+                        assert.is_equal(0, processor.metadata_bytes)
+                        assert.is_nil(next(processor.key_metadata_bytes))
+                    end
+                )
+
+                for _, case in ipairs({
+                    {
+                        name = "OpenAI Chat event names",
+                        protocol = "openai-chat",
+                        value = {
+                            choices = {{index = 0, delta = {content = token:sub(1, -2)}}},
+                        },
+                    },
+                    {
+                        name = "Anthropic event names",
+                        protocol = "anthropic-messages",
+                        value = {
+                            type = "content_block_delta",
+                            index = 0,
+                            delta = {
+                                type = "text_delta",
+                                text = token:sub(1, -2),
+                            },
+                        },
+                    },
+                }) do
+                    it(
+                        "bounds long " .. case.name, function()
+                            local processor = assert(sse_restorer.new(
+                                case.protocol, {[token] = "secret"}, namespace
+                            ))
+                            local input = frame(string.rep("e", 33000), case.value)
+
+                            local ok = pcall(processor.feed, processor, input, false)
+
+                            assert.is_false(ok)
+                            assert.is_equal(0, processor.stream.active_count)
+                            assert.is_equal(0, processor.metadata_bytes)
+                            assert.is_nil(next(processor.key_metadata_bytes))
+                        end
+                    )
+                end
 
                 it(
                     "rejects more than 1024 active logical fields", function()
@@ -2162,6 +2231,79 @@ describe(
                         assert.is_true(ctx._ai_redaction_stream_passthrough)
                         assert.is_nil(ctx._ai_redaction_mapping)
                         assert.is_nil(ctx._ai_redaction_sse_restorer)
+                        assert.stub(core.log.error).was_called(1)
+                    end
+                )
+
+                it(
+                    "rolls back and clears metadata overflow without duplicating its chunk",
+                    function()
+                        local request_id = "8a2fa378-5002-4035-88e5-82b637117490"
+                        local namespace =
+                            "__BK_REDACT_8a2fa3785002403588e582b637117490_"
+                        local token = namespace .. "1__"
+                        local prefix = token:sub(1, -2)
+                        local ctx = request_context({
+                            var = {request_type = "ai_stream"},
+                            ai_client_protocol = "openai-responses",
+                            _ai_redaction_request_id = request_id,
+                            _ai_redaction_namespace = namespace,
+                            _ai_redaction_mapping = {[token] = "sensitive-original"},
+                        })
+                        local function response_delta(item_id, delta)
+                            local event_type = "response.output_text.delta"
+                            return "event: " .. event_type .. "\ndata: " ..
+                                   assert(core.json.encode({
+                                       type = event_type,
+                                       item_id = item_id,
+                                       output_index = 0,
+                                       content_index = 0,
+                                       delta = delta,
+                                   })) .. "\n\n"
+                        end
+
+                        local first = response_delta(string.rep("a", 18000), prefix)
+                        local code1, output1 = plugin.lua_body_filter(
+                            config(), ctx, {}, first, false
+                        )
+                        local processor = ctx._ai_redaction_sse_restorer
+                        local complete = response_delta(
+                            string.rep("c", 40000), "ordinary text"
+                        )
+                        local overflowing = response_delta(
+                            string.rep("b", 18000), prefix
+                        )
+                        local current_chunk = complete .. overflowing
+                        local code2, output2 = plugin.lua_body_filter(
+                            config(), ctx, {}, current_chunk, false
+                        )
+
+                        local combined = output1 .. output2
+                        local occurrences = 0
+                        local position = 1
+                        while true do
+                            local found = combined:find(prefix, position, true)
+                            if not found then
+                                break
+                            end
+                            occurrences = occurrences + 1
+                            position = found + #prefix
+                        end
+                        assert.is_nil(code1)
+                        assert.is_nil(code2)
+                        assert.is_equal(current_chunk, output2:sub(-#current_chunk))
+                        assert.is_equal(2, occurrences)
+                        assert.is_nil(combined:find("sensitive-original", 1, true))
+                        assert.is_true(ctx._ai_redaction_stream_passthrough)
+                        assert.is_nil(ctx._ai_redaction_mapping)
+                        assert.is_nil(ctx._ai_redaction_sse_restorer)
+                        assert.is_equal(0, processor.stream.active_count)
+                        assert.is_equal(0, processor.stream.pending_bytes)
+                        assert.is_equal(0, processor.metadata_bytes)
+                        assert.is_nil(next(processor.stream.states))
+                        assert.is_nil(next(processor.keys))
+                        assert.is_nil(next(processor.key_metadata_bytes))
+                        assert.is_same({}, processor.key_order)
                         assert.stub(core.log.error).was_called(1)
                     end
                 )

--- a/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
@@ -301,6 +301,74 @@ describe(
                 )
 
                 it(
+                    "clears rewritten payload logs before a lower-priority rejection",
+                    function()
+                        local ctx = request_context({
+                            var = {
+                                llm_request_body = {
+                                    messages = {{
+                                        role = "user",
+                                        content = "rewrite-residue-secret",
+                                    }},
+                                },
+                            },
+                        })
+
+                        register_filter(ctx)
+
+                        assert.is_same({}, ctx.var.llm_request_body)
+                        proxy_base.set_logging(ctx, false, true)
+                        local payload_log = assert(core.json.encode(ctx.llm_request))
+                        assert.is_nil(payload_log:find(
+                            "rewrite-residue-secret", 1, true
+                        ))
+                        assert.is_equal(0, observed.request_count)
+                    end
+                )
+
+                it(
+                    "clears rewritten payload logs before early access failures",
+                    function()
+                        for _, case in ipairs({
+                            {
+                                ctx = request_context({
+                                    picked_ai_instance = false,
+                                    var = {
+                                        llm_request_body = {
+                                            secret = "missing-context-secret",
+                                        },
+                                    },
+                                }),
+                                conf = config(),
+                                status = 500,
+                            },
+                            {
+                                ctx = request_context({
+                                    var = {
+                                        llm_request_body = {
+                                            secret = "oversize-secret",
+                                        },
+                                    },
+                                }),
+                                conf = config({max_request_body_bytes = 1}),
+                                status = 413,
+                            },
+                        }) do
+                            local code = plugin.access(case.conf, case.ctx)
+
+                            assert.is_equal(case.status, code)
+                            assert.is_same({}, case.ctx.var.llm_request_body)
+                            proxy_base.set_logging(case.ctx, false, true)
+                            local payload_log = assert(core.json.encode(
+                                case.ctx.llm_request
+                            ))
+                            assert.is_nil(payload_log:find("-secret", 1, true))
+                        end
+                        assert.is_equal(0, observed.request_count)
+                    end
+                )
+
+                it(
                     "rejects an existing final-body callback instead of replacing it",
                     function()
                         local existing = function(body)

--- a/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
@@ -222,6 +222,9 @@ describe(
 
                                         local remaining = #response_body - response_offset + 1
                                         local read_size = math.min(max_bytes or remaining, remaining)
+                                        if behavior.one_byte_chunks then
+                                            read_size = 1
+                                        end
                                         local chunk = response_body:sub(
                                             response_offset,
                                             response_offset + read_size - 1
@@ -299,6 +302,67 @@ describe(
                         assert_no_request_mutation()
                     end
                 )
+
+                for _, case in ipairs({
+                    {
+                        name = "Anthropic Messages to OpenAI Chat",
+                        converter = "anthropic-messages-to-openai-chat",
+                        uri = "/v1/messages",
+                        client_protocol = "anthropic-messages",
+                        target_protocol = "openai-chat",
+                        body = {
+                            model = "gpt-4o",
+                            stream = false,
+                            max_tokens = 128,
+                            messages = {{
+                                role = "user",
+                                content = "phone: 13800138000",
+                            }},
+                        },
+                    },
+                    {
+                        name = "OpenAI Embeddings to Vertex Predict",
+                        converter = "openai-embeddings-to-vertex-predict",
+                        uri = "/v1/embeddings",
+                        client_protocol = "openai-embeddings",
+                        target_protocol = "vertex-predict",
+                        body = {
+                            model = "text-embedding-004",
+                            input = "phone: 13800138000",
+                        },
+                    },
+                }) do
+                    it(
+                        "accepts the real " .. case.name .. " converter output",
+                        function()
+                            request_body = case.body
+                            raw_request_body = assert(core.json.encode(request_body))
+                            local ctx = request_context({
+                                var = {uri = case.uri},
+                                ai_client_protocol = case.client_protocol,
+                                ai_target_protocol = case.target_protocol,
+                            })
+                            local converter = require(
+                                "apisix.plugins.ai-protocols.converters." ..
+                                case.converter
+                            )
+                            local converted = assert(converter.convert_request(
+                                request_body, ctx
+                            ))
+
+                            local filter = register_filter(ctx)
+                            local masked_body, err, code = filter(
+                                assert(core.json.encode(converted))
+                            )
+
+                            assert.is_nil(err)
+                            assert.is_nil(code)
+                            assert.is_string(masked_body)
+                            assert.is_nil(masked_body:find("13800138000", 1, true))
+                            assert.is_equal(1, observed.request_count)
+                        end
+                    )
+                end
 
                 it(
                     "clears rewritten payload logs before a lower-priority rejection",
@@ -1336,6 +1400,45 @@ describe(
                 )
 
                 it(
+                    "coalesces adversarial one-byte response chunks", function()
+                        local module_name =
+                            "apisix.plugins.bk-ai-sensitive-data-redaction"
+                        local original_module = package.loaded[module_name]
+                        local original_concat = table.concat
+                        local concat_entry_counts = {}
+                        table.concat = function(values, ...)
+                            concat_entry_counts[#concat_entry_counts + 1] = #values
+                            return original_concat(values, ...)
+                        end
+                        package.loaded[module_name] = nil
+                        local fresh_plugin = require(module_name)
+                        package.loaded[module_name] = original_module
+                        table.concat = original_concat
+
+                        behavior.one_byte_chunks = true
+                        behavior.response_builder = function(payload)
+                            local value = success_value(payload)
+                            value.padding = string.rep("x", 20000)
+                            return assert(core.json.encode(value))
+                        end
+                        local ctx = request_context()
+                        local access_code, access_err = fresh_plugin.access(config(), ctx)
+                        assert.is_nil(access_code)
+                        assert.is_nil(access_err)
+
+                        local masked_body, err, code =
+                            ctx.ai_final_request_body_filter(raw_request_body)
+
+                        assert.is_nil(err)
+                        assert.is_nil(code)
+                        assert.is_string(masked_body)
+                        assert.is_true(observed.body_reader_count > 20000)
+                        assert.is_true(#concat_entry_counts > 0)
+                        assert.is_true(math.max(unpack(concat_entry_counts)) <= 8192)
+                    end
+                )
+
+                it(
                     "rejects a decoded masked body above the request-body limit", function()
                         local ctx = request_context()
                         behavior.response_builder = function(payload)
@@ -1496,7 +1599,7 @@ describe(
         context(
             "successful mutation", function()
                 it(
-                    "installs only the validated masked body and request-local mapping", function()
+                    "keeps request payload logging empty after successful filtering", function()
                         local request_id = "da584df5-7bd5-4590-98e0-8f92a89f9494"
                         local ctx = request_context({
                             var = {apisix_request_id = request_id},
@@ -1521,11 +1624,11 @@ describe(
                         assert.is_equal(request_id, ctx._ai_redaction_request_id)
                         assert.is_equal(namespace, ctx._ai_redaction_namespace)
                         assert.is_same({[token] = "13800138000"}, ctx._ai_redaction_mapping)
-                        assert.is_same(masked, ctx.var.llm_request_body)
+                        assert.is_same({}, ctx.var.llm_request_body)
                         proxy_base.set_logging(ctx, false, true)
                         local payload_log = assert(core.json.encode(ctx.llm_request))
                         assert.is_nil(payload_log:find("13800138000", 1, true))
-                        assert.is_truthy(payload_log:find(token, 1, true))
+                        assert.is_nil(payload_log:find(token, 1, true))
                         assert.is_nil(ctx.ai_request_body_changed)
                         assert.is_nil(ctx._ai_redaction_sse_restorer)
                         assert_no_request_mutation()
@@ -1702,6 +1805,52 @@ describe(
                         assert.is_same({}, processor.key_order)
                         assert.is_equal(0, processor.metadata_bytes)
                         assert.is_nil(next(processor.key_metadata_bytes))
+                    end
+                )
+
+                it(
+                    "fails closed before repeated placeholders expand past the stream limit",
+                    function()
+                        local original = string.rep("s", 200)
+                        local processor = assert(sse_restorer.new(
+                            "openai-chat", {[token] = original}, namespace, 256
+                        ))
+                        local input =
+                            'data: {"choices":[{"index":0,"delta":{"content":"' ..
+                            token .. token .. '"}}]}\n\n'
+
+                        local ok, err = pcall(
+                            processor.feed, processor, input, false
+                        )
+                        local masked_fallback = processor:fail_closed(input)
+
+                        assert.is_false(ok)
+                        assert.is_truthy(err:find(
+                            "restored output size limit exceeded", 1, true
+                        ))
+                        assert.is_equal(input, masked_fallback)
+                        assert.is_nil(masked_fallback:find(original, 1, true))
+                    end
+                )
+
+                it(
+                    "preserves numeric lexemes in restored streaming events", function()
+                        local processor = assert(sse_restorer.new(
+                            "openai-chat", {[token] = "13800138000"}, namespace
+                        ))
+                        local input =
+                            'data: {"large":9007199254740993,"negative_zero":-0,' ..
+                            '"exponent":1.2300e+40,"choices":[{"index":0,' ..
+                            '"delta":{"content":"' .. token .. '"}}]}\n\n'
+                        local expected =
+                            'data: {"large":9007199254740993,"negative_zero":-0,' ..
+                            '"exponent":1.2300e+40,"choices":[{"index":0,' ..
+                            '"delta":{"content":"13800138000"}}]}\n\n'
+
+                        local output, restored_count = processor:feed(input, false)
+
+                        assert.is_equal(expected, output)
+                        assert.is_equal(1, restored_count)
                     end
                 )
 
@@ -2482,6 +2631,68 @@ describe(
                         assert.is_equal(1, ctx._ai_redaction_restored_count)
                         assert.is_nil(ctx._ai_redaction_namespace)
                         assert.is_nil(ctx._ai_redaction_mapping)
+                    end
+                )
+
+                it(
+                    "rejects repeated-placeholder expansion before concatenation",
+                    function()
+                        local namespace =
+                            "__BK_REDACT_da584df57bd5459098e08f92a89f9494_"
+                        local known = namespace .. "1__"
+                        local masked_body = '{"content":"' .. known .. known .. '"}'
+
+                        local restored, err = restorer.restore_json_text(
+                            masked_body,
+                            {[known] = string.rep("s", 100)},
+                            namespace,
+                            128
+                        )
+
+                        assert.is_nil(restored)
+                        assert.is_equal("restored output size limit exceeded", err)
+                    end
+                )
+
+                it(
+                    "passes the masked response through when expansion exceeds the route bound",
+                    function()
+                        local request_id = "da584df5-7bd5-4590-98e0-8f92a89f9494"
+                        local namespace =
+                            "__BK_REDACT_da584df57bd5459098e08f92a89f9494_"
+                        local known = namespace .. "1__"
+                        local masked_body =
+                            '{"content":"' .. string.rep(known, 70) .. '"}'
+                        local ctx = request_context({
+                            var = {request_type = "ai_chat"},
+                            _ai_redaction_request_id = request_id,
+                            _ai_redaction_namespace = namespace,
+                            _ai_redaction_mapping = {
+                                [known] = string.rep("s", 4000),
+                            },
+                        })
+
+                        local code, restored_body = plugin.lua_body_filter(
+                            config({
+                                max_request_body_bytes = 4096,
+                                max_mapping_bytes = 4096,
+                                max_mapping_entries = 1,
+                            }),
+                            ctx,
+                            {},
+                            masked_body,
+                            true
+                        )
+
+                        assert.is_nil(code)
+                        assert.is_nil(restored_body)
+                        assert.is_nil(masked_body:find(string.rep("s", 4000), 1, true))
+                        assert.is_nil(ctx._ai_redaction_mapping)
+                        assert.stub(core.log.error).was_called_with(
+                            "failed to restore masked AI response",
+                            ", request_id: ",
+                            request_id
+                        )
                     end
                 )
 

--- a/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
@@ -1,0 +1,801 @@
+--
+-- TencentBlueKing is pleased to support the open source community by making
+-- 蓝鲸智云 - API 网关(BlueKing - APIGateway) available.
+-- Copyright (C) Tencent. All rights reserved.
+-- Licensed under the MIT License (the "License"); you may not use this file except
+-- in compliance with the License. You may obtain a copy of the License at
+--
+--     http://opensource.org/licenses/MIT
+--
+-- Unless required by applicable law or agreed to in writing, software distributed under
+-- the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- We undertake not to change the open source license (MIT license) applicable
+-- to the current version of the project delivered to anyone in the future.
+--
+
+local core = require("apisix.core")
+local http = require("resty.http")
+local plugin = require("apisix.plugins.bk-ai-sensitive-data-redaction")
+
+
+describe(
+    "bk-ai-sensitive-data-redaction", function()
+        local behavior
+        local observed
+        local request_body
+        local request_headers
+        local installed_body
+
+        local function config(overrides)
+            local conf = {
+                endpoint = "https://redaction.example.com/v1/redact?tenant=blueking",
+                auth_header = "X-Redaction-Token",
+                auth_value = "secret-token",
+                session_id_header = "X-AI-Session-Id",
+                timeout = 3000,
+                ssl_verify = true,
+                keepalive = true,
+                keepalive_pool = 30,
+                keepalive_timeout = 60000,
+                max_request_body_bytes = 1048576,
+                max_mapping_entries = 1000,
+                max_mapping_bytes = 1048576,
+            }
+            for key, value in pairs(overrides or {}) do
+                conf[key] = value
+            end
+            return conf
+        end
+
+        local function request_context(overrides)
+            local ctx = CTX({
+                uri = "/v1/chat/completions",
+                request_type = "ai_chat",
+            })
+            ctx.picked_ai_instance = {provider = "openai"}
+            ctx.ai_client_protocol = "openai-chat"
+            for key, value in pairs(overrides or {}) do
+                if key == "var" then
+                    for var_name, var_value in pairs(value) do
+                        ctx.var[var_name] = var_value
+                    end
+                else
+                    ctx[key] = value
+                end
+            end
+            return ctx
+        end
+
+        local function success_value(payload)
+            local masked_body = assert(core.json.decode(assert(core.json.encode(payload.body))))
+            local token = payload.placeholder_namespace .. "1__"
+            masked_body.messages[1].content = "phone: " .. token
+            return {
+                body = masked_body,
+                replacements = {
+                    {
+                        placeholder = token,
+                        original = "13800138000",
+                    },
+                },
+            }
+        end
+
+        local function success_response(payload)
+            return assert(core.json.encode(success_value(payload)))
+        end
+
+        local function assert_no_request_mutation()
+            assert.is_nil(installed_body)
+            assert.stub(ngx.req.set_body_data).was_not_called()
+        end
+
+        before_each(
+            function()
+                request_body = {
+                    model = "gpt-4o",
+                    stream = false,
+                    messages = {
+                        {
+                            role = "user",
+                            content = "phone: 13800138000",
+                        },
+                    },
+                    metadata = {source = "final-client-body"},
+                }
+                request_headers = {}
+                installed_body = nil
+                behavior = {
+                    connect_ok = true,
+                    response_status = 200,
+                    response_builder = success_response,
+                }
+                observed = {
+                    new_count = 0,
+                    connect_count = 0,
+                    request_count = 0,
+                    read_count = 0,
+                    keepalive_count = 0,
+                    close_count = 0,
+                }
+
+                stub(
+                    core.request, "get_json_request_body_table", function(max_size)
+                        observed.body_limit = max_size
+                        if behavior.body_error then
+                            return nil, behavior.body_error
+                        end
+                        return request_body
+                    end
+                )
+                stub(
+                    core.request, "header", function(_, name)
+                        return request_headers[name]
+                    end
+                )
+                stub(
+                    ngx.req, "set_body_data", function(body)
+                        installed_body = body
+                    end
+                )
+                stub(
+                    http, "new", function()
+                        observed.new_count = observed.new_count + 1
+                        return {
+                            set_timeout = function(_, timeout)
+                                observed.timeout = timeout
+                            end,
+                            connect = function(_, options)
+                                observed.connect_count = observed.connect_count + 1
+                                observed.connect_options = options
+                                return behavior.connect_ok, behavior.connect_error
+                            end,
+                            request = function(_, options)
+                                observed.request_count = observed.request_count + 1
+                                observed.request_options = options
+                                if behavior.request_error then
+                                    return nil, behavior.request_error
+                                end
+
+                                observed.payload = assert(core.json.decode(options.body))
+                                local raw = behavior.response_builder(observed.payload)
+                                return {
+                                    status = behavior.response_status,
+                                    read_body = function()
+                                        observed.read_count = observed.read_count + 1
+                                        if behavior.read_error then
+                                            return nil, behavior.read_error
+                                        end
+                                        return raw
+                                    end,
+                                }
+                            end,
+                            set_keepalive = function(_, timeout, pool)
+                                observed.keepalive_count = observed.keepalive_count + 1
+                                observed.keepalive_timeout = timeout
+                                observed.keepalive_pool = pool
+                                return behavior.keepalive_ok ~= false,
+                                       behavior.keepalive_error
+                            end,
+                            close = function()
+                                observed.close_count = observed.close_count + 1
+                            end,
+                        }
+                    end
+                )
+            end
+        )
+
+        after_each(
+            function()
+                core.request.get_json_request_body_table:revert()
+                core.request.header:revert()
+                ngx.req.set_body_data:revert()
+                http.new:revert()
+            end
+        )
+
+        context(
+            "schema", function()
+                it(
+                    "accepts the complete safe configuration", function()
+                        local ok, err = plugin.check_schema(config())
+
+                        assert.is_true(ok)
+                        assert.is_nil(err)
+                        assert.is_equal("bk-ai-sensitive-data-redaction", plugin.name)
+                        assert.is_equal(1039, plugin.priority)
+                        assert.is_same({"auth_value"}, plugin.schema.encrypt_fields)
+                    end
+                )
+
+                for _, case in ipairs({
+                    {
+                        name = "a non-HTTP endpoint",
+                        conf = {endpoint = "ftp://redaction.example.com/v1/redact"},
+                    },
+                    {
+                        name = "an endpoint without a host",
+                        conf = {endpoint = "https:///v1/redact"},
+                    },
+                    {
+                        name = "an endpoint with raw control characters",
+                        conf = {
+                            endpoint = "https://redaction.example.com/v1/redact\r\nInjected",
+                        },
+                    },
+                    {
+                        name = "a zero timeout",
+                        conf = {timeout = 0},
+                    },
+                    {
+                        name = "a zero mapping entry limit",
+                        conf = {max_mapping_entries = 0},
+                    },
+                    {
+                        name = "an unsafe authentication header name",
+                        conf = {auth_header = "X-Token\r\nInjected"},
+                    },
+                    {
+                        name = "an unsafe session header name",
+                        conf = {session_id_header = "Bad Header"},
+                    },
+                }) do
+                    it(
+                        "rejects " .. case.name, function()
+                            local conf = config(case.conf)
+
+                            local ok = plugin.check_schema(conf)
+
+                            assert.is_false(ok)
+                        end
+                    )
+                end
+            end
+        )
+
+        context(
+            "identity and outbound request", function()
+                it(
+                    "prefers the canonical APISIX request ID and forwards the session ID",
+                    function()
+                        local apisix_request_id = "da584df5-7bd5-4590-98e0-8f92a89f9494"
+                        local bk_request_id = "00f6a0f8-a757-4d68-aa2d-5cf890802496"
+                        local session_id = "24395b38-bf3f-426c-a632-10df20ec69c8"
+                        local ctx = request_context({
+                            var = {
+                                apisix_request_id = apisix_request_id,
+                                bk_request_id = bk_request_id,
+                            },
+                        })
+                        request_headers["X-AI-Session-Id"] = session_id
+
+                        local code, err = plugin.access(config(), ctx)
+
+                        assert.is_nil(code)
+                        assert.is_nil(err)
+                        assert.is_equal(1, observed.request_count)
+                        assert.is_equal(apisix_request_id, observed.payload.request_id)
+                        assert.is_equal(session_id, observed.payload.session_id)
+                        assert.is_equal(
+                            "__BK_REDACT_da584df57bd5459098e08f92a89f9494_",
+                            observed.payload.placeholder_namespace
+                        )
+                        assert.is_same({
+                            model = "gpt-4o",
+                            stream = false,
+                            messages = {
+                                {
+                                    role = "user",
+                                    content = "phone: 13800138000",
+                                },
+                            },
+                            metadata = {source = "final-client-body"},
+                        }, observed.payload.body)
+                        assert.is_equal(apisix_request_id, ctx._ai_redaction_request_id)
+                        assert.is_equal(session_id, ctx._ai_redaction_session_id)
+                    end
+                )
+
+                it(
+                    "falls back to the canonical BlueKing request ID", function()
+                        local bk_request_id = "00f6a0f8-a757-4d68-aa2d-5cf890802496"
+                        local ctx = request_context({
+                            var = {
+                                apisix_request_id = "not-a-uuid",
+                                bk_request_id = bk_request_id,
+                            },
+                        })
+
+                        local code = plugin.access(config(), ctx)
+
+                        assert.is_nil(code)
+                        assert.is_equal(1, observed.request_count)
+                        assert.is_equal(bk_request_id, observed.payload.request_id)
+                    end
+                )
+
+                it(
+                    "generates a UUID v4 when neither request ID is canonical", function()
+                        local ctx = request_context({
+                            var = {
+                                apisix_request_id = "bad-apisix-id",
+                                bk_request_id = "bad-bk-id",
+                            },
+                        })
+
+                        local code = plugin.access(config(), ctx)
+
+                        assert.is_nil(code)
+                        assert.is_equal(1, observed.request_count)
+                        local uuid_v4_pattern =
+                            [[^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-]] ..
+                            [[[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$]]
+                        assert.is_truthy(ngx.re.match(
+                            observed.payload.request_id, uuid_v4_pattern, "jo"
+                        ))
+                        assert.is_equal(
+                            "__BK_REDACT_" ..
+                            observed.payload.request_id:gsub("-", ""):lower() .. "_",
+                            observed.payload.placeholder_namespace
+                        )
+                    end
+                )
+
+                it(
+                    "omits an absent session ID", function()
+                        local ctx = request_context({
+                            var = {
+                                apisix_request_id = "da584df5-7bd5-4590-98e0-8f92a89f9494",
+                            },
+                        })
+
+                        local code = plugin.access(config(), ctx)
+
+                        assert.is_nil(code)
+                        assert.is_equal(1, observed.request_count)
+                        assert.is_nil(observed.payload.session_id)
+                        assert.is_nil(ctx._ai_redaction_session_id)
+                    end
+                )
+
+                it(
+                    "rejects a non-empty invalid session ID before the service call", function()
+                        local ctx = request_context()
+                        request_headers["X-AI-Session-Id"] = "not-a-session-uuid"
+
+                        local code, err = plugin.access(config(), ctx)
+
+                        assert.is_equal(400, code)
+                        assert.is_equal("invalid AI session ID", err)
+                        assert.is_equal(0, observed.new_count)
+                        assert.is_equal(0, observed.request_count)
+                        assert_no_request_mutation()
+                    end
+                )
+
+                it(
+                    "sends authentication and connection settings once", function()
+                        local ctx = request_context()
+
+                        local code = plugin.access(config(), ctx)
+
+                        assert.is_nil(code)
+                        assert.is_equal(1, observed.new_count)
+                        assert.is_equal(1, observed.connect_count)
+                        assert.is_equal(1, observed.request_count)
+                        assert.is_equal(1, observed.read_count)
+                        assert.is_equal(1, observed.keepalive_count)
+                        assert.is_equal(0, observed.close_count)
+                        assert.is_equal(3000, observed.timeout)
+                        assert.is_same({
+                            scheme = "https",
+                            host = "redaction.example.com",
+                            port = nil,
+                            ssl_verify = true,
+                            ssl_server_name = "redaction.example.com",
+                            pool_size = 30,
+                        }, observed.connect_options)
+                        assert.is_equal("POST", observed.request_options.method)
+                        assert.is_equal(
+                            "/v1/redact?tenant=blueking", observed.request_options.path
+                        )
+                        assert.is_equal(
+                            "application/json",
+                            observed.request_options.headers["Content-Type"]
+                        )
+                        assert.is_equal(
+                            "secret-token",
+                            observed.request_options.headers["X-Redaction-Token"]
+                        )
+                        assert.is_equal(60000, observed.keepalive_timeout)
+                        assert.is_equal(30, observed.keepalive_pool)
+                    end
+                )
+
+                it(
+                    "closes non-keepalive connections and omits absent authentication", function()
+                        local ctx = request_context()
+                        local conf = config({keepalive = false})
+                        conf.auth_value = nil
+
+                        local code = plugin.access(conf, ctx)
+
+                        assert.is_nil(code)
+                        assert.is_equal(1, observed.request_count)
+                        assert.is_equal(0, observed.keepalive_count)
+                        assert.is_equal(1, observed.close_count)
+                        assert.is_false(observed.connect_options.pool_size)
+                        assert.is_nil(
+                            observed.request_options.headers["X-Redaction-Token"]
+                        )
+                    end
+                )
+            end
+        )
+
+        context(
+            "early request rejection", function()
+                for _, protocol in ipairs({"bedrock-converse", "passthrough"}) do
+                    it(
+                        "rejects streaming " .. protocol .. " before external calls",
+                        function()
+                            local ctx = request_context({
+                                ai_client_protocol = protocol,
+                                var = {request_type = "ai_stream"},
+                            })
+
+                            local code, err = plugin.access(config(), ctx)
+
+                            assert.is_equal(400, code)
+                            assert.is_equal(
+                                "streaming protocol " .. protocol ..
+                                " is not supported for response restoration",
+                                err
+                            )
+                            assert.is_equal(0, observed.new_count)
+                            assert.is_equal(0, observed.request_count)
+                            assert_no_request_mutation()
+                        end
+                    )
+                end
+
+                it(
+                    "allows supported SSE client protocol with a Bedrock provider", function()
+                        local ctx = request_context({
+                            picked_ai_instance = {provider = "bedrock"},
+                            ai_client_protocol = "openai-chat",
+                            var = {request_type = "ai_stream"},
+                        })
+                        request_body.stream = true
+
+                        local code = plugin.access(config(), ctx)
+
+                        assert.is_nil(code)
+                        assert.is_equal(1, observed.request_count)
+                    end
+                )
+
+                it(
+                    "requires an AI proxy selection before the service call", function()
+                        local ctx = request_context({picked_ai_instance = false})
+
+                        local code, err = plugin.access(config(), ctx)
+
+                        assert.is_equal(500, code)
+                        assert.is_equal(
+                            "bk-ai-sensitive-data-redaction must be used with " ..
+                            "ai-proxy or ai-proxy-multi",
+                            err
+                        )
+                        assert.is_equal(0, observed.request_count)
+                        assert_no_request_mutation()
+                    end
+                )
+
+                it(
+                    "maps an oversized request body to 413 before the service call", function()
+                        local ctx = request_context()
+                        behavior.body_error = {
+                            message = "request size 2048 is greater than the maximum size 1024",
+                        }
+
+                        local code, err = plugin.access(config(), ctx)
+
+                        assert.is_equal(413, code)
+                        assert.is_same(behavior.body_error, err)
+                        assert.is_equal(1048576, observed.body_limit)
+                        assert.is_equal(0, observed.request_count)
+                        assert_no_request_mutation()
+                    end
+                )
+
+                it(
+                    "rechecks the final cached JSON body against the configured limit", function()
+                        local ctx = request_context()
+                        request_body.messages[1].content = string.rep("x", 128)
+
+                        local code, err = plugin.access(
+                            config({max_request_body_bytes = 64}), ctx
+                        )
+
+                        assert.is_equal(413, code)
+                        assert.is_same({
+                            message = "request body is greater than the maximum size",
+                        }, err)
+                        assert.is_equal(64, observed.body_limit)
+                        assert.is_equal(0, observed.request_count)
+                        assert_no_request_mutation()
+                    end
+                )
+
+                it(
+                    "maps malformed JSON input to 400 before the service call", function()
+                        local ctx = request_context()
+                        behavior.body_error = {message = "failed to decode request body"}
+
+                        local code, err = plugin.access(config(), ctx)
+
+                        assert.is_equal(400, code)
+                        assert.is_same(behavior.body_error, err)
+                        assert.is_equal(0, observed.request_count)
+                        assert_no_request_mutation()
+                    end
+                )
+            end
+        )
+
+        context(
+            "third-party and contract failures", function()
+                local function assert_502_without_mutation(
+                    expected_message, expected_request_count
+                )
+                    local ctx = request_context()
+                    local original = assert(core.json.encode(request_body))
+
+                    local code, err = plugin.access(config(), ctx)
+
+                    assert.is_equal(502, code)
+                    assert.is_same({message = expected_message}, err)
+                    assert.is_equal(expected_request_count or 1, observed.request_count)
+                    assert.is_equal(original, assert(core.json.encode(request_body)))
+                    assert.is_nil(ctx._ai_redaction_mapping)
+                    assert_no_request_mutation()
+                end
+
+                it(
+                    "fails closed on a connection timeout", function()
+                        behavior.connect_ok = nil
+                        behavior.connect_error = "timeout"
+
+                        assert_502_without_mutation(
+                            "redaction service connect failed: timeout", 0
+                        )
+
+                        assert.is_equal(1, observed.connect_count)
+                        assert.is_equal(0, observed.request_count)
+                    end
+                )
+
+                it(
+                    "fails closed on a request error", function()
+                        behavior.request_error = "closed"
+
+                        assert_502_without_mutation(
+                            "redaction service request failed: closed"
+                        )
+
+                        assert.is_equal(1, observed.request_count)
+                        assert.is_equal(1, observed.close_count)
+                    end
+                )
+
+                it(
+                    "fails closed on a response read error", function()
+                        behavior.read_error = "timeout"
+
+                        assert_502_without_mutation(
+                            "redaction service read failed: timeout"
+                        )
+
+                        assert.is_equal(1, observed.request_count)
+                        assert.is_equal(1, observed.read_count)
+                        assert.is_equal(1, observed.close_count)
+                    end
+                )
+
+                it(
+                    "fails closed on a non-200 response after one call", function()
+                        behavior.response_status = 500
+
+                        assert_502_without_mutation(
+                            "redaction service returned status 500"
+                        )
+
+                        assert.is_equal(1, observed.request_count)
+                    end
+                )
+
+                it(
+                    "fails closed on malformed response JSON", function()
+                        behavior.response_builder = function()
+                            return "{"
+                        end
+
+                        assert_502_without_mutation(
+                            "redaction service returned invalid JSON"
+                        )
+
+                        assert.is_equal(1, observed.request_count)
+                    end
+                )
+
+                it(
+                    "rejects a masked body with another protocol", function()
+                        behavior.response_builder = function(payload)
+                            local value = success_value(payload)
+                            value.body.messages = nil
+                            value.body.input = "phone: " ..
+                                               payload.placeholder_namespace .. "1__"
+                            return assert(core.json.encode(value))
+                        end
+
+                        assert_502_without_mutation(
+                            "redaction service changed the AI protocol"
+                        )
+                    end
+                )
+
+                it(
+                    "rejects a changed model", function()
+                        behavior.response_builder = function(payload)
+                            local value = success_value(payload)
+                            value.body.model = "other-model"
+                            return assert(core.json.encode(value))
+                        end
+
+                        assert_502_without_mutation(
+                            "redaction service changed model"
+                        )
+                    end
+                )
+
+                it(
+                    "rejects a changed stream flag", function()
+                        behavior.response_builder = function(payload)
+                            local value = success_value(payload)
+                            value.body.stream = true
+                            return assert(core.json.encode(value))
+                        end
+
+                        assert_502_without_mutation(
+                            "redaction service changed stream"
+                        )
+                    end
+                )
+
+                it(
+                    "rejects placeholders from another request namespace", function()
+                        behavior.response_builder = function(payload)
+                            local value = success_value(payload)
+                            local foreign = "__BK_REDACT_" .. string.rep("0", 32) .. "_1__"
+                            value.body.messages[1].content = foreign
+                            value.replacements[1].placeholder = foreign
+                            return assert(core.json.encode(value))
+                        end
+
+                        assert_502_without_mutation(
+                            "placeholder is outside request namespace"
+                        )
+                    end
+                )
+
+                it(
+                    "rejects a declared placeholder absent from the masked body", function()
+                        behavior.response_builder = function(payload)
+                            local value = success_value(payload)
+                            value.body.messages[1].content = "no placeholder"
+                            return assert(core.json.encode(value))
+                        end
+
+                        assert_502_without_mutation(
+                            "placeholder is absent from masked body"
+                        )
+                    end
+                )
+
+                it(
+                    "rejects mappings above the entry limit", function()
+                        behavior.response_builder = function(payload)
+                            local value = success_value(payload)
+                            local second = payload.placeholder_namespace .. "2__"
+                            value.body.messages[1].content =
+                                value.body.messages[1].content .. " " .. second
+                            value.replacements[2] = {
+                                placeholder = second,
+                                original = "second-secret",
+                            }
+                            return assert(core.json.encode(value))
+                        end
+                        local ctx = request_context()
+
+                        local code, err = plugin.access(
+                            config({max_mapping_entries = 1}), ctx
+                        )
+
+                        assert.is_equal(502, code)
+                        assert.is_same({message = "mapping entry limit exceeded"}, err)
+                        assert.is_equal(1, observed.request_count)
+                        assert_no_request_mutation()
+                    end
+                )
+
+                it(
+                    "rejects mappings above the byte limit", function()
+                        local ctx = request_context()
+
+                        local code, err = plugin.access(
+                            config({max_mapping_bytes = 1}), ctx
+                        )
+
+                        assert.is_equal(502, code)
+                        assert.is_same({message = "mapping byte limit exceeded"}, err)
+                        assert.is_equal(1, observed.request_count)
+                        assert_no_request_mutation()
+                    end
+                )
+
+                it(
+                    "rejects an object masquerading as an empty replacements array", function()
+                        behavior.response_builder = function(payload)
+                            local value = success_value(payload)
+                            return "{\"body\":" .. assert(core.json.encode(value.body)) ..
+                                   ",\"replacements\":{}}"
+                        end
+
+                        assert_502_without_mutation(
+                            "replacements must be a JSON array"
+                        )
+                    end
+                )
+            end
+        )
+
+        context(
+            "successful mutation", function()
+                it(
+                    "installs only the validated masked body and request-local mapping", function()
+                        local request_id = "da584df5-7bd5-4590-98e0-8f92a89f9494"
+                        local ctx = request_context({
+                            var = {apisix_request_id = request_id},
+                        })
+                        local namespace =
+                            "__BK_REDACT_da584df57bd5459098e08f92a89f9494_"
+                        local token = namespace .. "1__"
+
+                        local code, err = plugin.access(config(), ctx)
+
+                        assert.is_nil(code)
+                        assert.is_nil(err)
+                        assert.is_equal(1, observed.request_count)
+                        local masked = assert(core.json.decode(installed_body))
+                        assert.is_equal("phone: " .. token, masked.messages[1].content)
+                        assert.is_equal(
+                            "phone: " .. token, request_body.messages[1].content
+                        )
+                        assert.is_equal("gpt-4o", masked.model)
+                        assert.is_false(masked.stream)
+                        assert.is_equal(request_id, ctx._ai_redaction_request_id)
+                        assert.is_equal(namespace, ctx._ai_redaction_namespace)
+                        assert.is_same({[token] = "13800138000"}, ctx._ai_redaction_mapping)
+                        assert.is_true(ctx.ai_request_body_changed)
+                        assert.is_nil(ctx._ai_redaction_sse_restorer)
+                    end
+                )
+            end
+        )
+    end
+)

--- a/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
@@ -1581,6 +1581,341 @@ describe(
         )
 
         context(
+            "stream adapter safety", function()
+                local namespace = "__BK_REDACT_da584df57bd5459098e08f92a89f9494_"
+                local token = namespace .. "1__"
+
+                local function frame(event_type, value)
+                    local event = ""
+                    if event_type then
+                        event = "event: " .. event_type .. "\n"
+                    end
+                    return event .. "data: " .. assert(core.json.encode(value)) .. "\n\n"
+                end
+
+                local function response_frame(event_type, overrides)
+                    local value = {
+                        type = event_type,
+                        item_id = "msg_1",
+                        output_index = 0,
+                    }
+                    for key, item in pairs(overrides or {}) do
+                        value[key] = item
+                    end
+                    return frame(event_type, value)
+                end
+
+                local function decoded_events(output)
+                    local events = require("apisix.plugins.ai-transport.sse").decode(output)
+                    for _, event in ipairs(events) do
+                        event.value = assert(core.json.decode(event.data))
+                    end
+                    return events
+                end
+
+                it(
+                    "does not retain complete logical fields", function()
+                        local processor = assert(sse_restorer.new(
+                            "openai-chat", {[token] = "secret"}, namespace
+                        ))
+
+                        for index = 1, 10000 do
+                            local output = processor:feed(frame(nil, {
+                                choices = {{
+                                    index = index,
+                                    delta = {content = "ordinary text"},
+                                }},
+                            }), false)
+                            assert.is_string(output)
+                        end
+
+                        assert.is_nil(next(processor.stream.states))
+                        assert.is_nil(next(processor.keys))
+                        assert.is_same({}, processor.key_order)
+                    end
+                )
+
+                it(
+                    "rejects more than 1024 active logical fields", function()
+                        local processor = assert(sse_restorer.new(
+                            "openai-chat", {[token] = "secret"}, namespace
+                        ))
+                        local prefix = token:sub(1, -2)
+
+                        for index = 1, 1024 do
+                            local output = processor:feed(frame(nil, {
+                                choices = {{
+                                    index = index,
+                                    delta = {content = prefix},
+                                }},
+                            }), false)
+                            assert.is_string(output)
+                        end
+
+                        local ok = pcall(processor.feed, processor, frame(nil, {
+                            choices = {{
+                                index = 1025,
+                                delta = {content = prefix},
+                            }},
+                        }), false)
+
+                        assert.is_false(ok)
+                    end
+                )
+
+                it(
+                    "rejects more than 64 KiB of aggregate pending bytes", function()
+                        local huge_token = namespace .. string.rep("1", 65536) .. "__"
+                        local stream = restorer.new_stream(
+                            {[huge_token] = "secret"}, namespace
+                        )
+
+                        local output, _, err = stream:feed(
+                            "field", huge_token:sub(1, -2), "text", false
+                        )
+
+                        assert.is_nil(output)
+                        assert.is_equal("stream pending byte limit exceeded", err)
+                        assert.is_nil(next(stream.states))
+                    end
+                )
+
+                it(
+                    "keeps interleaved response content parts independent", function()
+                        local token2 = namespace .. "2__"
+                        local processor = assert(sse_restorer.new(
+                            "openai-responses",
+                            {[token] = "first", [token2] = "second"},
+                            namespace
+                        ))
+                        local split1 = math.floor(#token / 2)
+                        local split2 = math.floor(#token2 / 2)
+                        local output = {}
+                        local inputs = {
+                            response_frame("response.output_text.delta", {
+                                content_index = 0,
+                                delta = token:sub(1, split1),
+                            }),
+                            response_frame("response.output_text.delta", {
+                                content_index = 1,
+                                delta = token2:sub(1, split2),
+                            }),
+                            response_frame("response.output_text.delta", {
+                                content_index = 0,
+                                delta = token:sub(split1 + 1),
+                            }),
+                            response_frame("response.output_text.delta", {
+                                content_index = 1,
+                                delta = token2:sub(split2 + 1),
+                            }),
+                        }
+                        for _, input in ipairs(inputs) do
+                            output[#output + 1] = processor:feed(input, false)
+                        end
+
+                        local text = {[0] = "", [1] = ""}
+                        for _, event in ipairs(decoded_events(table.concat(output))) do
+                            local value = event.value
+                            text[value.content_index] = text[value.content_index] .. value.delta
+                        end
+
+                        assert.is_equal("first", text[0])
+                        assert.is_equal("second", text[1])
+                        assert.is_nil(next(processor.stream.states))
+                        assert.is_nil(next(processor.keys))
+                        assert.is_same({}, processor.key_order)
+                    end
+                )
+
+                it(
+                    "flushes only the matching response content part before done",
+                    function()
+                        local processor = assert(sse_restorer.new(
+                            "openai-responses", {[token] = "secret"}, namespace
+                        ))
+                        local prefix = token:sub(1, -2)
+                        assert.is_string(processor:feed(response_frame(
+                            "response.output_text.delta",
+                            {content_index = 0, delta = prefix}
+                        ), false))
+                        assert.is_string(processor:feed(response_frame(
+                            "response.output_text.delta",
+                            {content_index = 1, delta = prefix}
+                        ), false))
+
+                        local output = processor:feed(response_frame(
+                            "response.output_text.done",
+                            {content_index = 0, text = token}
+                        ), false)
+                        local events = decoded_events(output)
+
+                        assert.is_equal(2, #events)
+                        assert.is_equal("response.output_text.delta", events[1].value.type)
+                        assert.is_equal(0, events[1].value.content_index)
+                        assert.is_equal(prefix, events[1].value.delta)
+                        assert.is_equal("response.output_text.done", events[2].value.type)
+                        assert.is_equal(0, events[2].value.content_index)
+                        assert.is_equal("secret", events[2].value.text)
+                        assert.is_not_nil(next(processor.stream.states))
+
+                        local remaining = decoded_events(processor:feed(
+                            response_frame("response.output_text.done", {
+                                content_index = 1,
+                                text = token,
+                            }),
+                            false
+                        ))
+                        assert.is_equal(2, #remaining)
+                        assert.is_equal(1, remaining[1].value.content_index)
+                        assert.is_equal(prefix, remaining[1].value.delta)
+                        assert.is_equal("secret", remaining[2].value.text)
+                        assert.is_nil(next(processor.stream.states))
+                    end
+                )
+
+                it(
+                    "keeps reasoning summary parts independent through done events",
+                    function()
+                        local token2 = namespace .. "2__"
+                        local processor = assert(sse_restorer.new(
+                            "openai-responses",
+                            {[token] = "first", [token2] = "second"},
+                            namespace
+                        ))
+                        local split1 = math.floor(#token / 2)
+                        local split2 = math.floor(#token2 / 2)
+                        local output = {}
+                        local inputs = {
+                            response_frame("response.reasoning_summary_text.delta", {
+                                summary_index = 0,
+                                delta = token:sub(1, split1),
+                            }),
+                            response_frame("response.reasoning_summary_text.delta", {
+                                summary_index = 1,
+                                delta = token2:sub(1, split2),
+                            }),
+                            response_frame("response.reasoning_summary_text.delta", {
+                                summary_index = 0,
+                                delta = token:sub(split1 + 1),
+                            }),
+                            response_frame("response.reasoning_summary_text.done", {
+                                summary_index = 0,
+                                text = token,
+                            }),
+                            response_frame("response.reasoning_summary_text.delta", {
+                                summary_index = 1,
+                                delta = token2:sub(split2 + 1),
+                            }),
+                            response_frame("response.reasoning_summary_text.done", {
+                                summary_index = 1,
+                                text = token2,
+                            }),
+                        }
+                        for _, input in ipairs(inputs) do
+                            output[#output + 1] = processor:feed(input, false)
+                        end
+
+                        local delta_text = {[0] = "", [1] = ""}
+                        local done_text = {}
+                        for _, event in ipairs(decoded_events(table.concat(output))) do
+                            local value = event.value
+                            if value.type == "response.reasoning_summary_text.delta" then
+                                delta_text[value.summary_index] =
+                                    delta_text[value.summary_index] .. value.delta
+                            elseif value.type == "response.reasoning_summary_text.done" then
+                                done_text[value.summary_index] = value.text
+                            end
+                        end
+
+                        assert.is_equal("first", delta_text[0])
+                        assert.is_equal("second", delta_text[1])
+                        assert.is_equal("first", done_text[0])
+                        assert.is_equal("second", done_text[1])
+                    end
+                )
+
+                it(
+                    "flushes function arguments before their done event", function()
+                        local processor = assert(sse_restorer.new(
+                            "openai-responses", {[token] = "secret"}, namespace
+                        ))
+                        local prefix = token:sub(1, -2)
+                        assert.is_string(processor:feed(response_frame(
+                            "response.function_call_arguments.delta",
+                            {item_id = "call_1", delta = prefix}
+                        ), false))
+
+                        local events = decoded_events(processor:feed(response_frame(
+                            "response.function_call_arguments.done",
+                            {item_id = "call_1", arguments = token}
+                        ), false))
+
+                        assert.is_equal(2, #events)
+                        assert.is_equal(
+                            "response.function_call_arguments.delta",
+                            events[1].value.type
+                        )
+                        assert.is_equal(prefix, events[1].value.delta)
+                        assert.is_equal(
+                            "response.function_call_arguments.done",
+                            events[2].value.type
+                        )
+                        assert.is_equal("secret", events[2].value.arguments)
+                    end
+                )
+
+                it(
+                    "preserves response frames with non-numeric part indices", function()
+                        local processor = assert(sse_restorer.new(
+                            "openai-responses", {[token] = "secret"}, namespace
+                        ))
+                        local invalid = response_frame(
+                            "response.output_text.delta",
+                            {content_index = "0", delta = token}
+                        )
+
+                        local output = processor:feed(invalid, false)
+
+                        assert.is_equal(invalid, output)
+                        assert.is_nil(output:find("secret", 1, true))
+                    end
+                )
+
+                it(
+                    "restores all supported OpenAI Chat delta fields", function()
+                        local processor = assert(sse_restorer.new(
+                            "openai-chat", {[token] = "secret"}, namespace
+                        ))
+                        local input = frame(nil, {
+                            choices = {{
+                                index = 0,
+                                delta = {
+                                    reasoning_content = token,
+                                    refusal = token,
+                                    function_call = {arguments = token},
+                                    tool_calls = {{
+                                        index = 0,
+                                        ["function"] = {arguments = token},
+                                    }},
+                                },
+                            }},
+                        })
+
+                        local events = decoded_events(processor:feed(input, false))
+                        local delta = events[1].value.choices[1].delta
+
+                        assert.is_equal("secret", delta.reasoning_content)
+                        assert.is_equal("secret", delta.refusal)
+                        assert.is_equal("secret", delta.function_call.arguments)
+                        assert.is_equal(
+                            "secret", delta.tool_calls[1]["function"].arguments
+                        )
+                    end
+                )
+            end
+        )
+
+        context(
             "stream response restoration", function()
                 it(
                     "restores split SSE placeholders and clears state only at EOF",
@@ -1770,6 +2105,64 @@ describe(
                             ", request_id: ",
                             request_id
                         )
+                    end
+                )
+
+                it(
+                    "preserves masked prefixes exactly once when active state overflows",
+                    function()
+                        local request_id = "e7c1ca39-a99e-4934-af01-babb28956d47"
+                        local namespace =
+                            "__BK_REDACT_e7c1ca39a99e4934af01babb28956d47_"
+                        local token = namespace .. "1__"
+                        local prefix = token:sub(1, -2)
+                        local ctx = request_context({
+                            var = {request_type = "ai_stream"},
+                            _ai_redaction_request_id = request_id,
+                            _ai_redaction_namespace = namespace,
+                            _ai_redaction_mapping = {[token] = "sensitive-original"},
+                        })
+                        local function chat_frame(index)
+                            return "data: " .. assert(core.json.encode({
+                                choices = {{
+                                    index = index,
+                                    delta = {content = prefix},
+                                }},
+                            })) .. "\n\n"
+                        end
+
+                        local first = chat_frame(0)
+                        local code1, output1 = plugin.lua_body_filter(
+                            config(), ctx, {}, first, false
+                        )
+                        local overflow = {}
+                        for index = 1, 1024 do
+                            overflow[index] = chat_frame(index)
+                        end
+                        local raw_overflow = table.concat(overflow)
+                        local code2, output2 = plugin.lua_body_filter(
+                            config(), ctx, {}, raw_overflow, false
+                        )
+
+                        local combined = output1 .. output2
+                        local occurrences = 0
+                        local position = 1
+                        while true do
+                            local found = combined:find(prefix, position, true)
+                            if not found then
+                                break
+                            end
+                            occurrences = occurrences + 1
+                            position = found + #prefix
+                        end
+                        assert.is_nil(code1)
+                        assert.is_nil(code2)
+                        assert.is_equal(1025, occurrences)
+                        assert.is_nil(combined:find("sensitive-original", 1, true))
+                        assert.is_true(ctx._ai_redaction_stream_passthrough)
+                        assert.is_nil(ctx._ai_redaction_mapping)
+                        assert.is_nil(ctx._ai_redaction_sse_restorer)
+                        assert.stub(core.log.error).was_called(1)
                     end
                 )
             end

--- a/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
@@ -1043,5 +1043,123 @@ describe(
                 )
             end
         )
+
+        context(
+            "non-stream response restoration", function()
+                before_each(
+                    function()
+                        stub(core.log, "error")
+                    end
+                )
+
+                after_each(
+                    function()
+                        core.log.error:revert()
+                    end
+                )
+
+                it(
+                    "restores nested JSON strings and clears request-sensitive state",
+                    function()
+                        local request_id = "da584df5-7bd5-4590-98e0-8f92a89f9494"
+                        local namespace =
+                            "__BK_REDACT_da584df57bd5459098e08f92a89f9494_"
+                        local known = namespace .. "1__"
+                        local unknown = namespace .. "9__"
+                        local original = "line one\n\"line two\""
+                        local ctx = request_context({
+                            var = {request_type = "ai_chat"},
+                            _ai_redaction_request_id = request_id,
+                            _ai_redaction_session_id =
+                                "24395b38-bf3f-426c-a632-10df20ec69c8",
+                            _ai_redaction_namespace = namespace,
+                            _ai_redaction_mapping = {[known] = original},
+                            _ai_redaction_sse_restorer = {},
+                        })
+                        local response = {
+                            choices = {
+                                {
+                                    message = {
+                                        content = "echo: " .. known .. ":" .. unknown,
+                                        tool_calls = {
+                                            {
+                                                id = "call_1",
+                                                type = "function",
+                                                ["function"] = {
+                                                    name = "save_contact",
+                                                    arguments = core.json.encode({phone = known}),
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        }
+
+                        local code, restored_body = plugin.lua_body_filter(
+                            config(), ctx, {}, assert(core.json.encode(response)), true
+                        )
+
+                        assert.is_nil(code)
+                        local restored = assert(core.json.decode(restored_body))
+                        assert.is_equal(
+                            "echo: " .. original .. ":" .. unknown,
+                            restored.choices[1].message.content
+                        )
+                        local arguments = assert(core.json.decode(
+                            restored.choices[1].message.tool_calls[1]["function"].arguments
+                        ))
+                        assert.is_equal(original, arguments.phone)
+                        assert.is_equal(2, ctx._ai_redaction_restored_count)
+                        assert.is_equal(request_id, ctx._ai_redaction_request_id)
+                        assert.is_nil(ctx._ai_redaction_session_id)
+                        assert.is_nil(ctx._ai_redaction_namespace)
+                        assert.is_nil(ctx._ai_redaction_mapping)
+                        assert.is_nil(ctx._ai_redaction_sse_restorer)
+                    end
+                )
+
+                it(
+                    "passes malformed upstream JSON through masked and clears state",
+                    function()
+                        local request_id = "da584df5-7bd5-4590-98e0-8f92a89f9494"
+                        local namespace =
+                            "__BK_REDACT_da584df57bd5459098e08f92a89f9494_"
+                        local known = namespace .. "1__"
+                        local masked_body = "{\"content\":\"" .. known .. "\""
+                        local _, decode_err = core.json.decode(masked_body)
+                        local ctx = request_context({
+                            var = {request_type = "ai_chat"},
+                            _ai_redaction_request_id = request_id,
+                            _ai_redaction_session_id =
+                                "24395b38-bf3f-426c-a632-10df20ec69c8",
+                            _ai_redaction_namespace = namespace,
+                            _ai_redaction_mapping = {[known] = "13800138000"},
+                            _ai_redaction_sse_restorer = {},
+                            _ai_redaction_restored_count = 7,
+                        })
+
+                        local code, restored_body = plugin.lua_body_filter(
+                            config(), ctx, {}, masked_body, true
+                        )
+
+                        assert.is_nil(code)
+                        assert.is_nil(restored_body)
+                        assert.stub(core.log.error).was_called_with(
+                            "failed to decode masked AI response: ",
+                            decode_err,
+                            ", request_id: ",
+                            request_id
+                        )
+                        assert.is_equal(request_id, ctx._ai_redaction_request_id)
+                        assert.is_equal(7, ctx._ai_redaction_restored_count)
+                        assert.is_nil(ctx._ai_redaction_session_id)
+                        assert.is_nil(ctx._ai_redaction_namespace)
+                        assert.is_nil(ctx._ai_redaction_mapping)
+                        assert.is_nil(ctx._ai_redaction_sse_restorer)
+                    end
+                )
+            end
+        )
     end
 )

--- a/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
@@ -19,6 +19,7 @@
 local core = require("apisix.core")
 local http = require("resty.http")
 local plugin = require("apisix.plugins.bk-ai-sensitive-data-redaction")
+local sse_restorer = require("apisix.plugins.bk-ai-sensitive-data-redaction.sse")
 
 
 describe(
@@ -1111,6 +1112,129 @@ describe(
                         assert.is_nil(ctx._ai_redaction_sse_restorer)
                         assert.is_equal(1, ctx._ai_redaction_restored_count)
                         assert.is_equal(0, ctx._ai_redaction_unresolved_count)
+                    end
+                )
+            end
+        )
+
+        context(
+            "stream failure fallback", function()
+                before_each(
+                    function()
+                        stub(core.log, "error")
+                    end
+                )
+
+                after_each(
+                    function()
+                        core.log.error:revert()
+                    end
+                )
+
+                it(
+                    "latches masked passthrough when processor construction fails",
+                    function()
+                        local request_id = "cfb5b639-d51b-42d6-b62c-f1083007376a"
+                        local namespace =
+                            "__BK_REDACT_cfb5b639d51b42d6b62cf1083007376a_"
+                        local token = namespace .. "1__"
+                        local frame = "data: {\"masked\":\"" .. token .. "\"}\n\n"
+                        local ctx = request_context({
+                            var = {request_type = "ai_stream"},
+                            _ai_redaction_request_id = request_id,
+                            _ai_redaction_session_id =
+                                "24395b38-bf3f-426c-a632-10df20ec69c8",
+                            _ai_redaction_namespace = namespace,
+                            _ai_redaction_mapping = nil,
+                        })
+
+                        local code1, output1 = plugin.lua_body_filter(
+                            config(), ctx, {}, frame, false
+                        )
+                        local code2, output2 = plugin.lua_body_filter(
+                            config(), ctx, {}, frame, true
+                        )
+
+                        assert.is_nil(code1)
+                        assert.is_nil(code2)
+                        assert.is_equal(frame, output1)
+                        assert.is_equal(frame, output2)
+                        assert.is_falsy(output1:find("13800138000", 1, true))
+                        assert.is_true(ctx._ai_redaction_stream_passthrough)
+                        assert.is_equal(0, ctx._ai_redaction_restored_count)
+                        assert.is_equal(0, ctx._ai_redaction_unresolved_count)
+                        assert.is_nil(ctx._ai_redaction_session_id)
+                        assert.is_nil(ctx._ai_redaction_namespace)
+                        assert.is_nil(ctx._ai_redaction_mapping)
+                        assert.is_nil(ctx._ai_redaction_sse_restorer)
+                        assert.stub(core.log.error).was_called(1)
+                        assert.stub(core.log.error).was_called_with(
+                            "failed to create SSE restorer",
+                            ", request_id: ",
+                            request_id
+                        )
+                    end
+                )
+
+                it(
+                    "preserves buffered masked bytes and latches after feed failure",
+                    function()
+                        local request_id = "157240cf-4f4b-412d-8240-9f904123aa0d"
+                        local namespace =
+                            "__BK_REDACT_157240cf4f4b412d82409f904123aa0d_"
+                        local token = namespace .. "1__"
+                        local processor = assert(sse_restorer.new(
+                            "openai-chat", {[token] = "13800138000"}, namespace
+                        ))
+                        local buffered = "data: {\"choices\":["
+                        assert.is_equal("", processor:feed(buffered, false))
+                        local feed_count = 0
+                        processor.feed = function()
+                            feed_count = feed_count + 1
+                            error("unexpected feed failure with sensitive values")
+                        end
+                        local ctx = request_context({
+                            var = {request_type = "ai_stream"},
+                            _ai_redaction_request_id = request_id,
+                            _ai_redaction_session_id =
+                                "24395b38-bf3f-426c-a632-10df20ec69c8",
+                            _ai_redaction_namespace = namespace,
+                            _ai_redaction_mapping = {[token] = "13800138000"},
+                            _ai_redaction_sse_restorer = processor,
+                            _ai_redaction_restored_count = 3,
+                            _ai_redaction_unresolved_count = 4,
+                        })
+                        local remainder = "1]}\n\n"
+                        local valid = "data: {\"choices\":[{\"delta\":{\"content\":\"" ..
+                                      token .. "\"}}]}\n\n"
+
+                        local code1, output1 = plugin.lua_body_filter(
+                            config(), ctx, {}, remainder, false
+                        )
+                        local code2, output2 = plugin.lua_body_filter(
+                            config(), ctx, {}, valid, true
+                        )
+
+                        assert.is_nil(code1)
+                        assert.is_nil(code2)
+                        assert.is_equal(buffered .. remainder, output1)
+                        assert.is_equal(valid, output2)
+                        assert.is_falsy(output1:find("13800138000", 1, true))
+                        assert.is_falsy(output2:find("13800138000", 1, true))
+                        assert.is_equal(1, feed_count)
+                        assert.is_true(ctx._ai_redaction_stream_passthrough)
+                        assert.is_equal(3, ctx._ai_redaction_restored_count)
+                        assert.is_equal(4, ctx._ai_redaction_unresolved_count)
+                        assert.is_nil(ctx._ai_redaction_session_id)
+                        assert.is_nil(ctx._ai_redaction_namespace)
+                        assert.is_nil(ctx._ai_redaction_mapping)
+                        assert.is_nil(ctx._ai_redaction_sse_restorer)
+                        assert.stub(core.log.error).was_called(1)
+                        assert.stub(core.log.error).was_called_with(
+                            "failed to restore masked SSE response",
+                            ", request_id: ",
+                            request_id
+                        )
                     end
                 )
             end

--- a/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
@@ -1316,43 +1316,83 @@ describe(
                 )
 
                 it(
-                    "passes malformed upstream JSON through masked and clears state",
+                    "preserves response numeric lexemes while restoring string values",
                     function()
                         local request_id = "da584df5-7bd5-4590-98e0-8f92a89f9494"
                         local namespace =
                             "__BK_REDACT_da584df57bd5459098e08f92a89f9494_"
                         local known = namespace .. "1__"
-                        local masked_body = "{\"content\":\"" .. known .. "\""
-                        local _, decode_err = core.json.decode(masked_body)
                         local ctx = request_context({
                             var = {request_type = "ai_chat"},
                             _ai_redaction_request_id = request_id,
-                            _ai_redaction_session_id =
-                                "24395b38-bf3f-426c-a632-10df20ec69c8",
                             _ai_redaction_namespace = namespace,
                             _ai_redaction_mapping = {[known] = "13800138000"},
-                            _ai_redaction_sse_restorer = {},
-                            _ai_redaction_restored_count = 7,
                         })
+                        local masked_body =
+                            '{ "large":9007199254740993, "negative_zero":-0, ' ..
+                            '"exponent":1.2300e+40, "content":"' .. known .. '" }'
+                        local expected =
+                            '{ "large":9007199254740993, "negative_zero":-0, ' ..
+                            '"exponent":1.2300e+40, "content":"13800138000" }'
 
                         local code, restored_body = plugin.lua_body_filter(
                             config(), ctx, {}, masked_body, true
                         )
 
                         assert.is_nil(code)
-                        assert.is_nil(restored_body)
+                        assert.is_equal(expected, restored_body)
+                        assert.is_equal(1, ctx._ai_redaction_restored_count)
+                        assert.is_nil(ctx._ai_redaction_namespace)
+                        assert.is_nil(ctx._ai_redaction_mapping)
+                    end
+                )
+
+                it(
+                    "passes invalid upstream JSON through masked and clears state",
+                    function()
+                        local request_id = "da584df5-7bd5-4590-98e0-8f92a89f9494"
+                        local namespace =
+                            "__BK_REDACT_da584df57bd5459098e08f92a89f9494_"
+                        local known = namespace .. "1__"
+                        local cases = {
+                            '{"content":"' .. known .. '"',
+                            '{"content":"' .. known .. '"} trailing',
+                            string.rep("[", 129) .. '"' .. known .. '"' ..
+                                string.rep("]", 129),
+                        }
+
+                        for _, masked_body in ipairs(cases) do
+                            local ctx = request_context({
+                                var = {request_type = "ai_chat"},
+                                _ai_redaction_request_id = request_id,
+                                _ai_redaction_session_id =
+                                    "24395b38-bf3f-426c-a632-10df20ec69c8",
+                                _ai_redaction_namespace = namespace,
+                                _ai_redaction_mapping = {[known] = "13800138000"},
+                                _ai_redaction_sse_restorer = {},
+                                _ai_redaction_restored_count = 7,
+                            })
+
+                            local code, restored_body = plugin.lua_body_filter(
+                                config(), ctx, {}, masked_body, true
+                            )
+
+                            assert.is_nil(code)
+                            assert.is_nil(restored_body)
+                            assert.is_equal(request_id, ctx._ai_redaction_request_id)
+                            assert.is_equal(7, ctx._ai_redaction_restored_count)
+                            assert.is_nil(ctx._ai_redaction_session_id)
+                            assert.is_nil(ctx._ai_redaction_namespace)
+                            assert.is_nil(ctx._ai_redaction_mapping)
+                            assert.is_nil(ctx._ai_redaction_sse_restorer)
+                        end
+
+                        assert.stub(core.log.error).was_called(3)
                         assert.stub(core.log.error).was_called_with(
-                            "failed to decode masked AI response: ",
-                            decode_err,
+                            "failed to restore masked AI response",
                             ", request_id: ",
                             request_id
                         )
-                        assert.is_equal(request_id, ctx._ai_redaction_request_id)
-                        assert.is_equal(7, ctx._ai_redaction_restored_count)
-                        assert.is_nil(ctx._ai_redaction_session_id)
-                        assert.is_nil(ctx._ai_redaction_namespace)
-                        assert.is_nil(ctx._ai_redaction_mapping)
-                        assert.is_nil(ctx._ai_redaction_sse_restorer)
                     end
                 )
             end

--- a/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
@@ -19,6 +19,8 @@
 local core = require("apisix.core")
 local http = require("resty.http")
 local plugin = require("apisix.plugins.bk-ai-sensitive-data-redaction")
+local proxy_base = require("apisix.plugins.ai-proxy.base")
+local restorer = require("apisix.plugins.bk-ai-sensitive-data-redaction.restorer")
 local sse_restorer = require("apisix.plugins.bk-ai-sensitive-data-redaction.sse")
 
 
@@ -73,11 +75,9 @@ describe(
         end
 
         local function success_value(payload)
-            local masked_body = assert(core.json.decode(payload.body))
             local token = payload.placeholder_namespace .. "1__"
-            masked_body.messages[1].content = "phone: " .. token
             return {
-                body = assert(core.json.encode(masked_body)),
+                body = payload.body:gsub("13800138000", token, 1),
                 replacements = {
                     {
                         placeholder = token,
@@ -387,20 +387,23 @@ describe(
                             "__BK_REDACT_da584df57bd5459098e08f92a89f9494_"
                         local token = namespace .. "1__"
                         behavior.response_builder = function()
-                            return '{"body":"{\\"model\\":\\"gpt-4o\\",' ..
-                                   '\\"stream\\":false,\\"messages\\":[{' ..
-                                   '\\"role\\":\\"user\\",\\"content\\":' ..
-                                   '\\"\\u005f' .. token:sub(2) .. '\\"}]}",' ..
-                                   '"replacements":[{"placeholder":' ..
-                                   assert(core.json.encode(token)) .. ',' ..
-                                   '"original":"secret"}]}'
+                            local masked = raw_request_body:gsub(
+                                "13800138000", token, 1
+                            ):gsub(token, "\\u005f" .. token:sub(2), 1)
+                            return assert(core.json.encode({
+                                body = masked,
+                                replacements = {{
+                                    placeholder = token,
+                                    original = "13800138000",
+                                }},
+                            }))
                         end
 
                         local masked, err = register_filter(ctx)(raw_request_body)
 
                         assert.is_nil(err)
                         assert.is_string(masked)
-                        assert.is_equal("secret", ctx._ai_redaction_mapping[token])
+                        assert.is_equal("13800138000", ctx._ai_redaction_mapping[token])
                     end
                 )
 
@@ -424,8 +427,7 @@ describe(
                                 body = payload.body:gsub("13800138000", token, 1),
                                 replacements = {{
                                     placeholder = token,
-                                    original = observed.request_count == 1 and
-                                               "first-secret" or "second-secret",
+                                    original = "13800138000",
                                 }},
                             }))
                         end
@@ -436,7 +438,7 @@ describe(
                         assert.is_string(filter(raw_request_body))
 
                         assert.is_nil(ctx._ai_redaction_mapping[first])
-                        assert.is_equal("second-secret", ctx._ai_redaction_mapping[second])
+                        assert.is_equal("13800138000", ctx._ai_redaction_mapping[second])
                         assert.is_nil(ctx._ai_redaction_sse_restorer)
                         assert.is_nil(ctx._ai_redaction_stream_passthrough)
 
@@ -450,6 +452,37 @@ describe(
                         }, err)
                         assert.is_equal(502, status)
                         assert.is_nil(ctx._ai_redaction_mapping)
+                    end
+                )
+
+                it(
+                    "clears the original logging body and attempt state at callback entry",
+                    function()
+                        local ctx = request_context({
+                            var = {
+                                llm_request_body = {
+                                    messages = {{
+                                        role = "user",
+                                        content = "client-log-secret",
+                                    }},
+                                },
+                            },
+                            _ai_redaction_mapping = {stale = "override-log-secret"},
+                            _ai_redaction_sse_restorer = {stale = true},
+                            _ai_redaction_stream_passthrough = true,
+                        })
+
+                        local masked, err, status = register_filter(ctx)({})
+
+                        assert.is_nil(masked)
+                        assert.is_same({
+                            message = "final AI request body must be a JSON object string",
+                        }, err)
+                        assert.is_equal(400, status)
+                        assert.is_same({}, ctx.var.llm_request_body)
+                        assert.is_nil(ctx._ai_redaction_mapping)
+                        assert.is_nil(ctx._ai_redaction_sse_restorer)
+                        assert.is_nil(ctx._ai_redaction_stream_passthrough)
                     end
                 )
 
@@ -539,6 +572,37 @@ describe(
                         }, err)
                         assert.is_equal(502, status)
                         assert.is_equal(0, observed.body_reader_count)
+                    end
+                )
+
+                it(
+                    "rejects an oversized masked body before mapping or integrity work",
+                    function()
+                        local ctx = request_context({
+                            ai_target_protocol = "openai-chat",
+                        })
+                        behavior.response_builder = function(payload)
+                            local value = success_value(payload)
+                            local body = assert(core.json.decode(value.body))
+                            body.padding = string.rep("x", 256)
+                            value.body = assert(core.json.encode(body))
+                            return assert(core.json.encode(value))
+                        end
+                        local mapping_validation_called = false
+                        stub(restorer, "validate_mapping", function()
+                            mapping_validation_called = true
+                            return {}
+                        end)
+
+                        local masked, err, status = register_filter(ctx, config({
+                            max_request_body_bytes = 200,
+                        }))(raw_request_body)
+                        restorer.validate_mapping:revert()
+
+                        assert.is_nil(masked)
+                        assert.is_same({message = "masked body size limit exceeded"}, err)
+                        assert.is_equal(502, status)
+                        assert.is_false(mapping_validation_called)
                     end
                 )
             end
@@ -1375,9 +1439,9 @@ describe(
 
                         local masked_body, err, code = run_filter(ctx)
 
-                        assert.is_string(masked_body)
                         assert.is_nil(err)
                         assert.is_nil(code)
+                        assert.is_string(masked_body)
                         assert.is_equal(1, observed.request_count)
                         local masked = assert(core.json.decode(masked_body))
                         assert.is_equal("phone: " .. token, masked.messages[1].content)
@@ -1389,11 +1453,130 @@ describe(
                         assert.is_equal(request_id, ctx._ai_redaction_request_id)
                         assert.is_equal(namespace, ctx._ai_redaction_namespace)
                         assert.is_same({[token] = "13800138000"}, ctx._ai_redaction_mapping)
+                        assert.is_same(masked, ctx.var.llm_request_body)
+                        proxy_base.set_logging(ctx, false, true)
+                        local payload_log = assert(core.json.encode(ctx.llm_request))
+                        assert.is_nil(payload_log:find("13800138000", 1, true))
+                        assert.is_truthy(payload_log:find(token, 1, true))
                         assert.is_nil(ctx.ai_request_body_changed)
                         assert.is_nil(ctx._ai_redaction_sse_restorer)
                         assert_no_request_mutation()
                     end
                 )
+            end
+        )
+
+        context(
+            "request redaction integrity", function()
+                local namespace = "__BK_REDACT_da584df57bd5459098e08f92a89f9494_"
+                local token = namespace .. "1__"
+
+                local function verify(original, masked, mapping)
+                    assert.is_function(restorer.verify_redaction)
+                    return restorer.verify_redaction(
+                        original, masked, mapping or {}, namespace
+                    )
+                end
+
+                it(
+                    "accepts semantic string escapes and insignificant JSON whitespace",
+                    function()
+                        local original =
+                            '{"messages":[{"role":"user","content":' ..
+                            '"line\\nsecret"}],"tool":{"name":"lookup"},' ..
+                            '"number":1.2300e+40}'
+                        local masked =
+                            '{ "messages" : [ { "role" : "u\\u0073er", ' ..
+                            '"content" : "line\\u000a' .. token .. '" } ], ' ..
+                            '"tool" : { "name" : "lookup" }, ' ..
+                            '"number" : 1.2300e+40 }'
+
+                        local ok, err = verify(original, masked, {
+                            [token] = "secret",
+                        })
+
+                        assert.is_true(ok)
+                        assert.is_nil(err)
+                    end
+                )
+
+                it(
+                    "allows an empty mapping when only whitespace and escapes differ",
+                    function()
+                        local ok, err = verify(
+                            '{"message":"slash /","values":[true,null,-0]}',
+                            '{ "message" : "slash \\/", "values" : [ true, null, -0 ] }'
+                        )
+
+                        assert.is_true(ok)
+                        assert.is_nil(err)
+                    end
+                )
+
+                for _, case in ipairs({
+                    {
+                        name = "prompt content changes",
+                        original = '{"prompt":"secret","role":"user"}',
+                        masked = '{"prompt":"other","role":"user"}',
+                        mapping = {},
+                    },
+                    {
+                        name = "role changes",
+                        original = '{"prompt":"secret","role":"user"}',
+                        masked = '{"prompt":"secret","role":"assistant"}',
+                        mapping = {},
+                    },
+                    {
+                        name = "tool content changes",
+                        original = '{"tool":{"name":"lookup","strict":true}}',
+                        masked = '{"tool":{"name":"delete","strict":true}}',
+                        mapping = {},
+                    },
+                    {
+                        name = "numeric lexemes change",
+                        original = '{"number":1.2300e+40}',
+                        masked = '{"number":1.23e40}',
+                        mapping = {},
+                    },
+                    {
+                        name = "non-string values change",
+                        original = '{"enabled":true,"value":null}',
+                        masked = '{"enabled":false,"value":null}',
+                        mapping = {},
+                    },
+                    {
+                        name = "object key order changes",
+                        original = '{"first":1,"second":2}',
+                        masked = '{"second":2,"first":1}',
+                        mapping = {},
+                    },
+                    {
+                        name = "array shape changes",
+                        original = '{"values":[1,2]}',
+                        masked = '{"values":[1,2,3]}',
+                        mapping = {},
+                    },
+                    {
+                        name = "mapping originals disagree with the finalized body",
+                        original = '{"prompt":"secret"}',
+                        masked = '{"prompt":"' .. token .. '"}',
+                        mapping = {[token] = "different-secret"},
+                    },
+                }) do
+                    it(
+                        "rejects when " .. case.name, function()
+                            local ok, err = verify(
+                                case.original, case.masked, case.mapping
+                            )
+
+                            assert.is_nil(ok)
+                            assert.is_equal(
+                                "redaction service changed non-sensitive request content",
+                                err
+                            )
+                        end
+                    )
+                end
             end
         )
 

--- a/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
@@ -120,6 +120,7 @@ describe(
                     request_count = 0,
                     read_count = 0,
                     body_reader_count = 0,
+                    body_reader_sizes = {},
                     read_body_count = 0,
                     keepalive_count = 0,
                     close_count = 0,
@@ -165,24 +166,34 @@ describe(
 
                                 observed.payload = assert(core.json.decode(options.body))
                                 local raw = behavior.response_builder(observed.payload)
-                                local chunks = behavior.response_chunks or {raw}
-                                local chunk_index = 0
+                                local response_body = behavior.response_body or raw
+                                local response_offset = 1
                                 return {
                                     status = behavior.response_status,
                                     headers = behavior.response_headers,
-                                    body_reader = function()
+                                    body_reader = function(max_bytes)
                                         observed.body_reader_count =
                                             observed.body_reader_count + 1
+                                        observed.body_reader_sizes[
+                                            #observed.body_reader_sizes + 1
+                                        ] = max_bytes or false
                                         if behavior.read_error then
                                             observed.read_count = observed.read_count + 1
                                             return nil, behavior.read_error
                                         end
 
-                                        chunk_index = chunk_index + 1
-                                        local chunk = chunks[chunk_index]
-                                        if chunk then
-                                            observed.read_count = observed.read_count + 1
+                                        if response_offset > #response_body then
+                                            return nil
                                         end
+
+                                        local remaining = #response_body - response_offset + 1
+                                        local read_size = math.min(max_bytes or remaining, remaining)
+                                        local chunk = response_body:sub(
+                                            response_offset,
+                                            response_offset + read_size - 1
+                                        )
+                                        response_offset = response_offset + #chunk
+                                        observed.read_count = observed.read_count + 1
                                         return chunk
                                     end,
                                     read_body = function()
@@ -808,25 +819,28 @@ describe(
                 )
 
                 it(
-                    "closes a chunked response when its accumulated body exceeds the cap",
+                    "bounds reader allocations when one wire chunk exceeds the cap",
                     function()
                         local ctx = request_context()
-                        -- The same 1413-byte derived cap is crossed by the second chunk.
-                        behavior.response_chunks = {
-                            string.rep("a", 1000),
-                            string.rep("b", 414),
-                        }
+                        -- Wire cap = 27 + 6*1400 body bytes + 6*1 mapping byte
+                        --            + 33*1 mapping entry = 8466 bytes.
+                        behavior.response_body = string.rep("a", 8467)
 
                         local code, err = plugin.access(config({
-                            max_request_body_bytes = 200,
-                            max_mapping_bytes = 20,
-                            max_mapping_entries = 2,
+                            max_request_body_bytes = 1400,
+                            max_mapping_bytes = 1,
+                            max_mapping_entries = 1,
                         }), ctx)
 
                         assert.is_equal(502, code)
                         assert.is_same({
                             message = "redaction service response size limit exceeded",
                         }, err)
+                        assert.is_same({8192, 275}, observed.body_reader_sizes)
+                        for _, read_size in ipairs(observed.body_reader_sizes) do
+                            assert.is_true(read_size > 0)
+                            assert.is_true(read_size <= 8192)
+                        end
                         assert.is_equal(2, observed.read_count)
                         assert.is_equal(2, observed.body_reader_count)
                         assert.is_equal(0, observed.read_body_count)

--- a/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
+++ b/src/apisix/tests/test-bk-ai-sensitive-data-redaction.lua
@@ -1359,6 +1359,8 @@ describe(
                             '{"content":"' .. known .. '"} trailing',
                             string.rep("[", 129) .. '"' .. known .. '"' ..
                                 string.rep("]", 129),
+                            '{"content":"\\uD800"}',
+                            '{"' .. string.char(0x80) .. '":"value"}',
                         }
 
                         for _, masked_body in ipairs(cases) do
@@ -1387,7 +1389,7 @@ describe(
                             assert.is_nil(ctx._ai_redaction_sse_restorer)
                         end
 
-                        assert.stub(core.log.error).was_called(3)
+                        assert.stub(core.log.error).was_called(5)
                         assert.stub(core.log.error).was_called_with(
                             "failed to restore masked AI response",
                             ", request_id: ",

--- a/src/build/patches/010_ai_response_filter_eof.patch
+++ b/src/build/patches/010_ai_response_filter_eof.patch
@@ -1,0 +1,115 @@
+diff --git a/apisix/plugin.lua b/apisix/plugin.lua
+index 2e664e6..c831847 100644
+--- a/apisix/plugin.lua
++++ b/apisix/plugin.lua
+@@ -1469,9 +1469,10 @@ end
+ 
+ -- @param wait boolean When true, use synchronous flush (ngx.flush(true)) so callers
+ --   can detect client disconnection. Defaults to false (async flush).
++-- @param eof boolean|nil True only when no later response bytes will arrive.
+ -- @return boolean, string|nil Always returns (ok, err). On success returns true.
+ --   On flush failure or print failure returns false, err.
+-function _M.lua_response_filter(api_ctx, headers, body, no_flush, wait)
++function _M.lua_response_filter(api_ctx, headers, body, no_flush, wait, eof)
+     local plugins = api_ctx.plugins
+     if plugins and #plugins > 0 then
+         for i = 1, #plugins, 2 do
+@@ -1483,7 +1484,7 @@ function _M.lua_response_filter(api_ctx, headers, body, no_flush, wait)
+                 end
+ 
+                 run_meta_pre_function(conf, api_ctx, plugins[i]["name"])
+-                local code, new_body = phase_func(conf, api_ctx, headers, body)
++                local code, new_body = phase_func(conf, api_ctx, headers, body, eof)
+                 if code then
+                     if code ~= ngx_ok then
+                         ngx.status = code
+diff --git a/apisix/plugins/ai-providers/base.lua b/apisix/plugins/ai-providers/base.lua
+index 407fe0b..0836e77 100644
+--- a/apisix/plugins/ai-providers/base.lua
++++ b/apisix/plugins/ai-providers/base.lua
+@@ -364,7 +364,7 @@ function _M.parse_response(self, ctx, res, client_proto, converter, conf)
+     if decode_err then
+         core.log.warn("failed to decode response from ai service, err: ", decode_err,
+             ", it will cause token usage not available")
+-        plugin.lua_response_filter(ctx, headers, raw_res_body)
++        plugin.lua_response_filter(ctx, headers, raw_res_body, nil, nil, true)
+         return nil
+     end
+ 
+@@ -402,7 +402,7 @@ function _M.parse_response(self, ctx, res, client_proto, converter, conf)
+         ctx.var.llm_response_text = response_text
+     end
+ 
+-    plugin.lua_response_filter(ctx, headers, raw_res_body)
++    plugin.lua_response_filter(ctx, headers, raw_res_body, nil, nil, true)
+     return res_body
+ end
+ 
+@@ -435,6 +435,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+     -- all events may be skipped and no output produced, leaving the response
+     -- uncommitted and causing nginx to fall through to the balancer phase.
+     local output_sent = false
++    local response_filter_finalized = false
+ 
+     -- Runaway-upstream safeguards. Both are opt-in; unset means no cap.
+     local max_duration_ms = conf and conf.max_stream_duration_ms
+@@ -503,6 +504,21 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+         ctx.var.llm_request_done = true
+     end
+ 
++    local function finalize_response_filter()
++        if response_filter_finalized then
++            return true
++        end
++
++        response_filter_finalized = true
++        local ok, filter_err = plugin.lua_response_filter(
++            ctx, res.headers, "", true, false, true)
++        if not ok then
++            abort_on_disconnect(filter_err)
++            return false
++        end
++        return true
++    end
++
+     -- Use a local flag instead of reading ctx.var on every chunk.
+     local first_token_set = false
+ 
+@@ -518,6 +534,9 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+                 (ngx_now() - ctx.llm_request_start_time) * 1000)
+             core.log.warn("failed to read response chunk: ", err)
+             res._upstream_bytes = bytes_read
++            if not finalize_response_filter() then
++                return
++            end
+             if flush_thread then
+                 ngx.thread.kill(flush_thread)
+                 flush_thread = nil
+@@ -550,6 +569,9 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+                 ngx.thread.kill(flush_thread)
+                 flush_thread = nil
+             end
++            if not finalize_response_filter() then
++                return
++            end
+             if not flush_err then
+                 ngx.flush(true)
+             end
+@@ -636,7 +658,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+         if converter then
+             for _, c in ipairs(converted_chunks) do
+                 local ok, flush_err = plugin.lua_response_filter(
+-                    ctx, res.headers, c, no_flush, true)
++                    ctx, res.headers, c, no_flush, true, false)
+                 if not ok then
+                     abort_on_disconnect(flush_err)
+                     return
+@@ -645,7 +667,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+             end
+         else
+             local ok, flush_err = plugin.lua_response_filter(
+-                ctx, res.headers, chunk, no_flush, true)
++                ctx, res.headers, chunk, no_flush, true, false)
+             if not ok then
+                 abort_on_disconnect(flush_err)
+                 return

--- a/src/build/patches/010_ai_response_filter_eof.patch
+++ b/src/build/patches/010_ai_response_filter_eof.patch
@@ -24,7 +24,7 @@ index 2e664e6..c831847 100644
                      if code ~= ngx_ok then
                          ngx.status = code
 diff --git a/apisix/plugins/ai-providers/base.lua b/apisix/plugins/ai-providers/base.lua
-index 407fe0b..0836e77 100644
+index 407fe0b..dfa15ff 100644
 --- a/apisix/plugins/ai-providers/base.lua
 +++ b/apisix/plugins/ai-providers/base.lua
 @@ -364,7 +364,7 @@ function _M.parse_response(self, ctx, res, client_proto, converter, conf)
@@ -53,7 +53,7 @@ index 407fe0b..0836e77 100644
  
      -- Runaway-upstream safeguards. Both are opt-in; unset means no cap.
      local max_duration_ms = conf and conf.max_stream_duration_ms
-@@ -503,6 +504,21 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -503,6 +504,22 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
          ctx.var.llm_request_done = true
      end
  
@@ -63,6 +63,7 @@ index 407fe0b..0836e77 100644
 +        end
 +
 +        response_filter_finalized = true
++        ctx.llm_response_contents_in_chunk = {}
 +        local ok, filter_err = plugin.lua_response_filter(
 +            ctx, res.headers, "", true, false, true)
 +        if not ok then
@@ -75,7 +76,7 @@ index 407fe0b..0836e77 100644
      -- Use a local flag instead of reading ctx.var on every chunk.
      local first_token_set = false
  
-@@ -518,6 +534,9 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -518,6 +535,9 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
                  (ngx_now() - ctx.llm_request_start_time) * 1000)
              core.log.warn("failed to read response chunk: ", err)
              res._upstream_bytes = bytes_read
@@ -85,17 +86,36 @@ index 407fe0b..0836e77 100644
              if flush_thread then
                  ngx.thread.kill(flush_thread)
                  flush_thread = nil
-@@ -550,6 +569,9 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
-                 ngx.thread.kill(flush_thread)
-                 flush_thread = nil
-             end
+@@ -534,10 +554,14 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+             res._upstream_bytes = bytes_read
+             ctx.var.apisix_upstream_response_time = math.floor(
+                 (ngx_now() - ctx.llm_request_start_time) * 1000)
++            if flush_thread then
++                ngx.thread.kill(flush_thread)
++                flush_thread = nil
++            end
 +            if not finalize_response_filter() then
 +                return
 +            end
+             if converter and not output_sent then
+-                if flush_thread then
+-                    ngx.thread.kill(flush_thread)
+-                end
+                 local msg = "streaming response completed without producing "
+                             .. "any output; the upstream likely returned a "
+                             .. "different stream format than the converter expects"
+@@ -546,10 +570,6 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+             end
+             -- Final sync flush: ensure the last async-queued bytes reach the client.
+             -- flush_err means client already disconnected; skip to avoid a noisy log.
+-            if flush_thread then
+-                ngx.thread.kill(flush_thread)
+-                flush_thread = nil
+-            end
              if not flush_err then
                  ngx.flush(true)
              end
-@@ -636,7 +658,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -636,7 +656,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
          if converter then
              for _, c in ipairs(converted_chunks) do
                  local ok, flush_err = plugin.lua_response_filter(
@@ -104,7 +124,7 @@ index 407fe0b..0836e77 100644
                  if not ok then
                      abort_on_disconnect(flush_err)
                      return
-@@ -645,7 +667,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -645,7 +665,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
              end
          else
              local ok, flush_err = plugin.lua_response_filter(

--- a/src/build/patches/010_ai_response_filter_eof.patch
+++ b/src/build/patches/010_ai_response_filter_eof.patch
@@ -3,7 +3,7 @@ index 2e664e6..c831847 100644
 --- a/apisix/plugin.lua
 +++ b/apisix/plugin.lua
 @@ -1469,9 +1469,10 @@ end
- 
+
  -- @param wait boolean When true, use synchronous flush (ngx.flush(true)) so callers
  --   can detect client disconnection. Defaults to false (async flush).
 +-- @param eof boolean|nil True only when no later response bytes will arrive.
@@ -16,7 +16,7 @@ index 2e664e6..c831847 100644
          for i = 1, #plugins, 2 do
 @@ -1483,7 +1484,7 @@ function _M.lua_response_filter(api_ctx, headers, body, no_flush, wait)
                  end
- 
+
                  run_meta_pre_function(conf, api_ctx, plugins[i]["name"])
 -                local code, new_body = phase_func(conf, api_ctx, headers, body)
 +                local code, new_body = phase_func(conf, api_ctx, headers, body, eof)
@@ -35,28 +35,28 @@ index 407fe0b..dfa15ff 100644
 +        plugin.lua_response_filter(ctx, headers, raw_res_body, nil, nil, true)
          return nil
      end
- 
+
 @@ -402,7 +402,7 @@ function _M.parse_response(self, ctx, res, client_proto, converter, conf)
          ctx.var.llm_response_text = response_text
      end
- 
+
 -    plugin.lua_response_filter(ctx, headers, raw_res_body)
 +    plugin.lua_response_filter(ctx, headers, raw_res_body, nil, nil, true)
      return res_body
  end
- 
+
 @@ -435,6 +435,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
      -- all events may be skipped and no output produced, leaving the response
      -- uncommitted and causing nginx to fall through to the balancer phase.
      local output_sent = false
 +    local response_filter_finalized = false
- 
+
      -- Runaway-upstream safeguards. Both are opt-in; unset means no cap.
      local max_duration_ms = conf and conf.max_stream_duration_ms
 @@ -503,6 +504,22 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
          ctx.var.llm_request_done = true
      end
- 
+
 +    local function finalize_response_filter()
 +        if response_filter_finalized then
 +            return true
@@ -75,7 +75,7 @@ index 407fe0b..dfa15ff 100644
 +
      -- Use a local flag instead of reading ctx.var on every chunk.
      local first_token_set = false
- 
+
 @@ -518,6 +535,9 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
                  (ngx_now() - ctx.llm_request_start_time) * 1000)
              core.log.warn("failed to read response chunk: ", err)

--- a/src/build/patches/010_ai_response_filter_eof.patch
+++ b/src/build/patches/010_ai_response_filter_eof.patch
@@ -133,3 +133,13 @@ index 407fe0b..dfa15ff 100644
              if not ok then
                  abort_on_disconnect(flush_err)
                  return
+@@ -686,6 +706,9 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+             ctx.var.apisix_upstream_response_time = duration_ms
+             ctx.var.llm_request_done = true
+             res._upstream_bytes = bytes_read
++            if not finalize_response_filter() then
++                return
++            end
+             if output_sent then
+                 -- Client has already received partial SSE; stop feeding chunks.
+                 -- nginx will close the downstream connection at end of content

--- a/src/build/patches/010_ai_response_filter_eof.patch
+++ b/src/build/patches/010_ai_response_filter_eof.patch
@@ -1,30 +1,81 @@
 diff --git a/apisix/plugin.lua b/apisix/plugin.lua
-index 2e664e6..c831847 100644
+index 2e664e6..29129d4 100644
 --- a/apisix/plugin.lua
 +++ b/apisix/plugin.lua
-@@ -1469,9 +1469,10 @@ end
+@@ -1469,9 +1469,12 @@ end
 
  -- @param wait boolean When true, use synchronous flush (ngx.flush(true)) so callers
  --   can detect client disconnection. Defaults to false (async flush).
+--- @return boolean, string|nil Always returns (ok, err). On success returns true.
 +-- @param eof boolean|nil True only when no later response bytes will arrive.
- -- @return boolean, string|nil Always returns (ok, err). On success returns true.
++-- @param abort_reason string|nil Why an abnormal stream ended, if applicable.
++-- @return boolean, string|nil, boolean|nil Returns (ok, err, emitted). emitted is
++--   present on EOF and reports whether the final transformed body was written.
  --   On flush failure or print failure returns false, err.
 -function _M.lua_response_filter(api_ctx, headers, body, no_flush, wait)
-+function _M.lua_response_filter(api_ctx, headers, body, no_flush, wait, eof)
++function _M.lua_response_filter(api_ctx, headers, body, no_flush, wait, eof, abort_reason)
      local plugins = api_ctx.plugins
      if plugins and #plugins > 0 then
          for i = 1, #plugins, 2 do
-@@ -1483,7 +1484,7 @@ function _M.lua_response_filter(api_ctx, headers, body, no_flush, wait)
+@@ -1483,12 +1486,17 @@ function _M.lua_response_filter(api_ctx, headers, body, no_flush, wait)
                  end
 
                  run_meta_pre_function(conf, api_ctx, plugins[i]["name"])
 -                local code, new_body = phase_func(conf, api_ctx, headers, body)
-+                local code, new_body = phase_func(conf, api_ctx, headers, body, eof)
++                local code, new_body = phase_func(
++                    conf, api_ctx, headers, body, eof, abort_reason)
                  if code then
                      if code ~= ngx_ok then
                          ngx.status = code
+                     end
+
++                    if eof then
++                        body = new_body
++                        goto RESPONSE_FILTER_OUTPUT
++                    end
+                     ngx_print(new_body)
+                     ngx_exit(ngx_ok)
+                 end
+@@ -1500,6 +1508,10 @@ function _M.lua_response_filter(api_ctx, headers, body, no_flush, wait)
+             ::CONTINUE::
+         end
+     end
++    ::RESPONSE_FILTER_OUTPUT::
++    if eof and body == "" then
++        return true, nil, false
++    end
+     local ok, err = ngx_print(body)
+     if not ok then
+         return false, err
+@@ -1511,6 +1523,9 @@ function _M.lua_response_filter(api_ctx, headers, body, no_flush, wait)
+             return false, err
+         end
+     end
++    if eof then
++        return true, nil, true
++    end
+     return true
+ end
+
+diff --git a/apisix/plugins/ai-aliyun-content-moderation.lua b/apisix/plugins/ai-aliyun-content-moderation.lua
+index 49cc6c9..9f0e765 100644
+--- a/apisix/plugins/ai-aliyun-content-moderation.lua
++++ b/apisix/plugins/ai-aliyun-content-moderation.lua
+@@ -342,7 +342,11 @@ function _M.access(conf, ctx)
+     end
+ end
+
+-function _M.lua_body_filter(conf, ctx, headers, body)
++function _M.lua_body_filter(conf, ctx, headers, body, eof, abort_reason)
++    if eof and abort_reason then
++        return nil, body
++    end
++
+     if not conf.check_response then
+         core.log.info("skip response check for this request")
+         return
 diff --git a/apisix/plugins/ai-providers/base.lua b/apisix/plugins/ai-providers/base.lua
-index 407fe0b..dfa15ff 100644
+index 407fe0b..7f463db 100644
 --- a/apisix/plugins/ai-providers/base.lua
 +++ b/apisix/plugins/ai-providers/base.lua
 @@ -364,7 +364,7 @@ function _M.parse_response(self, ctx, res, client_proto, converter, conf)
@@ -45,48 +96,50 @@ index 407fe0b..dfa15ff 100644
      return res_body
  end
 
-@@ -435,6 +435,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -435,6 +435,8 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
      -- all events may be skipped and no output produced, leaving the response
      -- uncommitted and causing nginx to fall through to the balancer phase.
      local output_sent = false
 +    local response_filter_finalized = false
++    local response_filter_emitted = false
 
      -- Runaway-upstream safeguards. Both are opt-in; unset means no cap.
      local max_duration_ms = conf and conf.max_stream_duration_ms
-@@ -503,6 +504,22 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -503,6 +505,23 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
          ctx.var.llm_request_done = true
      end
 
-+    local function finalize_response_filter()
++    local function finalize_response_filter(abort_reason)
 +        if response_filter_finalized then
-+            return true
++            return true, response_filter_emitted
 +        end
 +
 +        response_filter_finalized = true
 +        ctx.llm_response_contents_in_chunk = {}
-+        local ok, filter_err = plugin.lua_response_filter(
-+            ctx, res.headers, "", true, false, true)
++        local ok, filter_err, emitted = plugin.lua_response_filter(
++            ctx, res.headers, "", true, false, true, abort_reason)
 +        if not ok then
 +            abort_on_disconnect(filter_err)
 +            return false
 +        end
-+        return true
++        response_filter_emitted = emitted == true
++        return true, response_filter_emitted
 +    end
 +
      -- Use a local flag instead of reading ctx.var on every chunk.
      local first_token_set = false
 
-@@ -518,6 +535,9 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -518,6 +537,9 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
                  (ngx_now() - ctx.llm_request_start_time) * 1000)
              core.log.warn("failed to read response chunk: ", err)
              res._upstream_bytes = bytes_read
-+            if not finalize_response_filter() then
++            if not finalize_response_filter("upstream_read_error") then
 +                return
 +            end
              if flush_thread then
                  ngx.thread.kill(flush_thread)
                  flush_thread = nil
-@@ -534,10 +554,14 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -534,10 +556,22 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
              res._upstream_bytes = bytes_read
              ctx.var.apisix_upstream_response_time = math.floor(
                  (ngx_now() - ctx.llm_request_start_time) * 1000)
@@ -94,8 +147,16 @@ index 407fe0b..dfa15ff 100644
 +                ngx.thread.kill(flush_thread)
 +                flush_thread = nil
 +            end
-+            if not finalize_response_filter() then
++            local abort_reason
++            if converter and not output_sent then
++                abort_reason = "converter_no_output"
++            end
++            local filter_ok, emitted = finalize_response_filter(abort_reason)
++            if not filter_ok then
 +                return
++            end
++            if emitted then
++                output_sent = true
 +            end
              if converter and not output_sent then
 -                if flush_thread then
@@ -104,7 +165,7 @@ index 407fe0b..dfa15ff 100644
                  local msg = "streaming response completed without producing "
                              .. "any output; the upstream likely returned a "
                              .. "different stream format than the converter expects"
-@@ -546,10 +570,6 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -546,10 +580,6 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
              end
              -- Final sync flush: ensure the last async-queued bytes reach the client.
              -- flush_err means client already disconnected; skip to avoid a noisy log.
@@ -115,7 +176,7 @@ index 407fe0b..dfa15ff 100644
              if not flush_err then
                  ngx.flush(true)
              end
-@@ -636,7 +656,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -636,7 +666,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
          if converter then
              for _, c in ipairs(converted_chunks) do
                  local ok, flush_err = plugin.lua_response_filter(
@@ -124,7 +185,7 @@ index 407fe0b..dfa15ff 100644
                  if not ok then
                      abort_on_disconnect(flush_err)
                      return
-@@ -645,7 +665,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -645,7 +675,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
              end
          else
              local ok, flush_err = plugin.lua_response_filter(
@@ -133,12 +194,16 @@ index 407fe0b..dfa15ff 100644
              if not ok then
                  abort_on_disconnect(flush_err)
                  return
-@@ -686,6 +706,9 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -686,6 +716,13 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
              ctx.var.apisix_upstream_response_time = duration_ms
              ctx.var.llm_request_done = true
              res._upstream_bytes = bytes_read
-+            if not finalize_response_filter() then
++            local filter_ok, emitted = finalize_response_filter("stream_limit")
++            if not filter_ok then
 +                return
++            end
++            if emitted then
++                output_sent = true
 +            end
              if output_sent then
                  -- Client has already received partial SSE; stop feeding chunks.

--- a/src/build/patches/010_ai_response_filter_eof.patch
+++ b/src/build/patches/010_ai_response_filter_eof.patch
@@ -75,7 +75,7 @@ index 49cc6c9..9f0e765 100644
          core.log.info("skip response check for this request")
          return
 diff --git a/apisix/plugins/ai-providers/base.lua b/apisix/plugins/ai-providers/base.lua
-index 407fe0b..7f463db 100644
+index 407fe0b..5598753 100644
 --- a/apisix/plugins/ai-providers/base.lua
 +++ b/apisix/plugins/ai-providers/base.lua
 @@ -364,7 +364,7 @@ function _M.parse_response(self, ctx, res, client_proto, converter, conf)
@@ -129,17 +129,22 @@ index 407fe0b..7f463db 100644
      -- Use a local flag instead of reading ctx.var on every chunk.
      local first_token_set = false
 
-@@ -518,6 +537,9 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
-                 (ngx_now() - ctx.llm_request_start_time) * 1000)
-             core.log.warn("failed to read response chunk: ", err)
-             res._upstream_bytes = bytes_read
-+            if not finalize_response_filter("upstream_read_error") then
-+                return
-+            end
-             if flush_thread then
+@@ -522,6 +541,14 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
                  ngx.thread.kill(flush_thread)
                  flush_thread = nil
-@@ -534,10 +556,22 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+             end
++            local filter_ok, emitted =
++                finalize_response_filter("upstream_read_error")
++            if not filter_ok then
++                return
++            end
++            if output_sent or emitted then
++                return
++            end
+             return transport_http.handle_error(err)
+         end
+         if not chunk then
+@@ -534,10 +561,22 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
              res._upstream_bytes = bytes_read
              ctx.var.apisix_upstream_response_time = math.floor(
                  (ngx_now() - ctx.llm_request_start_time) * 1000)
@@ -165,7 +170,7 @@ index 407fe0b..7f463db 100644
                  local msg = "streaming response completed without producing "
                              .. "any output; the upstream likely returned a "
                              .. "different stream format than the converter expects"
-@@ -546,10 +580,6 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -546,10 +585,6 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
              end
              -- Final sync flush: ensure the last async-queued bytes reach the client.
              -- flush_err means client already disconnected; skip to avoid a noisy log.
@@ -176,7 +181,7 @@ index 407fe0b..7f463db 100644
              if not flush_err then
                  ngx.flush(true)
              end
-@@ -636,7 +666,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -636,7 +671,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
          if converter then
              for _, c in ipairs(converted_chunks) do
                  local ok, flush_err = plugin.lua_response_filter(
@@ -185,7 +190,7 @@ index 407fe0b..7f463db 100644
                  if not ok then
                      abort_on_disconnect(flush_err)
                      return
-@@ -645,7 +675,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -645,7 +680,7 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
              end
          else
              local ok, flush_err = plugin.lua_response_filter(
@@ -194,7 +199,7 @@ index 407fe0b..7f463db 100644
              if not ok then
                  abort_on_disconnect(flush_err)
                  return
-@@ -686,6 +716,13 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
+@@ -686,6 +721,13 @@ function _M.parse_streaming_response(self, ctx, res, target_proto, converter, co
              ctx.var.apisix_upstream_response_time = duration_ms
              ctx.var.llm_request_done = true
              res._upstream_bytes = bytes_read

--- a/src/build/patches/011_ai_final_request_body_filter.patch
+++ b/src/build/patches/011_ai_final_request_body_filter.patch
@@ -1,11 +1,14 @@
 diff --git a/apisix/plugins/ai-providers/base.lua b/apisix/plugins/ai-providers/base.lua
-index 407fe0b..5f984fc 100644
+index dfa15ff36..066d6a7d2 100644
 --- a/apisix/plugins/ai-providers/base.lua
 +++ b/apisix/plugins/ai-providers/base.lua
-@@ -97,6 +97,12 @@ end
+@@ -97,4 +97,13 @@ end
  -- @return string|nil err Error message
++-- @return number|nil status HTTP status for build failures
++-- @return boolean|nil non_retryable Whether ai-proxy must bypass provider fallback
  function _M.build_request(self, ctx, conf, request_body, opts)
      local body_changed = false
++    local baseline_body_changed = ctx.ai_request_body_changed
 +    local final_body_filter = ctx.ai_final_request_body_filter
 +    if final_body_filter then
 +        -- A provider build mutates its request table during conversion and overrides.
@@ -13,11 +16,27 @@ index 407fe0b..5f984fc 100644
 +        request_body = core.table.deepcopy(request_body)
 +    end
 
-     -- Protocol conversion (when a converter bridges client→target protocol)
-     local converter = ctx.ai_converter
-@@ -263,6 +269,43 @@ function _M.build_request(self, ctx, conf, request_body, opts)
-         params.body = request_body
-     end
+@@ -123,4 +132,8 @@ function _M.build_request(self, ctx, conf, request_body, opts)
+
+-    core.log.info("request extra_opts to LLM server: ",
+-                  core.json.delay_encode(log_sanitize.redact_extra_opts(opts), true))
++    if final_body_filter then
++        core.log.info("request extra_opts to LLM server: final body filter active")
++    else
++        core.log.info("request extra_opts to LLM server: ",
++                      core.json.delay_encode(log_sanitize.redact_extra_opts(opts), true))
++    end
+
+@@ -248,7 +261,3 @@ function _M.build_request(self, ctx, conf, request_body, opts)
+
+-    if body_changed then
+-        ctx.ai_request_body_changed = true
+-    end
+-
+-    if not ctx.ai_request_body_changed then
++    if not baseline_body_changed and not body_changed then
+         if ctx.ai_raw_request_body == nil then
+@@ -265,2 +274,35 @@ function _M.build_request(self, ctx, conf, request_body, opts)
 
 +    if final_body_filter then
 +        local raw_body = params.body
@@ -44,40 +63,60 @@ index 407fe0b..5f984fc 100644
 +        if not ok or (type(filtered_body) ~= "string" and not valid_failure)
 +                or (type(filtered_body) == "string"
 +                    and (error_body ~= nil or status ~= nil)) then
-+            -- ai-proxy-multi treats a missing picker as an abort signal and returns
-+            -- the status directly instead of selecting another LLM instance.
-+            ctx.server_picker = nil
-+            return nil, {message = "failed to filter final AI request body"}, 500
++            return nil, {message = "failed to filter final AI request body"}, 500, true
 +        end
 +        if valid_failure then
-+            ctx.server_picker = nil
-+            return nil, error_body, status
++            return nil, error_body, status, true
 +        end
 +        params.body = filtered_body
 +    end
 +
      -- AWS SigV4 signing (must be last — signs the finalized body)
-     if self.aws_sigv4 and auth.aws then
-         local auth_aws = require("apisix.plugins.ai-transport.auth-aws")
+diff --git a/apisix/plugins/ai-proxy-multi.lua b/apisix/plugins/ai-proxy-multi.lua
+index 0d23ad096..0df272b44 100644
+--- a/apisix/plugins/ai-proxy-multi.lua
++++ b/apisix/plugins/ai-proxy-multi.lua
+@@ -650,2 +650,5 @@ function _M.log(conf, ctx)
+     end
++    if ctx.server_picker then
++        ctx.server_picker.after_balance(ctx, false)
++    end
+     if conf.logging then
+diff --git a/apisix/plugins/ai-proxy/base.lua b/apisix/plugins/ai-proxy/base.lua
+index d2b6e67a9..81f3a3705 100644
+--- a/apisix/plugins/ai-proxy/base.lua
++++ b/apisix/plugins/ai-proxy/base.lua
+@@ -208,5 +208,8 @@ function _M.before_proxy(conf, ctx, on_error)
+             -- Step 3: Build HTTP request params
+-            local params, build_err, code = ai_provider:build_request(
++            local params, build_err, code, non_retryable = ai_provider:build_request(
+                 ctx, conf, request_body, extra_opts)
+             if not params then
++                if non_retryable then
++                    return code or 500, build_err, true
++                end
+                 local body = {error_msg = build_err}
+@@ -345,3 +348,3 @@ function _M.before_proxy(conf, ctx, on_error)
+         ctx.llm_active_connections_tracked = true
+-        local ok, code_or_err, body = pcall(do_request)
++        local ok, code_or_err, body, non_retryable = pcall(do_request)
+         if not ok then
+@@ -350,3 +353,3 @@ function _M.before_proxy(conf, ctx, on_error)
+         end
+-        if code_or_err and on_error then
++        if code_or_err and on_error and not non_retryable then
+             local abort_code = on_error(ctx, conf, code_or_err)
 diff --git a/apisix/plugins/ai-transport/http.lua b/apisix/plugins/ai-transport/http.lua
-index eb7efc3..7c3d876 100644
+index eb7efc34b..7c3d876a8 100644
 --- a/apisix/plugins/ai-transport/http.lua
 +++ b/apisix/plugins/ai-transport/http.lua
-@@ -103,7 +103,7 @@ local function rapidjson_encode(body)
- end
-
+@@ -105,3 +105,3 @@ end
 
 -local function encode_body(body)
 +function _M.encode_body(body)
      local ok, encoded = pcall(rapidjson_encode, body)
-     if ok and encoded then
-         return encoded
-@@ -159,7 +159,7 @@ function _M.request(params, timeout)
-         req_json = params.body
-     else
+@@ -161,3 +161,3 @@ function _M.request(params, timeout)
          local err
 -        req_json, err = encode_body(params.body)
 +        req_json, err = _M.encode_body(params.body)
          if not req_json then
-             httpc:close()
-             return nil, "encode body: " .. (err or "unknown"), {

--- a/src/build/patches/011_ai_final_request_body_filter.patch
+++ b/src/build/patches/011_ai_final_request_body_filter.patch
@@ -72,16 +72,6 @@ index dfa15ff36..066d6a7d2 100644
 +    end
 +
      -- AWS SigV4 signing (must be last — signs the finalized body)
-diff --git a/apisix/plugins/ai-proxy-multi.lua b/apisix/plugins/ai-proxy-multi.lua
-index 0d23ad096..0df272b44 100644
---- a/apisix/plugins/ai-proxy-multi.lua
-+++ b/apisix/plugins/ai-proxy-multi.lua
-@@ -650,2 +650,5 @@ function _M.log(conf, ctx)
-     end
-+    if ctx.server_picker then
-+        ctx.server_picker.after_balance(ctx, false)
-+    end
-     if conf.logging then
 diff --git a/apisix/plugins/ai-proxy/base.lua b/apisix/plugins/ai-proxy/base.lua
 index d2b6e67a9..81f3a3705 100644
 --- a/apisix/plugins/ai-proxy/base.lua

--- a/src/build/patches/011_ai_final_request_body_filter.patch
+++ b/src/build/patches/011_ai_final_request_body_filter.patch
@@ -73,15 +73,19 @@ index dfa15ff36..066d6a7d2 100644
 +
      -- AWS SigV4 signing (must be last — signs the finalized body)
 diff --git a/apisix/plugins/ai-proxy/base.lua b/apisix/plugins/ai-proxy/base.lua
-index d2b6e67a..c908c138 100644
+index d2b6e67a..3e279855 100644
 --- a/apisix/plugins/ai-proxy/base.lua
 +++ b/apisix/plugins/ai-proxy/base.lua
-@@ -205,8 +205,15 @@ function _M.before_proxy(conf, ctx, on_error)
+@@ -123,2 +123,5 @@ function _M.before_proxy(conf, ctx, on_error)
+     while true do
++        if ctx.ai_final_request_body_filter then
++            ctx.var.llm_request_body = {}
++        end
+         local ai_instance = ctx.picked_ai_instance
+@@ -205,8 +208,13 @@ function _M.before_proxy(conf, ctx, on_error)
              ctx.llm_request_start_time = ngx.now()
 -            ctx.var.llm_request_body = request_body
-+            if ctx.ai_final_request_body_filter then
-+                ctx.var.llm_request_body = {}
-+            else
++            if not ctx.ai_final_request_body_filter then
 +                ctx.var.llm_request_body = request_body
 +            end
 
@@ -94,12 +98,12 @@ index d2b6e67a..c908c138 100644
 +                    return code or 500, build_err, true
 +                end
                  local body = {error_msg = build_err}
-@@ -345,3 +352,3 @@ function _M.before_proxy(conf, ctx, on_error)
+@@ -345,3 +353,3 @@ function _M.before_proxy(conf, ctx, on_error)
          ctx.llm_active_connections_tracked = true
 -        local ok, code_or_err, body = pcall(do_request)
 +        local ok, code_or_err, body, non_retryable = pcall(do_request)
          if not ok then
-@@ -350,3 +357,3 @@ function _M.before_proxy(conf, ctx, on_error)
+@@ -350,3 +358,3 @@ function _M.before_proxy(conf, ctx, on_error)
          end
 -        if code_or_err and on_error then
 +        if code_or_err and on_error and not non_retryable then

--- a/src/build/patches/011_ai_final_request_body_filter.patch
+++ b/src/build/patches/011_ai_final_request_body_filter.patch
@@ -73,10 +73,18 @@ index dfa15ff36..066d6a7d2 100644
 +
      -- AWS SigV4 signing (must be last — signs the finalized body)
 diff --git a/apisix/plugins/ai-proxy/base.lua b/apisix/plugins/ai-proxy/base.lua
-index d2b6e67a9..81f3a3705 100644
+index d2b6e67a..c908c138 100644
 --- a/apisix/plugins/ai-proxy/base.lua
 +++ b/apisix/plugins/ai-proxy/base.lua
-@@ -208,5 +208,8 @@ function _M.before_proxy(conf, ctx, on_error)
+@@ -205,8 +205,15 @@ function _M.before_proxy(conf, ctx, on_error)
+             ctx.llm_request_start_time = ngx.now()
+-            ctx.var.llm_request_body = request_body
++            if ctx.ai_final_request_body_filter then
++                ctx.var.llm_request_body = {}
++            else
++                ctx.var.llm_request_body = request_body
++            end
+
              -- Step 3: Build HTTP request params
 -            local params, build_err, code = ai_provider:build_request(
 +            local params, build_err, code, non_retryable = ai_provider:build_request(
@@ -86,12 +94,12 @@ index d2b6e67a9..81f3a3705 100644
 +                    return code or 500, build_err, true
 +                end
                  local body = {error_msg = build_err}
-@@ -345,3 +348,3 @@ function _M.before_proxy(conf, ctx, on_error)
+@@ -345,3 +352,3 @@ function _M.before_proxy(conf, ctx, on_error)
          ctx.llm_active_connections_tracked = true
 -        local ok, code_or_err, body = pcall(do_request)
 +        local ok, code_or_err, body, non_retryable = pcall(do_request)
          if not ok then
-@@ -350,3 +353,3 @@ function _M.before_proxy(conf, ctx, on_error)
+@@ -350,3 +357,3 @@ function _M.before_proxy(conf, ctx, on_error)
          end
 -        if code_or_err and on_error then
 +        if code_or_err and on_error and not non_retryable then

--- a/src/build/patches/011_ai_final_request_body_filter.patch
+++ b/src/build/patches/011_ai_final_request_body_filter.patch
@@ -73,7 +73,7 @@ index dfa15ff36..066d6a7d2 100644
 +
      -- AWS SigV4 signing (must be last — signs the finalized body)
 diff --git a/apisix/plugins/ai-proxy/base.lua b/apisix/plugins/ai-proxy/base.lua
-index d2b6e67a..3e279855 100644
+index d2b6e67a..d76b2bf1 100644
 --- a/apisix/plugins/ai-proxy/base.lua
 +++ b/apisix/plugins/ai-proxy/base.lua
 @@ -123,2 +123,5 @@ function _M.before_proxy(conf, ctx, on_error)
@@ -98,12 +98,29 @@ index d2b6e67a..3e279855 100644
 +                    return code or 500, build_err, true
 +                end
                  local body = {error_msg = build_err}
-@@ -345,3 +353,3 @@ function _M.before_proxy(conf, ctx, on_error)
+@@ -219,4 +227,15 @@ function _M.before_proxy(conf, ctx, on_error)
+
++            local log_params = params
++            if ctx.ai_final_request_body_filter then
++                log_params = {
++                    method = params.method,
++                    scheme = params.scheme,
++                    host = params.host,
++                    port = params.port,
++                    path = params.path,
++                    ssl_server_name = params.ssl_server_name,
++                }
++            end
+             core.log.info("sending request to LLM server: ",
+-                          core.json.delay_encode(log_sanitize.redact_params(params), true))
++                          core.json.delay_encode(log_sanitize.redact_params(log_params), true))
+
+@@ -345,3 +364,3 @@ function _M.before_proxy(conf, ctx, on_error)
          ctx.llm_active_connections_tracked = true
 -        local ok, code_or_err, body = pcall(do_request)
 +        local ok, code_or_err, body, non_retryable = pcall(do_request)
          if not ok then
-@@ -350,3 +358,3 @@ function _M.before_proxy(conf, ctx, on_error)
+@@ -350,3 +369,3 @@ function _M.before_proxy(conf, ctx, on_error)
          end
 -        if code_or_err and on_error then
 +        if code_or_err and on_error and not non_retryable then

--- a/src/build/patches/011_ai_final_request_body_filter.patch
+++ b/src/build/patches/011_ai_final_request_body_filter.patch
@@ -1,0 +1,83 @@
+diff --git a/apisix/plugins/ai-providers/base.lua b/apisix/plugins/ai-providers/base.lua
+index 407fe0b..5f984fc 100644
+--- a/apisix/plugins/ai-providers/base.lua
++++ b/apisix/plugins/ai-providers/base.lua
+@@ -97,6 +97,12 @@ end
+ -- @return string|nil err Error message
+ function _M.build_request(self, ctx, conf, request_body, opts)
+     local body_changed = false
++    local final_body_filter = ctx.ai_final_request_body_filter
++    if final_body_filter then
++        -- A provider build mutates its request table during conversion and overrides.
++        -- Keep each ai-proxy-multi attempt isolated from the cached client request.
++        request_body = core.table.deepcopy(request_body)
++    end
+
+     -- Protocol conversion (when a converter bridges client→target protocol)
+     local converter = ctx.ai_converter
+@@ -263,6 +269,43 @@ function _M.build_request(self, ctx, conf, request_body, opts)
+         params.body = request_body
+     end
+
++    if final_body_filter then
++        local raw_body = params.body
++        if type(raw_body) ~= "string" then
++            local encode_err
++            if self.aws_sigv4 and auth.aws then
++                raw_body, encode_err = core.json.encode(raw_body)
++            else
++                raw_body, encode_err = transport_http.encode_body(raw_body)
++            end
++            if not raw_body then
++                return nil, "failed to encode final AI request body: " ..
++                            (encode_err or "unknown")
++            end
++        end
++
++        local ok, filtered_body, error_body, status = pcall(final_body_filter, raw_body)
++        local valid_failure = filtered_body == nil
++                              and (type(error_body) == "string"
++                                   or type(error_body) == "table")
++                              and type(status) == "number"
++                              and status >= 400 and status < 600
++                              and status % 1 == 0
++        if not ok or (type(filtered_body) ~= "string" and not valid_failure)
++                or (type(filtered_body) == "string"
++                    and (error_body ~= nil or status ~= nil)) then
++            -- ai-proxy-multi treats a missing picker as an abort signal and returns
++            -- the status directly instead of selecting another LLM instance.
++            ctx.server_picker = nil
++            return nil, {message = "failed to filter final AI request body"}, 500
++        end
++        if valid_failure then
++            ctx.server_picker = nil
++            return nil, error_body, status
++        end
++        params.body = filtered_body
++    end
++
+     -- AWS SigV4 signing (must be last — signs the finalized body)
+     if self.aws_sigv4 and auth.aws then
+         local auth_aws = require("apisix.plugins.ai-transport.auth-aws")
+diff --git a/apisix/plugins/ai-transport/http.lua b/apisix/plugins/ai-transport/http.lua
+index eb7efc3..7c3d876 100644
+--- a/apisix/plugins/ai-transport/http.lua
++++ b/apisix/plugins/ai-transport/http.lua
+@@ -103,7 +103,7 @@ local function rapidjson_encode(body)
+ end
+
+
+-local function encode_body(body)
++function _M.encode_body(body)
+     local ok, encoded = pcall(rapidjson_encode, body)
+     if ok and encoded then
+         return encoded
+@@ -159,7 +159,7 @@ function _M.request(params, timeout)
+         req_json = params.body
+     else
+         local err
+-        req_json, err = encode_body(params.body)
++        req_json, err = _M.encode_body(params.body)
+         if not req_json then
+             httpc:close()
+             return nil, "encode body: " .. (err or "unknown"), {


### PR DESCRIPTION
### Description

Add a sensitive-data redaction plugin for AI gateway traffic.

- Send finalized provider JSON to the configured third-party redaction service before request signing and upstream transport.
- Carry the request ID and an optional session UUID, with isolated per-request redaction mappings.
- Restore non-stream responses losslessly and restore bounded OpenAI Chat Completions, OpenAI Responses, and Anthropic SSE streams.
- Fail closed when redaction cannot be completed, bound third-party response reads and restoration expansion, and keep logging safe for payloads and headers.
- Ship the required upstream behavior through patches 010 and 011 for finalized AI request-body filtering and response EOF handling.

No linked issue.

### Verification

- [x] `RUN_WITH_IT= make lint` — 95 files, 0 warnings/errors
- [x] `RUN_WITH_IT= make test` — Busted 926/926; Test::Nginx 33 files/874
- [x] `make check-license`
- [x] `git diff --check`
- [x] Patches 010 and 011 pass `git apply --no-index --check --recount` and GNU patch with fuzz=0
- [x] Independent final review found no issues

### Checklist

- [x] PR description is complete; no related issue applies
- [x] Code style checks pass
- [x] Unit and functional coverage is included
- [x] Unit and functional tests pass
- [x] Local integration verification passes
