### PR TITLE
chore(build): refresh APISIX 3.18 patches

### DIFF
--- a/src/build/patches/002_upstream_parse_domain_for_nodes.patch
+++ b/src/build/patches/002_upstream_parse_domain_for_nodes.patch
@@ -1,36 +1,11 @@
 diff --git a/apisix/utils/upstream.lua b/apisix/utils/upstream.lua
-index c61c9f71..2549e052 100644
+index ece23776..42730ab5 100644
 --- a/apisix/utils/upstream.lua
 +++ b/apisix/utils/upstream.lua
-@@ -99,10 +99,36 @@ local function parse_domain_for_nodes(nodes)
-                 core.log.error("dns resolver domain: ", host, " error: ", err)
-             end
-         else
--            core.table.insert(new_nodes, node)
-+            -- patch for: https://github.com/apache/apisix/issues/12436
-+            if node.domain then
-+                core.log.error("issue 12436 happened")
-+                local ip, err = core.resolver.parse_domain(node.domain)
-+                if ip then
-+                    local new_node = core.table.clone(node)
-+                    -- only reset the host to ip here
-+                    new_node.host = ip
-+                    core.table.insert(new_nodes, new_node)
-+                end
-+
-+                if err then
-+                    -- add the old ip back
-+                    core.table.insert(new_nodes, node)
-+                end
-+            else
-+                -- add the old ip back
-+                core.table.insert(new_nodes, node)
-+            end
-+
+@@ -111,6 +111,12 @@ local function parse_domain_for_nodes(nodes)
          end
      end
      span:finish(ngx.ctx)
-+    -- patch for: https://github.com/apache/apisix/issues/10093#issuecomment-1738381865
 +    if #new_nodes == 0 then
 +        local err = "no valid ip found"
 +        core.log.error("parse domain for nodes: ", core.json.delay_encode(nodes), " error: ", err)

--- a/src/build/patches/007_ngx_tpl_add_backlog.patch
+++ b/src/build/patches/007_ngx_tpl_add_backlog.patch
@@ -1,8 +1,8 @@
 diff --git a/apisix/cli/ngx_tpl.lua b/apisix/cli/ngx_tpl.lua
-index 5dd739b6..fb54967a 100644
+index df264110..b8139bcc 100644
 --- a/apisix/cli/ngx_tpl.lua
 +++ b/apisix/cli/ngx_tpl.lua
-@@ -698,7 +698,7 @@ http {
+@@ -750,7 +750,7 @@ http {
          http3 on;
          {% end %}
          {% for _, item in ipairs(node_listen) do %}
@@ -11,7 +11,7 @@ index 5dd739b6..fb54967a 100644
          {% end %}
          {% if ssl.enable then %}
          {% for _, item in ipairs(ssl.listen) do %}
-@@ -706,7 +706,7 @@ http {
+@@ -758,7 +758,7 @@ http {
          listen {* item.ip *}:{* item.port *} quic default_server {% if enable_reuseport then %} reuseport {% end %};
          listen {* item.ip *}:{* item.port *} ssl default_server;
          {% else %}


### PR DESCRIPTION
## Summary

- remove the obsolete domain re-resolution workaround already covered by APISIX 3.18 while retaining the BlueKing no-valid-IP error contract
- regenerate the DNS and NGINX backlog patches against the pinned APISIX 3.18.0 source so blob indexes and hunk locations match exactly

## Verification

- `git apply --verbose --check --directory=src/apisix-core` for both patches
- `patch --dry-run --batch --forward --fuzz=0 -p1` for both patches
- `make lint RUN_WITH_IT=`: 92 files, 0 warnings, 0 errors
- `make test RUN_WITH_IT=`: 777 Busted tests and 742 test-nginx tests passed
