### PR TITLE
fix(error-wrapper): handle missing upstream byte counters

### DIFF
--- a/src/apisix/plugins/bk-error-wrapper.lua
+++ b/src/apisix/plugins/bk-error-wrapper.lua
@@ -101,7 +101,10 @@ local function _get_upstream_error_msg(ctx)
                 end
             else
                 -- upstream_connect_time is ok, connected
-                if upstream_bytes_sent > 0 and upstream_bytes_received == 0 then
+                if upstream_bytes_sent
+                    and upstream_bytes_sent > 0
+                    and upstream_bytes_received == 0
+                then
                     -- 成功建立连接并发送了请求，但收到 0 字节响应
                     -- → upstream 在响应前就 RST 或关闭了连接
                     -- readv() failed (104: Connection reset by peer) while reading upstream
@@ -144,7 +147,10 @@ local function _get_upstream_error_msg(ctx)
                 -- nginx error: upstream timed out (110: Connection timed out) while connecting to upstream
                 return proxy_phases.CONNECTING, "connection timed out while connecting to upstream"
             end
-            if upstream_bytes_sent > 0 and upstream_bytes_received == 0 then
+            if upstream_bytes_sent
+                and upstream_bytes_sent > 0
+                and upstream_bytes_received == 0
+            then
                 -- 连上了、发了请求，但一个字节响应都没收到 → 等 header 超时
                 -- nginx error: upstream timed out (110: Connection timed out)
                 --              while reading response header from upstream

--- a/src/apisix/tests/test-bk-error-wrapper.lua
+++ b/src/apisix/tests/test-bk-error-wrapper.lua
@@ -573,6 +573,24 @@ describe(
                 )
 
                 it(
+                    "504 retry sentinel does not crash", function()
+                        ngx.status = 504
+                        local ctx = {
+                            var = {
+                                upstream_connect_time = 0.1,
+                                upstream_bytes_sent = "256, -",
+                                upstream_bytes_received = "0, -",
+                            },
+                        }
+                        local ok, phase, err = pcall(plugin._get_upstream_error_msg, ctx)
+                        assert.is_true(ok)
+                        assert.is_equal(proxy_phases.HEADER_WAITING, phase)
+                        assert.is_equal("cannot read header from upstream.", err)
+
+                    end
+                )
+
+                it(
                     "connection timeout when upstream_bytes_sent is not set", function()
                         ngx.status = 504
                         local ctx = {
@@ -619,6 +637,24 @@ describe(
                         local phase, err = plugin._get_upstream_error_msg(ctx)
                         assert.is_equal(proxy_phases.HEADER_WAITING, phase)
                         assert.is_equal("connection reset by peer OR upstream prematurely closed connection", err)
+
+                    end
+                )
+
+                it(
+                    "502 retry sentinel does not crash", function()
+                        ngx.status = 502
+                        local ctx = {
+                            var = {
+                                upstream_connect_time = 0.1,
+                                upstream_bytes_sent = "256, -",
+                                upstream_bytes_received = "0, -",
+                            },
+                        }
+                        local ok, phase, err = pcall(plugin._get_upstream_error_msg, ctx)
+                        assert.is_true(ok)
+                        assert.is_equal(proxy_phases.HEADER_WAITING, phase)
+                        assert.is_equal("cannot read header from upstream.", err)
 
                     end
                 )


### PR DESCRIPTION
## Summary
- guard upstream byte comparisons when NGINX retry sentinels parse as `nil`
- preserve the existing header-waiting fallback for unavailable byte counters
- add regression coverage for 502 and 504 retry sentinel values

## Verification
- focused Busted: 35 successes, 0 failures, 0 errors
- `RUN_WITH_IT= make lint`: 92 files, 0 warnings, 0 errors
- `RUN_WITH_IT= make test`: 779 Busted successes; 33 test-nginx files / 742 tests, PASS