### PR TITLE
fix(apisix): align concurrency metadata schema validation

### DIFF
--- a/src/apisix/plugins/bk-concurrency-limit.lua
+++ b/src/apisix/plugins/bk-concurrency-limit.lua
@@ -31,6 +31,10 @@ local errorx = require("apisix.plugins.bk-core.errorx")
 local table_concat = table.concat
 
 local metadata_schema = core.table.deepcopy(limit_conn.schema)
+-- APISIX applies defaults before conditional schemas, while external validators do not.
+-- Require policy so omitted values follow the default local policy in both validators.
+metadata_schema["if"].required = {"policy"}
+metadata_schema["else"]["if"].required = {"policy"}
 local plugin_name = "bk-concurrency-limit"
 
 local _M = {

--- a/src/apisix/tests/test-bk-concurrency-limit.lua
+++ b/src/apisix/tests/test-bk-concurrency-limit.lua
@@ -92,6 +92,73 @@ describe(
                         assert.is_true(result)
                     end
                 )
+
+                it(
+                    "should require policy before matching redis conditions", function()
+                        local schema = concurrency_limit.metadata_schema
+
+                        assert.same({"policy"}, schema["if"].required)
+                        assert.same({"policy"}, schema["else"]["if"].required)
+                    end
+                )
+
+                it(
+                    "should use local policy when metadata omits policy", function()
+                        local conf = {
+                            conn = 1,
+                            burst = 1,
+                            default_conn_delay = 0.01,
+                            key_type = "var",
+                            key = "bk_concurrency_limit_key",
+                        }
+
+                        local result, _ = concurrency_limit.check_schema(
+                            conf, core.schema.TYPE_METADATA
+                        )
+
+                        assert.is_true(result)
+                        assert.is_equal("local", conf.policy)
+                    end
+                )
+
+                it(
+                    "should require redis host for redis policy", function()
+                        local conf = {
+                            conn = 1,
+                            burst = 1,
+                            default_conn_delay = 0.01,
+                            key_type = "var",
+                            key = "bk_concurrency_limit_key",
+                            policy = "redis",
+                        }
+
+                        local result, _ = concurrency_limit.check_schema(
+                            conf, core.schema.TYPE_METADATA
+                        )
+
+                        assert.is_false(result)
+                    end
+                )
+
+                it(
+                    "should accept redis policy with redis host", function()
+                        local conf = {
+                            conn = 1,
+                            burst = 1,
+                            default_conn_delay = 0.01,
+                            key_type = "var",
+                            key = "bk_concurrency_limit_key",
+                            policy = "redis",
+                            redis_host = "redis.example.com",
+                        }
+
+                        local result, _ = concurrency_limit.check_schema(
+                            conf, core.schema.TYPE_METADATA
+                        )
+
+                        assert.is_true(result)
+                    end
+                )
             end
         )
 


### PR DESCRIPTION
## Summary

- require policy before evaluating the Redis conditional branches copied from limit-conn
- keep omitted policy on the APISIX default local path for both APISIX and external JSON Schema validators
- preserve redis_host requirements for explicit Redis policies
- document why the conditional required fields are necessary

## Related

- Dashboard default and Operator schema sync: https://github.com/TencentBlueKing/blueking-apigateway/pull/3201

## Verification

- RUN_WITH_IT= make lint
- RUN_WITH_IT= make test (776 Busted tests and 742 test-nginx tests)
- make check-license
- focused bk-concurrency-limit suite: 15 passed