### PR TITLE
fix(error-wrapper): preserve real AI upstream errors

### DIFF
--- a/src/apisix/plugins/bk-error-wrapper.lua
+++ b/src/apisix/plugins/bk-error-wrapper.lua
@@ -198,6 +198,13 @@ function _M.header_filter(conf, ctx) -- luacheck: no unused
         return
     end
 
+    -- ai-proxy bypasses the NGINX upstream module and populates synthetic upstream variables.
+    -- Trust the response source before using NGINX byte counters to classify transport failures.
+    if ctx.var.upstream_status and core.response.get_response_source(ctx) == "upstream" then
+        ctx.var.proxy_phase = proxy_phases.FINISH
+        return
+    end
+
     local proxy_phase, upstream_error_msg
     if ctx.var.upstream_status then
         proxy_phase, upstream_error_msg = _get_upstream_error_msg(ctx)

--- a/src/apisix/tests/test-bk-error-wrapper.lua
+++ b/src/apisix/tests/test-bk-error-wrapper.lua
@@ -164,6 +164,29 @@ describe(
                 )
 
                 it(
+                    "keeps real ai upstream error response unwrapped", function()
+                        ngx.status = 402
+                        ctx = CTX(
+                            {
+                                upstream_status = 402,
+                                upstream_connect_time = 0.1,
+                                upstream_header_time = 0.1,
+                                upstream_response_length = "91",
+                            }
+                        )
+                        response.set_response_source(ctx, "upstream")
+
+                        plugin.header_filter(nil, ctx)
+
+                        assert.is_nil(ctx.var.bk_apigw_error)
+                        assert.is_equal("0", ctx.var.proxy_error)
+                        assert.is_equal(proxy_phases.FINISH, ctx.var.proxy_phase)
+                        assert.stub(response.clear_header_as_body_modified).was_not_called()
+                        assert.stub(response.set_header).was_not_called()
+                    end
+                )
+
+                it(
                     "upstream returns 5xx", function()
                         ngx.status = 502
                         plugin.header_filter(nil, ctx)


### PR DESCRIPTION
### Description

APISIX 3.18 `ai-proxy` records synthetic upstream variables for requests made through its HTTP client. `bk-error-wrapper` treated a missing NGINX `upstream_bytes_received` value as a transport failure even when APISIX had explicitly marked the response as coming from the AI provider. As a result, real provider responses such as DeepSeek HTTP 402 were rewritten as BlueKing `UNKNOWN_ERROR` responses.

This change:

- trusts `core.response.get_response_source(ctx)` before classifying transport failures from NGINX byte counters;
- preserves the original status, headers, and body for real AI upstream responses;
- keeps existing wrapping behavior for connection and timeout failures;
- adds regression coverage for an AI upstream 402 response without `upstream_bytes_received`.

### Verification

- `RUN_WITH_IT= make lint`: 92 files, 0 warnings, 0 errors
- `RUN_WITH_IT= make test`: Busted 777 successes; test-nginx 33 files / 742 tests, PASS
- `make check-license`: PASS

### Checklist

- [x] 填写 PR 描述及相关 issue (write PR description and related issue)
- [x] 代码风格检查通过 (code style check passed)
- [x] PR 中包含单元测试 (include unit test)
- [x] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (not replayed against a live DeepSeek account)
